### PR TITLE
local dev/testing env based on docker-compose

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,8 @@ endif
 
 KIND_CLUSTER_NAME ?= wasm-shim-cluster
 
+WASM_RELEASE_PATH = $(PROJECT_PATH)/target/wasm32-unknown-unknown/release/wasm_shim.wasm
+
 # Start a local Kubernetes cluster using Kind
 .PHONY: cluster-up
 cluster-up: kind
@@ -133,6 +135,16 @@ update-protobufs:
 # Rust protobuf support doesn't allow multiple files with same name and diff dir to merge so we have to create one our own.
 #	cd vendor-protobufs/data-plane-api/envoy/type/ && \
 #	touch tmp && git merge-file ./matcher/v3/metadata.proto ./tmp ./metadata/v3/metadata.proto --own && rm tmp
+
+$(WASM_RELEASE_PATH): export BUILD = release
+$(WASM_RELEASE_PATH):
+	make -C $(PROJECT_PATH) -f $(MKFILE_PATH) build
+
+development: $(WASM_RELEASE_PATH)
+	docker-compose up
+
+stop-development:
+	docker-compose down
 
 # get-protoc will download zip from $2 and install it to $1.
 define get-protoc

--- a/README.md
+++ b/README.md
@@ -49,3 +49,25 @@ Build the WASM module in release mode
 ```
 make build BUILD=release
 ```
+
+## Running/Testing locally
+
+`docker` and `docker-compose` required.
+
+Run local development environment
+
+```
+make development
+```
+
+Testing the WASM filter
+
+```
+curl http://127.0.0.1:18000/get
+```
+
+Clean up all resources
+
+```
+make stop-development
+```

--- a/deploy/docker-compose/envoy.yaml
+++ b/deploy/docker-compose/envoy.yaml
@@ -1,0 +1,119 @@
+---
+static_resources:
+  listeners:
+  - name: main
+    address:
+      socket_address:
+        address: 0.0.0.0
+        port_value: 80
+    filter_chains:
+      - filters:
+        - name: envoy.filters.network.http_connection_manager
+          typed_config:
+            "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+            stat_prefix: ingress_http
+            route_config:
+              name: local_route
+              virtual_hosts:
+                - name: local_service
+                  domains:
+                    - "*"
+                  routes:
+                    - match:
+                        prefix: "/"
+                      route:
+                        cluster: upstream
+            http_filters:
+              - name: envoy.filters.http.wasm
+                typed_config:
+                  "@type": type.googleapis.com/envoy.extensions.filters.http.wasm.v3.Wasm
+                  config:
+                    name: kuadrant_wasm
+                    root_id: kuadrant_wasm
+                    vm_config:
+                      vm_id: vm.sentinel.kuadrant_wasm
+                      runtime: envoy.wasm.runtime.v8
+                      code:
+                        local:
+                          filename: /opt/kuadrant/wasm/wasm_shim.wasm
+                      allow_precompiled: true
+                    configuration:
+                      "@type": "type.googleapis.com/google.protobuf.StringValue"
+                      value: >
+                        {
+                          "failure_mode_deny": true,
+                          "ratelimitpolicies": {
+                            "default-toystore": {
+                              "hosts": [
+                                "*"
+                              ],
+                              "rules": [
+                                {
+                                  "operations": [
+                                    {
+                                      "paths": [
+                                        "/get"
+                                      ],
+                                      "methods": [
+                                        "GET"
+                                      ]
+                                    }
+                                  ],
+                                  "actions": [
+                                    {
+                                      "generic_key": {
+                                        "descriptor_value": "1",
+                                        "descriptor_key": "admin"
+                                      }
+                                    }
+                                  ]
+                                }
+                              ],
+                              "global_actions": [
+                                {
+                                  "generic_key": {
+                                    "descriptor_value": "1",
+                                    "descriptor_key": "vhaction"
+                                  }
+                                }
+                              ],
+                              "upstream_cluster": "limitador",
+                              "domain": "toystore-app"
+                            }
+                          }
+                        }
+              - name: envoy.filters.http.router
+  clusters:
+    - name: upstream
+      connect_timeout: 0.25s
+      type: STRICT_DNS
+      lb_policy: round_robin
+      load_assignment:
+        cluster_name: upstream
+        endpoints:
+        - lb_endpoints:
+          - endpoint:
+              address:
+                socket_address:
+                  address: upstream
+                  port_value: 80
+    - name: limitador
+      connect_timeout: 0.25s
+      type: STRICT_DNS
+      lb_policy: round_robin
+      http2_protocol_options: {}
+      load_assignment:
+        cluster_name: limitador
+        endpoints:
+        - lb_endpoints:
+          - endpoint:
+              address:
+                socket_address:
+                  address: limitador
+                  port_value: 8081
+admin:
+  access_log_path: "/dev/null"
+  address:
+    socket_address:
+      address: 0.0.0.0
+      port_value: 8001

--- a/deploy/docker-compose/limits.yaml
+++ b/deploy/docker-compose/limits.yaml
@@ -1,0 +1,7 @@
+---
+- namespace: toystore-app
+  max_value: 10
+  seconds: 60
+  conditions:
+    - "req.method == GET"
+  variables: []

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,39 @@
+---
+version: '2.2'
+services:
+  envoy:
+    image: envoyproxy/envoy:v1.20-latest
+    depends_on:
+      - limitador
+      - upstream
+    command:
+      - /usr/local/bin/envoy
+      - --config-path
+      - /etc/envoy.yaml
+      - --log-level
+      - info
+      - --component-log-level
+      - wasm:debug,http:debug,router:debug
+      - --service-cluster
+      - proxy
+    expose:
+      - "80"
+      - "8001"
+    ports:
+      - "18000:80"
+      - "18001:8001"
+    volumes:
+      - ./deploy/docker-compose/envoy.yaml:/etc/envoy.yaml
+      - ./target/wasm32-unknown-unknown/release/wasm_shim.wasm:/opt/kuadrant/wasm/wasm_shim.wasm
+  limitador:
+    image: quay.io/3scale/limitador:0.5.1
+    environment:
+      RUST_LOG: debug
+      LIMITS_FILE: /opt/kuadrant/limits/limits.yaml
+    expose:
+      - "8080"
+      - "8081"
+    volumes:
+      - ./deploy/docker-compose/limits.yaml:/opt/kuadrant/limits/limits.yaml
+  upstream:
+    image: kennethreitz/httpbin


### PR DESCRIPTION
Running `make development`, few services are locally deployed using docker-compose:
* envoy loaded with the (recently) compiled WASM module
* Limitador container
* "upstream" app (echo api)

<details>

