### PR TITLE
policy index

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ protobuf = { version = "2.0", features = ["with-serde"] }
 thiserror = "1.0"
 regex = "1"
 serde_regex = "1.1.0"
+radix_trie = "0.2.1"
 
 [build-dependencies]
 protoc-rust = "2.0"

--- a/src/configuration.rs
+++ b/src/configuration.rs
@@ -38,6 +38,22 @@ pub struct RateLimitPolicy {
 }
 
 impl RateLimitPolicy {
+    pub fn new(
+        hosts: GlobPatternSet,
+        rules: Option<Vec<Rule>>,
+        global_actions: Option<Vec<RLA_action_specifier>>,
+        upstream_cluster: Option<String>,
+        domain: Option<String>,
+    ) -> Self {
+        RateLimitPolicy {
+            hosts,
+            rules,
+            global_actions,
+            upstream_cluster,
+            domain,
+        }
+    }
+
     pub fn rules(&self) -> Option<&[Rule]> {
         self.rules.as_deref()
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,4 +2,5 @@ mod configuration;
 mod envoy;
 mod filter;
 mod glob;
+mod policy_index;
 mod utils;

--- a/src/policy_index.rs
+++ b/src/policy_index.rs
@@ -1,0 +1,122 @@
+use radix_trie::Trie;
+
+use crate::configuration::RateLimitPolicy;
+
+pub struct PolicyIndex {
+    raw_tree: Trie<String, RateLimitPolicy>,
+}
+
+impl PolicyIndex {
+    pub fn new() -> Self {
+        Self {
+            raw_tree: Trie::new(),
+        }
+    }
+
+    pub fn insert(&mut self, subdomain: &str, policy: RateLimitPolicy) {
+        let rev = Self::reverse_subdomain(subdomain);
+        self.raw_tree.insert(rev, policy);
+    }
+
+    pub fn get_longest_match_policy(&self, subdomain: &str) -> Option<&RateLimitPolicy> {
+        let rev = Self::reverse_subdomain(subdomain);
+        self.raw_tree.get_ancestor_value(&rev)
+    }
+
+    fn reverse_subdomain(subdomain: &str) -> String {
+        let mut s = subdomain.to_string();
+        s.push('.');
+        if s.chars().nth(0).unwrap() == '*' {
+            s.remove(0);
+        } else {
+            s.insert(0, '$'); // $ is not a valid domain char
+        }
+        s.chars().rev().collect()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::configuration::RateLimitPolicy;
+    use crate::glob::GlobPatternSet;
+    use crate::policy_index::PolicyIndex;
+
+    fn build_ratelimit_policy(domain: String) -> RateLimitPolicy {
+        RateLimitPolicy::new(GlobPatternSet::default(), None, None, None, Some(domain))
+    }
+
+    #[test]
+    fn not_wildcard_subdomain() {
+        let mut index = PolicyIndex::new();
+        let rlp1 = build_ratelimit_policy(String::from("example.com"));
+        index.insert("example.com", rlp1);
+
+        let val = index.get_longest_match_policy("test.example.com");
+        assert_eq!(val.is_none(), true);
+
+        let val = index.get_longest_match_policy("other.com");
+        assert_eq!(val.is_none(), true);
+
+        let val = index.get_longest_match_policy("net");
+        assert_eq!(val.is_none(), true);
+
+        let val = index.get_longest_match_policy("example.com");
+        assert_eq!(val.is_some(), true);
+        assert_eq!(val.unwrap().domain().is_some(), true);
+        assert_eq!(val.unwrap().domain().unwrap(), "example.com");
+    }
+
+    #[test]
+    fn wildcard_subdomain_does_not_match_domain() {
+        let mut index = PolicyIndex::new();
+        let rlp1 = build_ratelimit_policy(String::from("*.example.com"));
+
+        index.insert("*.example.com", rlp1);
+        let val = index.get_longest_match_policy("example.com");
+        assert_eq!(val.is_none(), true);
+    }
+
+    #[test]
+    fn wildcard_subdomain_matches_subdomains() {
+        let mut index = PolicyIndex::new();
+        let rlp1 = build_ratelimit_policy(String::from("*.example.com"));
+
+        index.insert("*.example.com", rlp1);
+        let val = index.get_longest_match_policy("test.example.com");
+
+        assert_eq!(val.is_some(), true);
+        assert_eq!(val.unwrap().domain().is_some(), true);
+        assert_eq!(val.unwrap().domain().unwrap(), "*.example.com");
+    }
+
+    #[test]
+    fn longest_domain_match() {
+        let mut index = PolicyIndex::new();
+        let rlp1 = build_ratelimit_policy(String::from("*.com"));
+        index.insert("*.com", rlp1);
+        let rlp2 = build_ratelimit_policy(String::from("*.example.com"));
+        index.insert("*.example.com", rlp2);
+
+        let val = index.get_longest_match_policy("test.example.com");
+        assert_eq!(val.is_some(), true);
+        assert_eq!(val.unwrap().domain().is_some(), true);
+        assert_eq!(val.unwrap().domain().unwrap(), "*.example.com");
+
+        let val = index.get_longest_match_policy("example.com");
+        assert_eq!(val.is_some(), true);
+        assert_eq!(val.unwrap().domain().is_some(), true);
+        assert_eq!(val.unwrap().domain().unwrap(), "*.com");
+    }
+
+    #[test]
+    fn global_wildcard_match_all() {
+        let mut index = PolicyIndex::new();
+        let rlp1 = build_ratelimit_policy(String::from("*"));
+        index.insert("*", rlp1);
+
+        let val = index.get_longest_match_policy("test.example.com");
+        assert_eq!(val.is_some(), true);
+        assert_eq!(val.unwrap().domain().is_some(), true);
+        assert_eq!(val.unwrap().domain().unwrap(), "*");
+    }
+}


### PR DESCRIPTION
The WASM-SHIM builds a tree based data structure holding the rate limit policies. The longest hostname match is used to select the policy to be applied. Only one policy is being applied per invocation.

It is based on using https://docs.rs/radix_trie/latest/radix_trie/struct.Trie.html, which implements longest prefix match. So, for longest *suffix* match (for subdomain match), reverse operation is needed.

Note: this PR target is `new-design` branch and more PRs are coming
