### PR TITLE
Add Dockerfile and Makefile for extension image

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,22 +4,26 @@ A Proxy-Wasm module written in Rust, acting as a shim between Envoy and Limitado
 Following is a sample configuration used by the shim.
 
 ```yaml
-failure_mode_deny: true,
+failure_mode_deny: true
 ratelimitpolicies:
-  - ratelimitpolicy-1:
-      hosts: ["*.toystore.com"]
-      rules:
-        - operations:
-            - paths: ["/toy*"]
-              methods: ["GET"]
-          actions:
-            - generic_key:
-                descriptor_key: "get-toy"
-                descriptor_value: "yes"
-      global_actions:
-        - generic_key:
-            descriptor_key: "vhost-hit"
-            descriptor_value: "yes"
-      upstream_cluster: "limitador" # Should match cluster name in envoy
-      domain: "toystore"
+  default/toystore:
+    hosts:
+    - "*.toystore.com"
+    rules:
+    - operations:
+      - paths:
+        - "/admin/toy"
+        methods:
+        - POST
+        - DELETE
+      actions:
+      - generic_key:
+          descriptor_value: 'yes'
+          descriptor_key: admin
+    global_actions:
+    - generic_key:
+        descriptor_value: 'yes'
+        descriptor_key: vhaction
+    upstream_cluster: rate-limit-cluster
+    domain: toystore-app
 ```

--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -1,0 +1,3 @@
+FROM scratch
+
+COPY wasm_shim.wasm /plugin.wasm

--- a/deploy/Makefile
+++ b/deploy/Makefile
@@ -1,0 +1,16 @@
+MKFILE_PATH := $(abspath $(lastword $(MAKEFILE_LIST)))
+PROJECT_PATH := $(patsubst %/,%,$(dir $(MKFILE_PATH)))
+IMAGE_VERSION ?= latest
+DOCKER ?= podman
+
+.PHONY: build
+build:
+	$(DOCKER) build -t quay.io/rahanand/wasm-shim:$(IMAGE_VERSION) -f $(PROJECT_PATH)/Dockerfile
+
+.PHONY: clean
+clean:
+	$(DOCKER) rmi quay.io/rahanand/wasm-shim:$(IMAGE_VERSION)
+
+.PHONY: push
+push:
+	$(DOCKER) push quay.io/rahanand/wasm-shim:$(IMAGE_VERSION)


### PR DESCRIPTION
This PR is a step required for https://github.com/Kuadrant/kuadrant-controller/issues/127 to be solved.
- Adds `Dockerfile` defining the way to create the image
- Adds `Makefile` containing scripts to build, clean, and push the image to `quay.io/rahanand/wash-shim/`
- Updates README to have a correct sample configuration.