```
$ make development
make -C /home/eguzki/git/wasm-shim -f /home/eguzki/git/wasm-shim/Makefile build
make[1]: Entering directory '/home/eguzki/git/wasm-shim'
Building the wasm filter
export PATH=/home/eguzki/git/wasm-shim/bin:$PATH; cargo build --target=wasm32-unknown-unknown --release
   Compiling proc-macro2 v1.0.39
   Compiling unicode-ident v1.0.1
   Compiling syn v1.0.96
   Compiling log v0.4.17
   Compiling either v1.6.1
   Compiling libc v0.2.126
   Compiling serde_derive v1.0.137
   Compiling protobuf v2.27.1
   Compiling cfg-if v1.0.0
   Compiling anyhow v1.0.57
   Compiling serde v1.0.137
   Compiling version_check v0.9.4
   Compiling memchr v2.5.0
   Compiling fastrand v1.7.0
   Compiling remove_dir_all v0.5.3
   Compiling once_cell v1.12.0
   Compiling proxy-wasm v0.2.0
   Compiling serde_json v1.0.81
   Compiling regex-syntax v0.6.26
   Compiling bytes v0.5.6
   Compiling ryu v1.0.10
   Compiling itoa v1.0.2
   Compiling itertools v0.8.2
   Compiling ahash v0.7.6
   Compiling aho-corasick v0.7.18
   Compiling quote v1.0.18
   Compiling which v4.2.5
   Compiling tempfile v3.3.0
   Compiling hashbrown v0.12.1
   Compiling protoc v2.27.1
   Compiling regex v1.5.6
   Compiling protobuf-codegen v2.27.1
   Compiling prost-derive v0.6.1
   Compiling thiserror-impl v1.0.31
   Compiling protoc-rust v2.27.1
   Compiling thiserror v1.0.31
   Compiling wasm-shim v0.1.0 (/home/eguzki/git/wasm-shim)
   Compiling prost v0.6.1
   Compiling prost-types v0.6.1
   Compiling serde_regex v1.1.0
warning: unused import: `debug`
 --> src/filter/root_context.rs:3:23
  |
3 | use log::{info, warn, debug};
  |                       ^^^^^
  |
  = note: `#[warn(unused_imports)]` on by default

warning: unused variable: `regex_matcher`
  --> src/utils.rs:38:63
   |
38 |                     HeaderMatcher_specifier::safe_regex_match(regex_matcher) => todo!(), // TODO(rahulanand16nov): not implemented.
   |                                                               ^^^^^^^^^^^^^ help: if this is intentional, prefix it with an underscore: `_regex_matcher`
   |
   = note: `#[warn(unused_variables)]` on by default

warning: unused variable: `ra`
   --> src/utils.rs:158:50
    |
158 |             RLA_action_specifier::remote_address(ra) => {
    |                                                  ^^ help: if this is intentional, prefix it with an underscore: `_ra`

warning: `wasm-shim` (lib) generated 3 warnings
    Finished release [optimized] target(s) in 50.09s
cp target/wasm32-unknown-unknown/release/*.wasm ./deploy/
make[1]: Leaving directory '/home/eguzki/git/wasm-shim'
docker-compose up
Creating network "wasm-shim_default" with the default driver
Creating wasm-shim_upstream_1  ... done
Creating wasm-shim_limitador_1 ... done
Creating wasm-shim_envoy_1     ... done
Attaching to wasm-shim_upstream_1, wasm-shim_limitador_1, wasm-shim_envoy_1
limitador_1  | [2022-06-20T22:38:02Z INFO  limitador_server] Envoy RLS server starting on 0.0.0.0:8081
limitador_1  | [2022-06-20T22:38:02Z INFO  actix_server::builder] Starting 4 workers
limitador_1  | [2022-06-20T22:38:02Z INFO  actix_server::server] Actix runtime found; starting in Actix runtime
upstream_1   | [2022-06-20 22:38:02 +0000] [1] [INFO] Starting gunicorn 19.9.0
upstream_1   | [2022-06-20 22:38:02 +0000] [1] [INFO] Listening at: http://0.0.0.0:80 (1)
upstream_1   | [2022-06-20 22:38:02 +0000] [1] [INFO] Using worker: gevent
upstream_1   | [2022-06-20 22:38:02 +0000] [9] [INFO] Booting worker with pid: 9
envoy_1      | [2022-06-20 22:38:02.708][1][info][main] [source/server/server.cc:368] initializing epoch 0 (base id=0, hot restart version=11.104)
envoy_1      | [2022-06-20 22:38:02.708][1][info][main] [source/server/server.cc:370] statically linked extensions:
envoy_1      | [2022-06-20 22:38:02.708][1][info][main] [source/server/server.cc:372]   envoy.common.key_value: envoy.key_value.file_based
envoy_1      | [2022-06-20 22:38:02.708][1][info][main] [source/server/server.cc:372]   envoy.grpc_credentials: envoy.grpc_credentials.aws_iam, envoy.grpc_credentials.default, envoy.grpc_credentials.file_based_metadata
envoy_1      | [2022-06-20 22:38:02.708][1][info][main] [source/server/server.cc:372]   envoy.rbac.matchers: envoy.rbac.matchers.upstream.upstream_ip_port
envoy_1      | [2022-06-20 22:38:02.708][1][info][main] [source/server/server.cc:372]   envoy.bootstrap: envoy.bootstrap.wasm, envoy.extensions.network.socket_interface.default_socket_interface
envoy_1      | [2022-06-20 22:38:02.708][1][info][main] [source/server/server.cc:372]   envoy.thrift_proxy.filters: envoy.filters.thrift.rate_limit, envoy.filters.thrift.router
envoy_1      | [2022-06-20 22:38:02.708][1][info][main] [source/server/server.cc:372]   envoy.filters.http: envoy.bandwidth_limit, envoy.buffer, envoy.cors, envoy.csrf, envoy.ext_authz, envoy.ext_proc, envoy.fault, envoy.filters.http.adaptive_concurrency, envoy.filters.http.admission_control, envoy.filters.http.alternate_protocols_cache, envoy.filters.http.aws_lambda, envoy.filters.http.aws_request_signing, envoy.filters.http.bandwidth_limit, envoy.filters.http.buffer, envoy.filters.http.cache, envoy.filters.http.cdn_loop, envoy.filters.http.composite, envoy.filters.http.compressor, envoy.filters.http.cors, envoy.filters.http.csrf, envoy.filters.http.decompressor, envoy.filters.http.dynamic_forward_proxy, envoy.filters.http.dynamo, envoy.filters.http.ext_authz, envoy.filters.http.ext_proc, envoy.filters.http.fault, envoy.filters.http.grpc_http1_bridge, envoy.filters.http.grpc_http1_reverse_bridge, envoy.filters.http.grpc_json_transcoder, envoy.filters.http.grpc_stats, envoy.filters.http.grpc_web, envoy.filters.http.header_to_metadata, envoy.filters.http.health_check, envoy.filters.http.ip_tagging, envoy.filters.http.jwt_authn, envoy.filters.http.local_ratelimit, envoy.filters.http.lua, envoy.filters.http.oauth2, envoy.filters.http.on_demand, envoy.filters.http.original_src, envoy.filters.http.ratelimit, envoy.filters.http.rbac, envoy.filters.http.router, envoy.filters.http.set_metadata, envoy.filters.http.tap, envoy.filters.http.wasm, envoy.grpc_http1_bridge, envoy.grpc_json_transcoder, envoy.grpc_web, envoy.health_check, envoy.http_dynamo_filter, envoy.ip_tagging, envoy.local_rate_limit, envoy.lua, envoy.rate_limit, envoy.router, match-wrapper
envoy_1      | [2022-06-20 22:38:02.708][1][info][main] [source/server/server.cc:372]   envoy.formatter: envoy.formatter.metadata, envoy.formatter.req_without_query
envoy_1      | [2022-06-20 22:38:02.708][1][info][main] [source/server/server.cc:372]   envoy.dubbo_proxy.route_matchers: default
envoy_1      | [2022-06-20 22:38:02.708][1][info][main] [source/server/server.cc:372]   envoy.stats_sinks: envoy.dog_statsd, envoy.graphite_statsd, envoy.metrics_service, envoy.stat_sinks.dog_statsd, envoy.stat_sinks.graphite_statsd, envoy.stat_sinks.hystrix, envoy.stat_sinks.metrics_service, envoy.stat_sinks.statsd, envoy.stat_sinks.wasm, envoy.statsd
envoy_1      | [2022-06-20 22:38:02.708][1][info][main] [source/server/server.cc:372]   envoy.guarddog_actions: envoy.watchdog.abort_action, envoy.watchdog.profile_action
envoy_1      | [2022-06-20 22:38:02.708][1][info][main] [source/server/server.cc:372]   envoy.thrift_proxy.protocols: auto, binary, binary/non-strict, compact, twitter
envoy_1      | [2022-06-20 22:38:02.708][1][info][main] [source/server/server.cc:372]   envoy.rate_limit_descriptors: envoy.rate_limit_descriptors.expr
envoy_1      | [2022-06-20 22:38:02.708][1][info][main] [source/server/server.cc:372]   envoy.resource_monitors: envoy.resource_monitors.fixed_heap, envoy.resource_monitors.injected_resource
envoy_1      | [2022-06-20 22:38:02.708][1][info][main] [source/server/server.cc:372]   envoy.matching.input_matchers: envoy.matching.matchers.consistent_hashing, envoy.matching.matchers.ip
envoy_1      | [2022-06-20 22:38:02.708][1][info][main] [source/server/server.cc:372]   envoy.upstream_options: envoy.extensions.upstreams.http.v3.HttpProtocolOptions, envoy.upstreams.http.http_protocol_options
envoy_1      | [2022-06-20 22:38:02.708][1][info][main] [source/server/server.cc:372]   envoy.request_id: envoy.request_id.uuid
envoy_1      | [2022-06-20 22:38:02.708][1][info][main] [source/server/server.cc:372]   envoy.filters.listener: envoy.filters.listener.http_inspector, envoy.filters.listener.original_dst, envoy.filters.listener.original_src, envoy.filters.listener.proxy_protocol, envoy.filters.listener.tls_inspector, envoy.listener.http_inspector, envoy.listener.original_dst, envoy.listener.original_src, envoy.listener.proxy_protocol, envoy.listener.tls_inspector
envoy_1      | [2022-06-20 22:38:02.708][1][info][main] [source/server/server.cc:372]   envoy.http.stateful_header_formatters: preserve_case
envoy_1      | [2022-06-20 22:38:02.708][1][info][main] [source/server/server.cc:372]   envoy.dubbo_proxy.serializers: dubbo.hessian2
envoy_1      | [2022-06-20 22:38:02.708][1][info][main] [source/server/server.cc:372]   envoy.transport_sockets.upstream: envoy.transport_sockets.alts, envoy.transport_sockets.quic, envoy.transport_sockets.raw_buffer, envoy.transport_sockets.starttls, envoy.transport_sockets.tap, envoy.transport_sockets.tls, envoy.transport_sockets.upstream_proxy_protocol, raw_buffer, starttls, tls
envoy_1      | [2022-06-20 22:38:02.708][1][info][main] [source/server/server.cc:372]   envoy.filters.network: envoy.client_ssl_auth, envoy.echo, envoy.ext_authz, envoy.filters.network.client_ssl_auth, envoy.filters.network.connection_limit, envoy.filters.network.direct_response, envoy.filters.network.dubbo_proxy, envoy.filters.network.echo, envoy.filters.network.ext_authz, envoy.filters.network.http_connection_manager, envoy.filters.network.local_ratelimit, envoy.filters.network.mongo_proxy, envoy.filters.network.ratelimit, envoy.filters.network.rbac, envoy.filters.network.redis_proxy, envoy.filters.network.sni_cluster, envoy.filters.network.sni_dynamic_forward_proxy, envoy.filters.network.tcp_proxy, envoy.filters.network.thrift_proxy, envoy.filters.network.wasm, envoy.filters.network.zookeeper_proxy, envoy.http_connection_manager, envoy.mongo_proxy, envoy.ratelimit, envoy.redis_proxy, envoy.tcp_proxy
envoy_1      | [2022-06-20 22:38:02.708][1][info][main] [source/server/server.cc:372]   envoy.matching.http.input: request-headers, request-trailers, response-headers, response-trailers
envoy_1      | [2022-06-20 22:38:02.708][1][info][main] [source/server/server.cc:372]   envoy.quic.server.crypto_stream: envoy.quic.crypto_stream.server.quiche
envoy_1      | [2022-06-20 22:38:02.708][1][info][main] [source/server/server.cc:372]   envoy.compression.compressor: envoy.compression.brotli.compressor, envoy.compression.gzip.compressor
envoy_1      | [2022-06-20 22:38:02.708][1][info][main] [source/server/server.cc:372]   envoy.dubbo_proxy.filters: envoy.filters.dubbo.router
envoy_1      | [2022-06-20 22:38:02.708][1][info][main] [source/server/server.cc:372]   envoy.transport_sockets.downstream: envoy.transport_sockets.alts, envoy.transport_sockets.quic, envoy.transport_sockets.raw_buffer, envoy.transport_sockets.starttls, envoy.transport_sockets.tap, envoy.transport_sockets.tls, raw_buffer, starttls, tls
envoy_1      | [2022-06-20 22:38:02.708][1][info][main] [source/server/server.cc:372]   envoy.retry_host_predicates: envoy.retry_host_predicates.omit_canary_hosts, envoy.retry_host_predicates.omit_host_metadata, envoy.retry_host_predicates.previous_hosts
envoy_1      | [2022-06-20 22:38:02.708][1][info][main] [source/server/server.cc:372]   envoy.tls.cert_validator: envoy.tls.cert_validator.default, envoy.tls.cert_validator.spiffe
envoy_1      | [2022-06-20 22:38:02.708][1][info][main] [source/server/server.cc:372]   envoy.compression.decompressor: envoy.compression.brotli.decompressor, envoy.compression.gzip.decompressor
envoy_1      | [2022-06-20 22:38:02.708][1][info][main] [source/server/server.cc:372]   envoy.thrift_proxy.transports: auto, framed, header, unframed
envoy_1      | [2022-06-20 22:38:02.708][1][info][main] [source/server/server.cc:372]   envoy.dubbo_proxy.protocols: dubbo
envoy_1      | [2022-06-20 22:38:02.708][1][info][main] [source/server/server.cc:372]   envoy.wasm.runtime: envoy.wasm.runtime.null, envoy.wasm.runtime.v8
envoy_1      | [2022-06-20 22:38:02.708][1][info][main] [source/server/server.cc:372]   envoy.matching.common_inputs: envoy.matching.common_inputs.environment_variable
envoy_1      | [2022-06-20 22:38:02.708][1][info][main] [source/server/server.cc:372]   envoy.clusters: envoy.cluster.eds, envoy.cluster.logical_dns, envoy.cluster.original_dst, envoy.cluster.static, envoy.cluster.strict_dns, envoy.clusters.aggregate, envoy.clusters.dynamic_forward_proxy, envoy.clusters.redis
envoy_1      | [2022-06-20 22:38:02.708][1][info][main] [source/server/server.cc:372]   envoy.upstreams: envoy.filters.connection_pools.tcp.generic
envoy_1      | [2022-06-20 22:38:02.708][1][info][main] [source/server/server.cc:372]   envoy.tracers: envoy.dynamic.ot, envoy.lightstep, envoy.tracers.datadog, envoy.tracers.dynamic_ot, envoy.tracers.lightstep, envoy.tracers.opencensus, envoy.tracers.skywalking, envoy.tracers.xray, envoy.tracers.zipkin, envoy.zipkin
envoy_1      | [2022-06-20 22:38:02.708][1][info][main] [source/server/server.cc:372]   envoy.access_loggers: envoy.access_loggers.file, envoy.access_loggers.http_grpc, envoy.access_loggers.open_telemetry, envoy.access_loggers.stderr, envoy.access_loggers.stdout, envoy.access_loggers.tcp_grpc, envoy.access_loggers.wasm, envoy.file_access_log, envoy.http_grpc_access_log, envoy.open_telemetry_access_log, envoy.stderr_access_log, envoy.stdout_access_log, envoy.tcp_grpc_access_log, envoy.wasm_access_log
envoy_1      | [2022-06-20 22:38:02.708][1][info][main] [source/server/server.cc:372]   envoy.health_checkers: envoy.health_checkers.redis
envoy_1      | [2022-06-20 22:38:02.708][1][info][main] [source/server/server.cc:372]   envoy.quic.proof_source: envoy.quic.proof_source.filter_chain
envoy_1      | [2022-06-20 22:38:02.708][1][info][main] [source/server/server.cc:372]   envoy.retry_priorities: envoy.retry_priorities.previous_priorities
envoy_1      | [2022-06-20 22:38:02.708][1][info][main] [source/server/server.cc:372]   envoy.resolvers: envoy.ip
envoy_1      | [2022-06-20 22:38:02.708][1][info][main] [source/server/server.cc:372]   envoy.matching.action: composite-action, skip
envoy_1      | [2022-06-20 22:38:02.708][1][info][main] [source/server/server.cc:372]   envoy.http.cache: envoy.extensions.http.cache.simple
envoy_1      | [2022-06-20 22:38:02.708][1][info][main] [source/server/server.cc:372]   envoy.internal_redirect_predicates: envoy.internal_redirect_predicates.allow_listed_routes, envoy.internal_redirect_predicates.previous_routes, envoy.internal_redirect_predicates.safe_cross_scheme
envoy_1      | [2022-06-20 22:38:02.708][1][info][main] [source/server/server.cc:372]   envoy.filters.udp_listener: envoy.filters.udp.dns_filter, envoy.filters.udp_listener.udp_proxy
envoy_1      | [2022-06-20 22:38:02.708][1][info][main] [source/server/server.cc:372]   envoy.http.original_ip_detection: envoy.http.original_ip_detection.custom_header, envoy.http.original_ip_detection.xff
envoy_1      | [2022-06-20 22:38:02.713][1][warning][misc] [source/common/protobuf/message_validator_impl.cc:21] Deprecated field: type envoy.config.cluster.v3.Cluster Using deprecated option 'envoy.config.cluster.v3.Cluster.http2_protocol_options' from file cluster.proto. This configuration will be removed from Envoy soon. Please see https://www.envoyproxy.io/docs/envoy/latest/version_history/version_history for details. If continued use of this field is absolutely necessary, see https://www.envoyproxy.io/docs/envoy/latest/configuration/operations/runtime#using-runtime-overrides-for-deprecated-features for how to apply a temporary and highly discouraged override.
envoy_1      | [2022-06-20 22:38:02.713][1][warning][misc] [source/common/protobuf/message_validator_impl.cc:21] Deprecated field: type envoy.config.bootstrap.v3.Admin Using deprecated option 'envoy.config.bootstrap.v3.Admin.access_log_path' from file bootstrap.proto. This configuration will be removed from Envoy soon. Please see https://www.envoyproxy.io/docs/envoy/latest/version_history/version_history for details. If continued use of this field is absolutely necessary, see https://www.envoyproxy.io/docs/envoy/latest/configuration/operations/runtime#using-runtime-overrides-for-deprecated-features for how to apply a temporary and highly discouraged override.
envoy_1      | [2022-06-20 22:38:02.713][1][info][main] [source/server/server.cc:390] HTTP header map info:
envoy_1      | [2022-06-20 22:38:02.715][1][info][main] [source/server/server.cc:393]   request header map: 640 bytes: :authority,:method,:path,:protocol,:scheme,accept,accept-encoding,access-control-request-method,authentication,authorization,cache-control,cdn-loop,connection,content-encoding,content-length,content-type,expect,grpc-accept-encoding,grpc-timeout,if-match,if-modified-since,if-none-match,if-range,if-unmodified-since,keep-alive,origin,pragma,proxy-connection,referer,te,transfer-encoding,upgrade,user-agent,via,x-client-trace-id,x-envoy-attempt-count,x-envoy-decorator-operation,x-envoy-downstream-service-cluster,x-envoy-downstream-service-node,x-envoy-expected-rq-timeout-ms,x-envoy-external-address,x-envoy-force-trace,x-envoy-hedge-on-per-try-timeout,x-envoy-internal,x-envoy-ip-tags,x-envoy-max-retries,x-envoy-original-path,x-envoy-original-url,x-envoy-retriable-header-names,x-envoy-retriable-status-codes,x-envoy-retry-grpc-on,x-envoy-retry-on,x-envoy-upstream-alt-stat-name,x-envoy-upstream-rq-per-try-timeout-ms,x-envoy-upstream-rq-timeout-alt-response,x-envoy-upstream-rq-timeout-ms,x-envoy-upstream-stream-duration-ms,x-forwarded-client-cert,x-forwarded-for,x-forwarded-proto,x-ot-span-context,x-request-id
envoy_1      | [2022-06-20 22:38:02.715][1][info][main] [source/server/server.cc:393]   request trailer map: 136 bytes: 
envoy_1      | [2022-06-20 22:38:02.715][1][info][main] [source/server/server.cc:393]   response header map: 432 bytes: :status,access-control-allow-credentials,access-control-allow-headers,access-control-allow-methods,access-control-allow-origin,access-control-expose-headers,access-control-max-age,age,cache-control,connection,content-encoding,content-length,content-type,date,etag,expires,grpc-message,grpc-status,keep-alive,last-modified,location,proxy-connection,server,transfer-encoding,upgrade,vary,via,x-envoy-attempt-count,x-envoy-decorator-operation,x-envoy-degraded,x-envoy-immediate-health-check-fail,x-envoy-ratelimited,x-envoy-upstream-canary,x-envoy-upstream-healthchecked-cluster,x-envoy-upstream-service-time,x-request-id
envoy_1      | [2022-06-20 22:38:02.715][1][info][main] [source/server/server.cc:393]   response trailer map: 160 bytes: grpc-message,grpc-status
envoy_1      | [2022-06-20 22:38:02.716][1][info][main] [source/server/server.cc:740] runtime: {}
envoy_1      | [2022-06-20 22:38:02.716][1][info][admin] [source/server/admin/admin.cc:135] admin address: 0.0.0.0:8001
envoy_1      | [2022-06-20 22:38:02.717][1][info][config] [source/server/configuration_impl.cc:127] loading tracing configuration
envoy_1      | [2022-06-20 22:38:02.717][1][info][config] [source/server/configuration_impl.cc:87] loading 0 static secret(s)
envoy_1      | [2022-06-20 22:38:02.717][1][info][config] [source/server/configuration_impl.cc:93] loading 2 cluster(s)
envoy_1      | [2022-06-20 22:38:02.718][1][info][config] [source/server/configuration_impl.cc:97] loading 1 listener(s)
envoy_1      | [2022-06-20 22:38:02.756][1][debug][wasm] [source/extensions/common/wasm/wasm.cc:87] Base Wasm created 1 now active
envoy_1      | [2022-06-20 22:38:03.176][1][debug][wasm] [source/extensions/common/wasm/wasm.cc:104] Thread-Local Wasm created 2 now active
envoy_1      | [2022-06-20 22:38:03.180][1][info][wasm] [source/extensions/common/wasm/context.cc:1167] wasm log kuadrant_wasm vm.sentinel.kuadrant_wasm: root-context #1: VM started
envoy_1      | [2022-06-20 22:38:03.181][1][info][wasm] [source/extensions/common/wasm/context.cc:1167] wasm log kuadrant_wasm vm.sentinel.kuadrant_wasm: plugin config parsed: FilterConfig { ratelimitpolicies: {"default-toystore": RateLimitPolicy { hosts: GlobPatternSet(RegexSet(["\\A.*\\z"])), rules: Some([Rule { operations: Some([Operation { paths: GlobPatternSet(RegexSet(["\\A/get\\z"])), methods: GlobPatternSet(RegexSet(["\\AGET\\z"])) }]), actions: Some([generic_key(descriptor_value: "1" descriptor_key: "admin")]) }]), global_actions: Some([generic_key(descriptor_value: "1" descriptor_key: "vhaction")]), upstream_cluster: Some("limitador"), domain: Some("toystore-app") }}, failure_mode_deny: true }
envoy_1      | [2022-06-20 22:38:03.181][1][debug][wasm] [source/extensions/common/wasm/wasm.cc:147] ~Wasm 1 remaining active
envoy_1      | [2022-06-20 22:38:03.186][1][debug][wasm] [source/extensions/common/wasm/wasm.cc:104] Thread-Local Wasm created 2 now active
envoy_1      | [2022-06-20 22:38:03.190][1][info][wasm] [source/extensions/common/wasm/context.cc:1167] wasm log kuadrant_wasm vm.sentinel.kuadrant_wasm: root-context #1: VM started
envoy_1      | [2022-06-20 22:38:03.191][1][info][wasm] [source/extensions/common/wasm/context.cc:1167] wasm log kuadrant_wasm vm.sentinel.kuadrant_wasm: plugin config parsed: FilterConfig { ratelimitpolicies: {"default-toystore": RateLimitPolicy { hosts: GlobPatternSet(RegexSet(["\\A.*\\z"])), rules: Some([Rule { operations: Some([Operation { paths: GlobPatternSet(RegexSet(["\\A/get\\z"])), methods: GlobPatternSet(RegexSet(["\\AGET\\z"])) }]), actions: Some([generic_key(descriptor_value: "1" descriptor_key: "admin")]) }]), global_actions: Some([generic_key(descriptor_value: "1" descriptor_key: "vhaction")]), upstream_cluster: Some("limitador"), domain: Some("toystore-app") }}, failure_mode_deny: true }
envoy_1      | [2022-06-20 22:38:03.191][1][info][config] [source/server/configuration_impl.cc:109] loading stats configuration
envoy_1      | [2022-06-20 22:38:03.192][1][info][main] [source/server/server.cc:836] starting main dispatch loop
envoy_1      | [2022-06-20 22:38:03.192][1][info][runtime] [source/common/runtime/runtime_impl.cc:449] RTDS has finished initialization
envoy_1      | [2022-06-20 22:38:03.192][1][info][upstream] [source/common/upstream/cluster_manager_impl.cc:206] cm init: all clusters initialized
envoy_1      | [2022-06-20 22:38:03.192][1][info][main] [source/server/server.cc:817] all clusters initialized. initializing init manager
envoy_1      | [2022-06-20 22:38:03.192][1][info][config] [source/server/listener_manager_impl.cc:779] all dependencies initialized. starting workers
envoy_1      | [2022-06-20 22:38:03.199][32][debug][wasm] [source/extensions/common/wasm/wasm.cc:104] Thread-Local Wasm created 3 now active
envoy_1      | [2022-06-20 22:38:03.204][27][debug][wasm] [source/extensions/common/wasm/wasm.cc:104] Thread-Local Wasm created 4 now active
envoy_1      | [2022-06-20 22:38:03.204][32][info][wasm] [source/extensions/common/wasm/context.cc:1167] wasm log kuadrant_wasm vm.sentinel.kuadrant_wasm: root-context #1: VM started
envoy_1      | [2022-06-20 22:38:03.204][34][debug][wasm] [source/extensions/common/wasm/wasm.cc:104] Thread-Local Wasm created 5 now active
envoy_1      | [2022-06-20 22:38:03.205][32][info][wasm] [source/extensions/common/wasm/context.cc:1167] wasm log kuadrant_wasm vm.sentinel.kuadrant_wasm: plugin config parsed: FilterConfig { ratelimitpolicies: {"default-toystore": RateLimitPolicy { hosts: GlobPatternSet(RegexSet(["\\A.*\\z"])), rules: Some([Rule { operations: Some([Operation { paths: GlobPatternSet(RegexSet(["\\A/get\\z"])), methods: GlobPatternSet(RegexSet(["\\AGET\\z"])) }]), actions: Some([generic_key(descriptor_value: "1" descriptor_key: "admin")]) }]), global_actions: Some([generic_key(descriptor_value: "1" descriptor_key: "vhaction")]), upstream_cluster: Some("limitador"), domain: Some("toystore-app") }}, failure_mode_deny: true }
envoy_1      | [2022-06-20 22:38:03.209][27][info][wasm] [source/extensions/common/wasm/context.cc:1167] wasm log kuadrant_wasm vm.sentinel.kuadrant_wasm: root-context #1: VM started
envoy_1      | [2022-06-20 22:38:03.209][34][info][wasm] [source/extensions/common/wasm/context.cc:1167] wasm log kuadrant_wasm vm.sentinel.kuadrant_wasm: root-context #1: VM started
envoy_1      | [2022-06-20 22:38:03.210][27][info][wasm] [source/extensions/common/wasm/context.cc:1167] wasm log kuadrant_wasm vm.sentinel.kuadrant_wasm: plugin config parsed: FilterConfig { ratelimitpolicies: {"default-toystore": RateLimitPolicy { hosts: GlobPatternSet(RegexSet(["\\A.*\\z"])), rules: Some([Rule { operations: Some([Operation { paths: GlobPatternSet(RegexSet(["\\A/get\\z"])), methods: GlobPatternSet(RegexSet(["\\AGET\\z"])) }]), actions: Some([generic_key(descriptor_value: "1" descriptor_key: "admin")]) }]), global_actions: Some([generic_key(descriptor_value: "1" descriptor_key: "vhaction")]), upstream_cluster: Some("limitador"), domain: Some("toystore-app") }}, failure_mode_deny: true }
envoy_1      | [2022-06-20 22:38:03.210][34][info][wasm] [source/extensions/common/wasm/context.cc:1167] wasm log kuadrant_wasm vm.sentinel.kuadrant_wasm: plugin config parsed: FilterConfig { ratelimitpolicies: {"default-toystore": RateLimitPolicy { hosts: GlobPatternSet(RegexSet(["\\A.*\\z"])), rules: Some([Rule { operations: Some([Operation { paths: GlobPatternSet(RegexSet(["\\A/get\\z"])), methods: GlobPatternSet(RegexSet(["\\AGET\\z"])) }]), actions: Some([generic_key(descriptor_value: "1" descriptor_key: "admin")]) }]), global_actions: Some([generic_key(descriptor_value: "1" descriptor_key: "vhaction")]), upstream_cluster: Some("limitador"), domain: Some("toystore-app") }}, failure_mode_deny: true }
envoy_1      | [2022-06-20 22:38:03.227][36][debug][wasm] [source/extensions/common/wasm/wasm.cc:104] Thread-Local Wasm created 6 now active
envoy_1      | [2022-06-20 22:38:03.228][26][debug][wasm] [source/extensions/common/wasm/wasm.cc:104] Thread-Local Wasm created 7 now active
envoy_1      | [2022-06-20 22:38:03.229][23][debug][wasm] [source/extensions/common/wasm/wasm.cc:104] Thread-Local Wasm created 8 now active
envoy_1      | [2022-06-20 22:38:03.231][22][debug][wasm] [source/extensions/common/wasm/wasm.cc:104] Thread-Local Wasm created 9 now active
envoy_1      | [2022-06-20 22:38:03.232][29][debug][wasm] [source/extensions/common/wasm/wasm.cc:104] Thread-Local Wasm created 10 now active
envoy_1      | [2022-06-20 22:38:03.233][36][info][wasm] [source/extensions/common/wasm/context.cc:1167] wasm log kuadrant_wasm vm.sentinel.kuadrant_wasm: root-context #1: VM started
envoy_1      | [2022-06-20 22:38:03.234][36][info][wasm] [source/extensions/common/wasm/context.cc:1167] wasm log kuadrant_wasm vm.sentinel.kuadrant_wasm: plugin config parsed: FilterConfig { ratelimitpolicies: {"default-toystore": RateLimitPolicy { hosts: GlobPatternSet(RegexSet(["\\A.*\\z"])), rules: Some([Rule { operations: Some([Operation { paths: GlobPatternSet(RegexSet(["\\A/get\\z"])), methods: GlobPatternSet(RegexSet(["\\AGET\\z"])) }]), actions: Some([generic_key(descriptor_value: "1" descriptor_key: "admin")]) }]), global_actions: Some([generic_key(descriptor_value: "1" descriptor_key: "vhaction")]), upstream_cluster: Some("limitador"), domain: Some("toystore-app") }}, failure_mode_deny: true }
envoy_1      | [2022-06-20 22:38:03.234][26][info][wasm] [source/extensions/common/wasm/context.cc:1167] wasm log kuadrant_wasm vm.sentinel.kuadrant_wasm: root-context #1: VM started
envoy_1      | [2022-06-20 22:38:03.235][26][info][wasm] [source/extensions/common/wasm/context.cc:1167] wasm log kuadrant_wasm vm.sentinel.kuadrant_wasm: plugin config parsed: FilterConfig { ratelimitpolicies: {"default-toystore": RateLimitPolicy { hosts: GlobPatternSet(RegexSet(["\\A.*\\z"])), rules: Some([Rule { operations: Some([Operation { paths: GlobPatternSet(RegexSet(["\\A/get\\z"])), methods: GlobPatternSet(RegexSet(["\\AGET\\z"])) }]), actions: Some([generic_key(descriptor_value: "1" descriptor_key: "admin")]) }]), global_actions: Some([generic_key(descriptor_value: "1" descriptor_key: "vhaction")]), upstream_cluster: Some("limitador"), domain: Some("toystore-app") }}, failure_mode_deny: true }
envoy_1      | [2022-06-20 22:38:03.235][23][info][wasm] [source/extensions/common/wasm/context.cc:1167] wasm log kuadrant_wasm vm.sentinel.kuadrant_wasm: root-context #1: VM started
envoy_1      | [2022-06-20 22:38:03.236][22][info][wasm] [source/extensions/common/wasm/context.cc:1167] wasm log kuadrant_wasm vm.sentinel.kuadrant_wasm: root-context #1: VM started
envoy_1      | [2022-06-20 22:38:03.236][29][info][wasm] [source/extensions/common/wasm/context.cc:1167] wasm log kuadrant_wasm vm.sentinel.kuadrant_wasm: root-context #1: VM started
envoy_1      | [2022-06-20 22:38:03.236][23][info][wasm] [source/extensions/common/wasm/context.cc:1167] wasm log kuadrant_wasm vm.sentinel.kuadrant_wasm: plugin config parsed: FilterConfig { ratelimitpolicies: {"default-toystore": RateLimitPolicy { hosts: GlobPatternSet(RegexSet(["\\A.*\\z"])), rules: Some([Rule { operations: Some([Operation { paths: GlobPatternSet(RegexSet(["\\A/get\\z"])), methods: GlobPatternSet(RegexSet(["\\AGET\\z"])) }]), actions: Some([generic_key(descriptor_value: "1" descriptor_key: "admin")]) }]), global_actions: Some([generic_key(descriptor_value: "1" descriptor_key: "vhaction")]), upstream_cluster: Some("limitador"), domain: Some("toystore-app") }}, failure_mode_deny: true }
envoy_1      | [2022-06-20 22:38:03.237][29][info][wasm] [source/extensions/common/wasm/context.cc:1167] wasm log kuadrant_wasm vm.sentinel.kuadrant_wasm: plugin config parsed: FilterConfig { ratelimitpolicies: {"default-toystore": RateLimitPolicy { hosts: GlobPatternSet(RegexSet(["\\A.*\\z"])), rules: Some([Rule { operations: Some([Operation { paths: GlobPatternSet(RegexSet(["\\A/get\\z"])), methods: GlobPatternSet(RegexSet(["\\AGET\\z"])) }]), actions: Some([generic_key(descriptor_value: "1" descriptor_key: "admin")]) }]), global_actions: Some([generic_key(descriptor_value: "1" descriptor_key: "vhaction")]), upstream_cluster: Some("limitador"), domain: Some("toystore-app") }}, failure_mode_deny: true }
envoy_1      | [2022-06-20 22:38:03.237][22][info][wasm] [source/extensions/common/wasm/context.cc:1167] wasm log kuadrant_wasm vm.sentinel.kuadrant_wasm: plugin config parsed: FilterConfig { ratelimitpolicies: {"default-toystore": RateLimitPolicy { hosts: GlobPatternSet(RegexSet(["\\A.*\\z"])), rules: Some([Rule { operations: Some([Operation { paths: GlobPatternSet(RegexSet(["\\A/get\\z"])), methods: GlobPatternSet(RegexSet(["\\AGET\\z"])) }]), actions: Some([generic_key(descriptor_value: "1" descriptor_key: "admin")]) }]), global_actions: Some([generic_key(descriptor_value: "1" descriptor_key: "vhaction")]), upstream_cluster: Some("limitador"), domain: Some("toystore-app") }}, failure_mode_deny: true }
envoy_1      | [2022-06-20 22:38:03.237][1][warning][main] [source/server/server.cc:715] there is no configured limit to the number of allowed active connections. Set a limit via the runtime key overload.global_downstream_max_connections
```

</details>

Test rate limited service with

```
curl http://127.0.0.1:18000/get
{
  "args": {}, 
  "headers": {
    "Accept": "*/*", 
    "Host": "127.0.0.1:18000", 
    "User-Agent": "curl/7.68.0", 
    "X-Envoy-Expected-Rq-Timeout-Ms": "15000"
  }, 
  "origin": "172.24.0.4", 
  "url": "http://127.0.0.1:18000/get"
}
```
Envoy  and limitador log stream provides insight

<details>

```
envoy_1      | [2022-06-20 22:39:52.057][23][debug][http] [source/common/http/conn_manager_impl.cc:274] [C0] new stream
envoy_1      | [2022-06-20 22:39:52.057][23][debug][http] [source/common/http/conn_manager_impl.cc:867] [C0][S3257213266290420283] request headers complete (end_stream=true):
envoy_1      | ':authority', '127.0.0.1:18000'
envoy_1      | ':path', '/get'
envoy_1      | ':method', 'GET'
envoy_1      | 'user-agent', 'curl/7.68.0'
envoy_1      | 'accept', '*/*'
envoy_1      | 
envoy_1      | [2022-06-20 22:39:52.057][23][debug][http] [source/common/http/filter_manager.cc:841] [C0][S3257213266290420283] request end stream
envoy_1      | [2022-06-20 22:39:52.058][23][info][wasm] [source/extensions/common/wasm/context.cc:1167] wasm log kuadrant_wasm kuadrant_wasm vm.sentinel.kuadrant_wasm: context #2: on_http_request_headers called
envoy_1      | [2022-06-20 22:39:52.058][23][info][wasm] [source/extensions/common/wasm/context.cc:1167] wasm log kuadrant_wasm kuadrant_wasm vm.sentinel.kuadrant_wasm: context #2: match found in default-toystore RateLimitPolicy
envoy_1      | [2022-06-20 22:39:52.058][23][debug][wasm] [source/extensions/common/wasm/context.cc:1164] wasm log kuadrant_wasm kuadrant_wasm vm.sentinel.kuadrant_wasm: context #2: matched operation: Some(Operation { paths: GlobPatternSet(RegexSet(["\\A/get\\z"])), methods: GlobPatternSet(RegexSet(["\\AGET\\z"])) })
envoy_1      | [2022-06-20 22:39:52.058][23][debug][router] [source/common/router/router.cc:457] [C0][S10252595939100066059] cluster 'limitador' match for URL '/envoy.service.ratelimit.v3.RateLimitService/ShouldRateLimit'
envoy_1      | [2022-06-20 22:39:52.058][23][debug][router] [source/common/router/router.cc:673] [C0][S10252595939100066059] router decoding headers:
envoy_1      | ':method', 'POST'
envoy_1      | ':path', '/envoy.service.ratelimit.v3.RateLimitService/ShouldRateLimit'
envoy_1      | ':authority', 'limitador'
envoy_1      | ':scheme', 'http'
envoy_1      | 'te', 'trailers'
envoy_1      | 'grpc-timeout', '5000m'
envoy_1      | 'content-type', 'application/grpc'
envoy_1      | 'x-envoy-internal', 'true'
envoy_1      | 'x-forwarded-for', '172.24.0.4'
envoy_1      | 'x-envoy-expected-rq-timeout-ms', '5000'
envoy_1      | 
envoy_1      | [2022-06-20 22:39:52.058][23][info][wasm] [source/extensions/common/wasm/context.cc:1167] wasm log kuadrant_wasm kuadrant_wasm vm.sentinel.kuadrant_wasm: Initiated gRPC call (id# 5) to Limitador
limitador_1  | [2022-06-20T22:39:52Z DEBUG h2::codec::framed_write] send frame=Settings { flags: (0x0), initial_window_size: 1048576, max_frame_size: 16384 } 
limitador_1  | [2022-06-20T22:39:52Z DEBUG h2::proto::connection] Connection; peer=Server
envoy_1      | [2022-06-20 22:39:52.058][23][debug][router] [source/common/router/upstream_request.cc:416] [C0][S10252595939100066059] pool ready
envoy_1      | [2022-06-20 22:39:52.059][23][debug][router] [source/common/router/router.cc:1285] [C0][S10252595939100066059] upstream headers complete: end_stream=false
envoy_1      | [2022-06-20 22:39:52.059][23][debug][http] [source/common/http/async_client_impl.cc:101] async http request response headers (end_stream=false):
envoy_1      | ':status', '200'
envoy_1      | 'content-type', 'application/grpc'
envoy_1      | 'date', 'Mon, 20 Jun 2022 22:39:52 GMT'
envoy_1      | 'x-envoy-upstream-service-time', '0'
envoy_1      | 
limitador_1  | [2022-06-20T22:39:52Z DEBUG h2::codec::framed_read] received frame=Settings { flags: (0x0), header_table_size: 4096, enable_push: 0, max_concurrent_streams: 2147483647, initial_window_size: 268435456, enable_connect_protocol: 0 } 
limitador_1  | [2022-06-20T22:39:52Z DEBUG h2::codec::framed_write] send frame=Settings { flags: (0x1: ACK) } 
limitador_1  | [2022-06-20T22:39:52Z DEBUG h2::codec::framed_read] received frame=WindowUpdate { stream_id: StreamId(0), size_increment: 268369921 } 
limitador_1  | [2022-06-20T22:39:52Z DEBUG h2::codec::framed_read] received frame=Headers { stream_id: StreamId(1), flags: (0x4: END_HEADERS) } 
limitador_1  | [2022-06-20T22:39:52Z DEBUG h2::codec::framed_read] received frame=Data { stream_id: StreamId(1), flags: (0x1: END_STREAM) } 
limitador_1  | [2022-06-20T22:39:52Z DEBUG h2::codec::framed_read] received frame=Settings { flags: (0x1: ACK) } 
limitador_1  | [2022-06-20T22:39:52Z DEBUG h2::proto::settings] received settings ACK; applying Settings { flags: (0x0), initial_window_size: 1048576, max_frame_size: 16384 } 
limitador_1  | [2022-06-20T22:39:52Z DEBUG h2::codec::framed_write] send frame=WindowUpdate { stream_id: StreamId(0), size_increment: 983041 } 
limitador_1  | [2022-06-20T22:39:52Z DEBUG limitador_server::envoy_rls::server] Request received: Request { metadata: MetadataMap { headers: {"te": "trailers", "grpc-timeout": "5000m", "content-type": "application/grpc", "x-envoy-internal": "true", "x-forwarded-for": "172.24.0.4", "x-envoy-expected-rq-timeout-ms": "5000"} }, message: RateLimitRequest { domain: "toystore-app", descriptors: [RateLimitDescriptor { entries: [Entry { key: "admin", value: "1" }, Entry { key: "vhaction", value: "1" }], limit: None }], hits_addend: 1 }, extensions: Extensions }
limitador_1  | [2022-06-20T22:39:52Z DEBUG h2::codec::framed_write] send frame=Headers { stream_id: StreamId(1), flags: (0x4: END_HEADERS) } 
limitador_1  | [2022-06-20T22:39:52Z DEBUG h2::codec::framed_write] send frame=Data { stream_id: StreamId(1) } 
limitador_1  | [2022-06-20T22:39:52Z DEBUG h2::codec::framed_write] send frame=Headers { stream_id: StreamId(1), flags: (0x5: END_HEADERS | END_STREAM) } 
envoy_1      | [2022-06-20 22:39:52.059][23][debug][http] [source/common/http/async_client_impl.cc:128] async http request response trailers:
envoy_1      | 'grpc-status', '0'
envoy_1      | 
envoy_1      | [2022-06-20 22:39:52.059][23][info][wasm] [source/extensions/common/wasm/context.cc:1167] wasm log kuadrant_wasm kuadrant_wasm vm.sentinel.kuadrant_wasm: received gRPC call response: token: 5, status: 0
envoy_1      | [2022-06-20 22:39:52.060][23][debug][router] [source/common/router/router.cc:457] [C0][S3257213266290420283] cluster 'upstream' match for URL '/get'
envoy_1      | [2022-06-20 22:39:52.060][23][debug][router] [source/common/router/router.cc:673] [C0][S3257213266290420283] router decoding headers:
envoy_1      | ':authority', '127.0.0.1:18000'
envoy_1      | ':path', '/get'
envoy_1      | ':method', 'GET'
envoy_1      | ':scheme', 'http'
envoy_1      | 'user-agent', 'curl/7.68.0'
envoy_1      | 'accept', '*/*'
envoy_1      | 'x-forwarded-proto', 'http'
envoy_1      | 'x-request-id', '96feeb04-20d9-4996-a036-95422a9ffaf0'
envoy_1      | 'x-envoy-expected-rq-timeout-ms', '15000'
envoy_1      | 
envoy_1      | [2022-06-20 22:39:52.060][23][debug][router] [source/common/router/upstream_request.cc:416] [C0][S3257213266290420283] pool ready
envoy_1      | [2022-06-20 22:39:52.067][23][debug][router] [source/common/router/router.cc:1285] [C0][S3257213266290420283] upstream headers complete: end_stream=false
envoy_1      | [2022-06-20 22:39:52.067][23][debug][http] [source/common/http/conn_manager_impl.cc:1467] [C0][S3257213266290420283] encoding headers via codec (end_stream=false):
envoy_1      | ':status', '200'
envoy_1      | 'server', 'envoy'
envoy_1      | 'date', 'Mon, 20 Jun 2022 22:39:52 GMT'
envoy_1      | 'content-type', 'application/json'
envoy_1      | 'content-length', '239'
envoy_1      | 'access-control-allow-origin', '*'
envoy_1      | 'access-control-allow-credentials', 'true'
envoy_1      | 'x-envoy-upstream-service-time', '6'
```

</details>


