### PR TITLE
New pluginconfiguration structure and implementation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -53,6 +53,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
 
 [[package]]
+name = "endian-type"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c34f04666d835ff5d62e058c3995147c06f42fe86ff053337632bca83e42702d"
+
+[[package]]
 name = "fastrand"
 version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -131,6 +137,15 @@ name = "memchr"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
+
+[[package]]
+name = "nibble_vec"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77a5d83df9f36fe23f0c3648c6bbb8b0298bb5f1939c8f2704431371f4b84d43"
+dependencies = [
+ "smallvec",
+]
 
 [[package]]
 name = "once_cell"
@@ -241,6 +256,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "radix_trie"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c069c179fcdc6a2fe24d8d18305cf085fdbd4f922c041943e203685d6a1c58fd"
+dependencies = [
+ "endian-type",
+ "nibble_vec",
+]
+
+[[package]]
 name = "redox_syscall"
 version = "0.2.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -323,6 +348,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "smallvec"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc88c725d61fc6c3132893370cac4a0200e3fedf5da8331c570664b1987f5ca2"
+
+[[package]]
 name = "syn"
 version = "1.0.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -395,6 +426,7 @@ dependencies = [
  "protobuf",
  "protoc-rust",
  "proxy-wasm",
+ "radix_trie",
  "regex",
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ protobuf = { version = "2.0", features = ["with-serde"] }
 thiserror = "1.0"
 regex = "1"
 serde_regex = "1.1.0"
+radix_trie = "0.2.1"
 
 [build-dependencies]
 protoc-rust = "2.0"

--- a/Makefile
+++ b/Makefile
@@ -136,8 +136,10 @@ update-protobufs:
 #	cd vendor-protobufs/data-plane-api/envoy/type/ && \
 #	touch tmp && git merge-file ./matcher/v3/metadata.proto ./tmp ./metadata/v3/metadata.proto --own && rm tmp
 
+RUST_SOURCES := $(shell find $(PROJECT_PATH)/src -name '*.rs')
+
 $(WASM_RELEASE_PATH): export BUILD = release
-$(WASM_RELEASE_PATH):
+$(WASM_RELEASE_PATH): $(RUST_SOURCES)
 	make -C $(PROJECT_PATH) -f $(MKFILE_PATH) build
 
 development: $(WASM_RELEASE_PATH)

--- a/deploy/docker-compose/envoy.yaml
+++ b/deploy/docker-compose/envoy.yaml
@@ -42,45 +42,121 @@ static_resources:
                       value: >
                         {
                           "failure_mode_deny": true,
-                          "ratelimitpolicies": {
-                            "default-toystore": {
-                              "hosts": [
-                                "*"
-                              ],
-                              "rules": [
+                          "rate_limit_policies": [
+                            {
+                              "name": "rlp-a",
+                              "rate_limit_domain": "rls-domain-a",
+                              "upstream_cluster": "limitador",
+                              "hostnames": ["*.a.com"],
+                              "gateway_actions": [
                                 {
-                                  "operations": [
+                                  "configurations": [
                                     {
-                                      "paths": [
-                                        "/get"
-                                      ],
-                                      "methods": [
-                                        "GET"
+                                      "actions": [
+                                        {
+                                          "request_headers": {
+                                            "header_name": "not-existing-header",
+                                            "skip_if_absent": true,
+                                            "descriptor_key": "my-not-existing-header"
+                                          }
+                                        }
                                       ]
-                                    }
-                                  ],
-                                  "actions": [
-                                    {
-                                      "generic_key": {
-                                        "descriptor_value": "1",
-                                        "descriptor_key": "admin"
-                                      }
                                     }
                                   ]
                                 }
-                              ],
-                              "global_actions": [
-                                {
-                                  "generic_key": {
-                                    "descriptor_value": "1",
-                                    "descriptor_key": "vhaction"
-                                  }
-                                }
-                              ],
+                              ]
+                            },
+                            {
+                              "name": "rlp-b",
+                              "rate_limit_domain": "rls-domain-b",
                               "upstream_cluster": "limitador",
-                              "domain": "toystore-app"
+                              "hostnames": ["*.b.com"],
+                              "gateway_actions": [
+                                {
+                                  "rules": [
+                                    {
+                                      "paths": ["/not/exising/path"]
+                                    }
+                                  ],
+                                  "configurations": [
+                                    {
+                                      "actions": [
+                                        {
+                                          "generic_key": {
+                                            "descriptor_key": "some_generic_key",
+                                            "descriptor_value": "some_generic_value"
+                                          }
+                                        }
+                                      ]
+                                    }
+                                  ]
+                                }
+                              ]
+                            },
+                            {
+                              "name": "rlp-c",
+                              "rate_limit_domain": "rls-domain-c",
+                              "upstream_cluster": "limitador",
+                              "hostnames": ["*.c.com"],
+                              "gateway_actions": [
+                                {
+                                  "rules": [
+                                    {
+                                      "paths": ["/get"],
+                                      "hosts": ["test.c.com"],
+                                      "method": ["GET"]
+                                    }
+                                  ],
+                                  "configurations": [
+                                    {
+                                      "actions": [
+                                        {
+                                          "generic_key": {
+                                            "descriptor_key": "some_generic_key_for_c",
+                                            "descriptor_value": "some_generic_value_for_c"
+                                          }
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "actions": [
+                                        {
+                                          "remote_address": {}
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "actions": [
+                                        {
+                                          "header_value_match": {
+                                            "descriptor_value": "header_value_match_value",
+                                            "headers": [
+                                              {
+                                                "name": "My-Custom-Header-01",
+                                                "exact_match": "my-custom-header-value",
+                                                "invert_match": false
+                                              }
+                                            ]
+                                          }
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "actions": [
+                                        {
+                                          "request_headers": {
+                                            "header_name": "My-Custom-Header-02",
+                                            "skip_if_absent": true,
+                                            "descriptor_key": "my-custom-header-key"
+                                          }
+                                        }
+                                      ]
+                                    }
+                                  ]
+                                }
+                              ]
                             }
-                          }
+                          ]
                         }
               - name: envoy.filters.http.router
   clusters:

--- a/src/configuration.rs
+++ b/src/configuration.rs
@@ -1,77 +1,80 @@
 use crate::envoy::RLA_action_specifier;
-use crate::glob::GlobPatternSet;
+use crate::policy_index::PolicyIndex;
 use serde::Deserialize;
-use std::collections::HashMap;
-
-#[derive(Deserialize, Debug, Clone)]
-pub struct Operation {
-    #[serde(default)]
-    pub paths: GlobPatternSet,
-    #[serde(default)]
-    pub methods: GlobPatternSet,
-}
 
 #[derive(Deserialize, Debug, Clone)]
 pub struct Rule {
-    pub operations: Option<Vec<Operation>>,
+    pub paths: Option<Vec<String>>,
+    pub hosts: Option<Vec<String>>,
+    pub methods: Option<Vec<String>>,
+}
+
+#[derive(Deserialize, Debug, Clone)]
+pub struct Configuration {
     pub actions: Option<Vec<RLA_action_specifier>>,
 }
 
-impl Rule {
-    pub fn operations(&self) -> Option<&[Operation]> {
-        self.operations.as_deref()
-    }
-
-    pub fn actions(&self) -> Option<&[RLA_action_specifier]> {
-        self.actions.as_deref()
-    }
+#[derive(Deserialize, Debug, Clone)]
+pub struct GatewayAction {
+    pub rules: Option<Vec<Rule>>,
+    pub configurations: Option<Vec<Configuration>>,
 }
 
 #[derive(Deserialize, Debug, Clone)]
 pub struct RateLimitPolicy {
-    #[serde(default)]
-    hosts: GlobPatternSet,
-    rules: Option<Vec<Rule>>,
-    global_actions: Option<Vec<RLA_action_specifier>>,
-    upstream_cluster: Option<String>,
-    domain: Option<String>,
+    pub name: String,
+    pub rate_limit_domain: String,
+    pub upstream_cluster: String,
+    pub hostnames: Vec<String>,
+    pub gateway_actions: Vec<GatewayAction>,
 }
 
 impl RateLimitPolicy {
+    #[cfg(test)]
     pub fn new(
-        hosts: GlobPatternSet,
-        rules: Option<Vec<Rule>>,
-        global_actions: Option<Vec<RLA_action_specifier>>,
-        upstream_cluster: Option<String>,
-        domain: Option<String>,
+        name: String,
+        rate_limit_domain: String,
+        upstream_cluster: String,
+        hostnames: Vec<String>,
+        gateway_actions: Vec<GatewayAction>,
     ) -> Self {
         RateLimitPolicy {
-            hosts,
-            rules,
-            global_actions,
+            name,
+            rate_limit_domain,
             upstream_cluster,
-            domain,
+            hostnames,
+            gateway_actions,
+        }
+    }
+}
+
+pub struct FilterConfig {
+    pub index: PolicyIndex,
+    // Deny request when faced with an irrecoverable failure.
+    pub failure_mode_deny: bool,
+}
+
+impl FilterConfig {
+    pub fn new() -> Self {
+        Self {
+            index: PolicyIndex::new(),
+            failure_mode_deny: true,
         }
     }
 
-    pub fn rules(&self) -> Option<&[Rule]> {
-        self.rules.as_deref()
-    }
+    pub fn from(config: PluginConfiguration) -> Self {
+        let mut index = PolicyIndex::new();
 
-    pub fn hosts(&self) -> &GlobPatternSet {
-        &self.hosts
-    }
+        for rlp in config.rate_limit_policies.iter() {
+            for hostname in rlp.hostnames.iter() {
+                index.insert(hostname, rlp.clone());
+            }
+        }
 
-    pub fn global_actions(&self) -> Option<&[RLA_action_specifier]> {
-        self.global_actions.as_deref()
-    }
-
-    pub fn upstream_cluster(&self) -> Option<&str> {
-        self.upstream_cluster.as_deref()
-    }
-
-    pub fn domain(&self) -> Option<&str> {
-        self.domain.as_deref()
+        Self {
+            index,
+            failure_mode_deny: config.failure_mode_deny,
+        }
     }
 }
 
@@ -80,68 +83,74 @@ impl RateLimitPolicy {
 // to sort through ratelimitpolicies and then further operations.
 
 #[derive(Deserialize, Debug, Clone)]
-pub struct FilterConfig {
-    ratelimitpolicies: HashMap<String, RateLimitPolicy>,
+pub struct PluginConfiguration {
+    pub rate_limit_policies: Vec<RateLimitPolicy>,
     // Deny request when faced with an irrecoverable failure.
-    failure_mode_deny: bool,
-}
-
-impl FilterConfig {
-    pub fn new() -> Self {
-        FilterConfig {
-            ratelimitpolicies: HashMap::new(),
-            failure_mode_deny: true,
-        }
-    }
-
-    pub fn ratelimitpolicies(&self) -> &HashMap<String, RateLimitPolicy> {
-        &self.ratelimitpolicies
-    }
-
-    pub fn failure_mode_deny(&self) -> bool {
-        self.failure_mode_deny
-    }
+    pub failure_mode_deny: bool,
 }
 
 #[cfg(test)]
 mod test {
     use super::*;
 
+    const CONFIG: &str = r#"{
+        "failure_mode_deny": true,
+        "rate_limit_policies": [
+        {
+            "name": "some-name",
+            "rate_limit_domain": "RLS-domain",
+            "upstream_cluster": "limitador-cluster",
+            "hostnames": ["*.toystore.com", "example.com"],
+            "gateway_actions": [
+            {
+                "rules": [
+                {
+                    "paths": ["/admin/toy"],
+                    "hosts": ["cars.toystore.com"],
+                    "methods": ["POST"]
+                }],
+                "configurations": [
+                {
+                    "actions": [
+                    {
+                        "generic_key": {
+                            "descriptor_key": "admin",
+                            "descriptor_value": "1"
+                        }
+                    }
+                    ]
+                }
+                ]
+            }
+            ]
+        }
+        ]
+    }"#;
+
     #[test]
     fn parse_config() {
-        const CONFIG: &str = r#"{
-            "failure_mode_deny": true,
-            "ratelimitpolicies": {
-                "default-toystore": {
-                    "hosts": ["*.toystore.com"],
-                    "rules": [{
-                        "operations": [{
-                            "paths": ["/toy*"],
-                            "methods": ["GET"]
-                        }],
-                        "actions": [{
-                            "generic_key": {
-                                "descriptor_value": "yes",
-                                "descriptor_key": "get-toy"
-                            }
-                        }]
-                    }],
-                    "global_actions": [{
-                        "generic_key": {
-                            "descriptor_value": "yes",
-                            "descriptor_key": "vhost-level"
-                        }
-                    }],
-                    "upstream_cluster": "outbound|8080||limitador.kuadrant-system.svc.cluster.local",
-                    "domain": "toystore"
-                }
-            }
-        }"#;
-
-        let res = serde_json::from_str::<FilterConfig>(CONFIG);
+        let res = serde_json::from_str::<PluginConfiguration>(CONFIG);
         if let Err(ref e) = res {
             eprintln!("{}", e);
         }
         assert!(res.is_ok());
+    }
+
+    #[test]
+    fn filter_config_from_configuration() {
+        let res = serde_json::from_str::<PluginConfiguration>(CONFIG);
+        assert!(res.is_ok());
+
+        let filter_config = FilterConfig::from(res.unwrap());
+        let rlp_option = filter_config.index.get_longest_match_policy("example.com");
+        assert!(rlp_option.is_some());
+
+        let rlp_option = filter_config
+            .index
+            .get_longest_match_policy("test.toystore.com");
+        assert!(rlp_option.is_some());
+
+        let rlp_option = filter_config.index.get_longest_match_policy("unknown");
+        assert!(rlp_option.is_none());
     }
 }

--- a/src/configuration.rs
+++ b/src/configuration.rs
@@ -38,6 +38,22 @@ pub struct RateLimitPolicy {
 }
 
 impl RateLimitPolicy {
+    pub fn new(
+        hosts: GlobPatternSet,
+        rules: Option<Vec<Rule>>,
+        global_actions: Option<Vec<RLA_action_specifier>>,
+        upstream_cluster: Option<String>,
+        domain: Option<String>,
+    ) -> Self {
+        RateLimitPolicy {
+            hosts,
+            rules,
+            global_actions,
+            upstream_cluster,
+            domain,
+        }
+    }
+
     pub fn rules(&self) -> Option<&[Rule]> {
         self.rules.as_deref()
     }

--- a/src/configuration.rs
+++ b/src/configuration.rs
@@ -4,20 +4,26 @@ use serde::Deserialize;
 
 #[derive(Deserialize, Debug, Clone)]
 pub struct Rule {
-    pub paths: Option<Vec<String>>,
-    pub hosts: Option<Vec<String>>,
-    pub methods: Option<Vec<String>>,
+    #[serde(default)]
+    pub paths: Vec<String>,
+    #[serde(default)]
+    pub hosts: Vec<String>,
+    #[serde(default)]
+    pub methods: Vec<String>,
 }
 
 #[derive(Deserialize, Debug, Clone)]
 pub struct Configuration {
-    pub actions: Option<Vec<RLA_action_specifier>>,
+    #[serde(default)]
+    pub actions: Vec<RLA_action_specifier>,
 }
 
 #[derive(Deserialize, Debug, Clone)]
 pub struct GatewayAction {
-    pub rules: Option<Vec<Rule>>,
-    pub configurations: Option<Vec<Configuration>>,
+    #[serde(default)]
+    pub rules: Vec<Rule>,
+    #[serde(default)]
+    pub configurations: Vec<Configuration>,
 }
 
 #[derive(Deserialize, Debug, Clone)]
@@ -26,6 +32,7 @@ pub struct RateLimitPolicy {
     pub rate_limit_domain: String,
     pub upstream_cluster: String,
     pub hostnames: Vec<String>,
+    #[serde(default)]
     pub gateway_actions: Vec<GatewayAction>,
 }
 

--- a/src/filter.rs
+++ b/src/filter.rs
@@ -20,18 +20,21 @@ mod root_context;
 // This is a C interface, so make it explicit in the fn signature (and avoid mangling)
 extern "C" fn start() {
     use crate::configuration::FilterConfig;
+    use log::info;
     use proxy_wasm::traits::RootContext;
     use proxy_wasm::types::LogLevel;
     use root_context::FilterRoot;
+    use std::rc::Rc;
 
     proxy_wasm::set_log_level(LogLevel::Trace);
     std::panic::set_hook(Box::new(|panic_info| {
         proxy_wasm::hostcalls::log(LogLevel::Critical, &panic_info.to_string()).unwrap();
     }));
     proxy_wasm::set_root_context(|context_id| -> Box<dyn RootContext> {
+        info!("set_root_context #{}", context_id);
         Box::new(FilterRoot {
             context_id,
-            config: FilterConfig::new(),
+            config: Rc::new(FilterConfig::new()),
         })
     });
 }

--- a/src/filter/http_context.rs
+++ b/src/filter/http_context.rs
@@ -1,27 +1,19 @@
-use crate::configuration::FilterConfig;
+use crate::configuration::{Configuration, FilterConfig, RateLimitPolicy, Rule};
 use crate::envoy::{
-    RLA_action_specifier, RateLimitRequest, RateLimitResponse, RateLimitResponse_Code,
+    RLA_action_specifier, RateLimitDescriptor, RateLimitDescriptor_Entry, RateLimitRequest,
+    RateLimitResponse, RateLimitResponse_Code,
 };
-use crate::utils::{descriptor_from_actions, request_process_failure, UtilsErr};
+use crate::utils::{match_headers, request_process_failure, subdomain_match};
 use log::{debug, info, warn};
 use protobuf::Message;
 use proxy_wasm::traits::{Context, HttpContext};
 use proxy_wasm::types::Action;
+use std::collections::HashMap;
 use std::rc::Rc;
 use std::time::Duration;
 
 const RATELIMIT_SERVICE_NAME: &str = "envoy.service.ratelimit.v3.RateLimitService";
 const RATELIMIT_METHOD_NAME: &str = "ShouldRateLimit";
-
-// we cannot determine using Istio's naming scheme because this cluster is patched
-// by the kuadrant-controller and should match whatever value is patched.
-const DEFAULT_UPSTREAM_CLUSTER: &str = "rate-limit-cluster";
-
-struct RequestInfo {
-    pub host: String,
-    pub path: String,
-    pub method: String,
-}
 
 pub struct Filter {
     pub context_id: u32,
@@ -29,118 +21,55 @@ pub struct Filter {
 }
 
 impl Filter {
-    fn config(&self) -> &FilterConfig {
-        &self.config
-    }
-
-    fn context_id(&self) -> u32 {
-        self.context_id
-    }
-
-    fn fetch_request_info(&self) -> RequestInfo {
-        // TODO(rahulanand16nov): Handle error
-        let host_bytes = self.get_property(vec!["request", "host"]).unwrap();
-        let mut host = String::from_utf8(host_bytes).unwrap();
-
-        // make sure port is removed from host before processing the request.
-        let split_host = host.split(':').collect::<Vec<_>>();
-        host = split_host[0].to_owned();
-
-        let path_bytes = self.get_property(vec!["request", "path"]).unwrap();
-        let path = String::from_utf8(path_bytes).unwrap();
-
-        let method_bytes = self.get_property(vec!["request", "method"]).unwrap();
-        let method = String::from_utf8(method_bytes).unwrap();
-
-        RequestInfo { host, path, method }
-    }
-
-    fn create_ratelimit_request(
-        &self,
-        domain: &str,
-        actions: &[RLA_action_specifier],
-    ) -> Result<RateLimitRequest, UtilsErr> {
-        let mut rl_req = RateLimitRequest::new();
-
-        rl_req.set_domain(domain.into());
-
-        rl_req.set_hits_addend(1);
-
-        rl_req
-            .mut_descriptors()
-            .push(descriptor_from_actions(self, actions)?);
-
-        Ok(rl_req)
-    }
-}
-
-impl HttpContext for Filter {
-    fn on_http_request_headers(&mut self, _: usize, _: bool) -> Action {
-        let context_id = self.context_id();
-        info!("context #{}: on_http_request_headers called", context_id);
-
-        let req_info = self.fetch_request_info();
-        let mut actions: Vec<RLA_action_specifier> = Vec::new();
-        let mut upstream_cluster = "";
-        let mut domain = "";
-
-        for (rlp_name, rlp) in self.config().ratelimitpolicies() {
-            if !rlp.hosts().is_match(&req_info.host) {
-                continue;
+    fn request_path(&self) -> String {
+        match self.get_http_request_header(":path") {
+            None => {
+                warn!(":path header not found");
+                String::new()
             }
-            info!(
-                "context #{}: match found in {} RateLimitPolicy",
-                context_id, rlp_name
-            );
-
-            if let Some(rules) = rlp.rules() {
-                for rule in rules {
-                    let matched_operation = rule.operations().and_then(|operations| {
-                        operations.iter().find(|operation| {
-                            operation.paths.is_match(&req_info.path)
-                                && operation.methods.is_match(&req_info.method)
-                        })
-                    });
-
-                    // Without the operation match, actions won't be included.
-                    if matched_operation.is_none() {
-                        continue;
-                    }
-
-                    debug!(
-                        "context #{}: matched operation: {:?}",
-                        context_id, matched_operation
-                    );
-
-                    if let Some(matched_actions) = rule.actions() {
-                        actions.append(&mut matched_actions.to_vec());
-                    }
-                    break; // only first match is allowed.
-                }
-            }
-
-            if let Some(global_actions) = rlp.global_actions() {
-                actions.append(&mut global_actions.to_vec());
-            }
-            upstream_cluster = rlp.upstream_cluster().unwrap_or(DEFAULT_UPSTREAM_CLUSTER);
-            domain = rlp.domain().unwrap_or(rlp_name);
-            break;
+            Some(path) => path,
         }
+    }
 
-        if actions.is_empty() {
-            info!(
-                "context #{}: Allowing request to pass because zero descriptors generated",
-                context_id
-            );
+    fn request_method(&self) -> String {
+        match self.get_http_request_header(":method") {
+            None => {
+                warn!(":method header not found");
+                String::new()
+            }
+            Some(method) => method,
+        }
+    }
+
+    fn request_authority(&self) -> String {
+        match self.get_http_request_header(":authority") {
+            None => {
+                warn!(":authority header not found");
+                String::new()
+            }
+            Some(host) => {
+                let split_host = host.split(':').collect::<Vec<_>>();
+                split_host[0].to_owned()
+            }
+        }
+    }
+
+    fn process_rate_limit_policy(&self, rlp: &RateLimitPolicy) -> Action {
+        let descriptors = self.build_descriptors(rlp);
+        if descriptors.len() == 0 {
+            debug!("[context_id: {}] empty descriptors", self.context_id);
             return Action::Continue;
         }
 
-        // Initiate a call to the limitador
-        let rl_request = self.create_ratelimit_request(domain, &actions).unwrap(); // TODO(rahulanand16nov): Error Handling
-        let rl_req_serialized = Message::write_to_bytes(&rl_request).unwrap(); // TODO(rahulanand16nov): Error Handling
+        let mut rl_req = RateLimitRequest::new();
+        rl_req.set_domain(rlp.rate_limit_domain.clone());
+        rl_req.set_hits_addend(1);
+        rl_req.set_descriptors(descriptors);
+
+        let rl_req_serialized = Message::write_to_bytes(&rl_req).unwrap(); // TODO(rahulanand16nov): Error Handling
 
         match self.dispatch_grpc_call(
-            upstream_cluster,
+            rlp.upstream_cluster.as_str(),
             RATELIMIT_SERVICE_NAME,
             RATELIMIT_METHOD_NAME,
             Vec::new(),
@@ -150,10 +79,183 @@ impl HttpContext for Filter {
             Ok(call_id) => info!("Initiated gRPC call (id# {}) to Limitador", call_id),
             Err(e) => {
                 warn!("gRPC call to Limitador failed! {:?}", e);
-                request_process_failure(self.config().failure_mode_deny());
+                request_process_failure(self.config.failure_mode_deny);
             }
         }
         Action::Pause
+    }
+
+    fn build_descriptors(
+        &self,
+        rlp: &RateLimitPolicy,
+    ) -> ::protobuf::RepeatedField<RateLimitDescriptor> {
+        //::protobuf::RepeatedField::default()
+        rlp.gateway_actions
+            .iter()
+            .filter(|ga| self.filter_configurations_by_rules(&ga.rules))
+            // flatten the vec<vec<Configurations> to vec<Configuration>
+            .flat_map(|ga| &ga.configurations)
+            // All actions cannot be flatten! each vec of actions defines one potential descriptor
+            .flat_map(|configuration| self.build_descriptor(configuration))
+            .collect()
+    }
+
+    fn filter_configurations_by_rules(&self, rules: &Vec<Rule>) -> bool {
+        if rules.is_empty() {
+            // no rules is equivalent to matching all the requests.
+            return true;
+        }
+
+        rules.iter().any(|rule| self.rule_applies(rule))
+    }
+
+    fn rule_applies(&self, rule: &Rule) -> bool {
+        if !rule.paths.is_empty() && !rule.paths.iter().any(|path| self.request_path().eq(path)) {
+            return false;
+        }
+
+        if !rule.methods.is_empty()
+            && !rule
+                .methods
+                .iter()
+                .any(|method| self.request_method().eq(method))
+        {
+            return false;
+        }
+
+        if !rule.hosts.is_empty()
+            && !rule
+                .hosts
+                .iter()
+                .any(|subdomain| subdomain_match(subdomain, self.request_authority().as_str()))
+        {
+            return false;
+        }
+
+        true
+    }
+
+    fn build_descriptor(&self, configuration: &Configuration) -> Option<RateLimitDescriptor> {
+        let mut entries = ::protobuf::RepeatedField::default();
+        for action in configuration.actions.iter() {
+            let mut descriptor_entry = RateLimitDescriptor_Entry::new();
+            match action {
+                RLA_action_specifier::source_cluster(_) => {
+                    match self.get_property(vec!["connection", "requested_server_name"]) {
+                        None => {
+                            debug!("requested service name not found");
+                            return None;
+                        }
+                        Some(src_cluster_bytes) => {
+                            match String::from_utf8(src_cluster_bytes) {
+                                // NOTE(rahulanand16nov): not sure if it's correct.
+                                Ok(src_cluster) => {
+                                    descriptor_entry.set_key("source_cluster".into());
+                                    descriptor_entry.set_value(src_cluster);
+                                    entries.push(descriptor_entry);
+                                }
+                                Err(e) => {
+                                    warn!("source_cluster action parsing error! {:?}", e);
+                                    return None;
+                                }
+                            }
+                        }
+                    }
+                }
+                RLA_action_specifier::destination_cluster(_) => {
+                    match self.get_property(vec!["cluster_name"]) {
+                        None => {
+                            debug!("cluster name not found");
+                            return None;
+                        }
+                        Some(cluster_name_bytes) => match String::from_utf8(cluster_name_bytes) {
+                            Ok(cluster_name) => {
+                                descriptor_entry.set_key("destination_cluster".into());
+                                descriptor_entry.set_value(cluster_name);
+                                entries.push(descriptor_entry);
+                            }
+                            Err(e) => {
+                                warn!("cluster_name action parsing error! {:?}", e);
+                                return None;
+                            }
+                        },
+                    }
+                }
+                RLA_action_specifier::request_headers(rh) => {
+                    match self.get_http_request_header(rh.get_header_name()) {
+                        None => {
+                            debug!("header name {} not found", rh.get_header_name());
+                            return None;
+                        }
+                        Some(header_value) => {
+                            descriptor_entry.set_key(rh.get_descriptor_key().into());
+                            descriptor_entry.set_value(header_value);
+                            entries.push(descriptor_entry);
+                        }
+                    }
+                }
+                RLA_action_specifier::remote_address(_) => {
+                    match self.get_http_request_header("x-forwarded-for") {
+                        None => {
+                            debug!("x-forwarded-for header not found");
+                            return None;
+                        }
+                        Some(remote_addess) => {
+                            descriptor_entry.set_key("remote_address".into());
+                            descriptor_entry.set_value(remote_addess);
+                            entries.push(descriptor_entry);
+                        }
+                    }
+                }
+                RLA_action_specifier::generic_key(gk) => {
+                    descriptor_entry.set_key(gk.get_descriptor_key().into());
+                    descriptor_entry.set_value(gk.get_descriptor_value().into());
+                    entries.push(descriptor_entry);
+                }
+                RLA_action_specifier::header_value_match(hvm) => {
+                    let request_headers: HashMap<_, _> =
+                        self.get_http_request_headers().into_iter().collect();
+
+                    if hvm.get_expect_match().get_value()
+                        == match_headers(&request_headers, hvm.get_headers())
+                    {
+                        descriptor_entry.set_key("header_match".into());
+                        descriptor_entry.set_value(hvm.get_descriptor_value().into());
+                        entries.push(descriptor_entry);
+                    } else {
+                        debug!("header_value_match does not add entry");
+                        return None;
+                    }
+                }
+                RLA_action_specifier::dynamic_metadata(_) => todo!(),
+                RLA_action_specifier::metadata(_) => todo!(),
+                RLA_action_specifier::extension(_) => todo!(),
+            }
+        }
+        let mut res = RateLimitDescriptor::new();
+        res.set_entries(entries);
+        Some(res)
+    }
+}
+
+impl HttpContext for Filter {
+    fn on_http_request_headers(&mut self, _: usize, _: bool) -> Action {
+        info!("on_http_request_headers #{}", self.context_id);
+
+        match self
+            .config
+            .index
+            .get_longest_match_policy(self.request_authority().as_str())
+        {
+            None => {
+                info!(
+                    "context #{}: Allowing request to pass because zero descriptors generated",
+                    self.context_id
+                );
+                Action::Continue
+            }
+            Some(rlp) => self.process_rate_limit_policy(rlp),
+        }
     }
 }
 
@@ -168,7 +270,7 @@ impl Context for Filter {
             Some(bytes) => bytes,
             None => {
                 warn!("grpc response body is empty!");
-                request_process_failure(self.config().failure_mode_deny());
+                request_process_failure(self.config.failure_mode_deny);
                 return;
             }
         };
@@ -180,14 +282,14 @@ impl Context for Filter {
                     "failed to parse grpc response body into RateLimitResponse message: {}",
                     e
                 );
-                request_process_failure(self.config().failure_mode_deny());
+                request_process_failure(self.config.failure_mode_deny);
                 return;
             }
         };
 
         match rl_resp.get_overall_code() {
             RateLimitResponse_Code::UNKNOWN => {
-                request_process_failure(self.config().failure_mode_deny());
+                request_process_failure(self.config.failure_mode_deny);
                 return;
             }
             RateLimitResponse_Code::OVER_LIMIT => {

--- a/src/filter/http_context.rs
+++ b/src/filter/http_context.rs
@@ -7,6 +7,7 @@ use log::{debug, info, warn};
 use protobuf::Message;
 use proxy_wasm::traits::{Context, HttpContext};
 use proxy_wasm::types::Action;
+use std::rc::Rc;
 use std::time::Duration;
 
 const RATELIMIT_SERVICE_NAME: &str = "envoy.service.ratelimit.v3.RateLimitService";
@@ -24,7 +25,7 @@ struct RequestInfo {
 
 pub struct Filter {
     pub context_id: u32,
-    pub config: FilterConfig,
+    pub config: Rc<FilterConfig>,
 }
 
 impl Filter {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,4 +2,5 @@ mod configuration;
 mod envoy;
 mod filter;
 mod glob;
+mod policy_index;
 mod utils;

--- a/src/policy_index.rs
+++ b/src/policy_index.rs
@@ -1,0 +1,122 @@
+use radix_trie::Trie;
+
+use crate::configuration::RateLimitPolicy;
+
+pub struct PolicyIndex {
+    raw_tree: Trie<String, RateLimitPolicy>,
+}
+
+impl PolicyIndex {
+    pub fn new() -> Self {
+        Self {
+            raw_tree: Trie::new(),
+        }
+    }
+
+    pub fn insert(&mut self, subdomain: &str, policy: RateLimitPolicy) {
+        let rev = Self::reverse_subdomain(subdomain);
+        self.raw_tree.insert(rev, policy);
+    }
+
+    pub fn get_longest_match_policy(&self, subdomain: &str) -> Option<&RateLimitPolicy> {
+        let rev = Self::reverse_subdomain(subdomain);
+        self.raw_tree.get_ancestor_value(&rev)
+    }
+
+    fn reverse_subdomain(subdomain: &str) -> String {
+        let mut s = subdomain.to_string();
+        s.push('.');
+        if s.chars().nth(0).unwrap() == '*' {
+            s.remove(0);
+        } else {
+            s.insert(0, '$'); // $ is not a valid domain char
+        }
+        s.chars().rev().collect()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::configuration::RateLimitPolicy;
+    use crate::glob::GlobPatternSet;
+    use crate::policy_index::PolicyIndex;
+
+    fn build_ratelimit_policy(domain: String) -> RateLimitPolicy {
+        RateLimitPolicy::new(GlobPatternSet::default(), None, None, None, Some(domain))
+    }
+
+    #[test]
+    fn not_wildcard_subdomain() {
+        let mut index = PolicyIndex::new();
+        let rlp1 = build_ratelimit_policy(String::from("example.com"));
+        index.insert("example.com", rlp1);
+
+        let val = index.get_longest_match_policy("test.example.com");
+        assert_eq!(val.is_none(), true);
+
+        let val = index.get_longest_match_policy("other.com");
+        assert_eq!(val.is_none(), true);
+
+        let val = index.get_longest_match_policy("net");
+        assert_eq!(val.is_none(), true);
+
+        let val = index.get_longest_match_policy("example.com");
+        assert_eq!(val.is_some(), true);
+        assert_eq!(val.unwrap().domain().is_some(), true);
+        assert_eq!(val.unwrap().domain().unwrap(), "example.com");
+    }
+
+    #[test]
+    fn wildcard_subdomain_does_not_match_domain() {
+        let mut index = PolicyIndex::new();
+        let rlp1 = build_ratelimit_policy(String::from("*.example.com"));
+
+        index.insert("*.example.com", rlp1);
+        let val = index.get_longest_match_policy("example.com");
+        assert_eq!(val.is_none(), true);
+    }
+
+    #[test]
+    fn wildcard_subdomain_matches_subdomains() {
+        let mut index = PolicyIndex::new();
+        let rlp1 = build_ratelimit_policy(String::from("*.example.com"));
+
+        index.insert("*.example.com", rlp1);
+        let val = index.get_longest_match_policy("test.example.com");
+
+        assert_eq!(val.is_some(), true);
+        assert_eq!(val.unwrap().domain().is_some(), true);
+        assert_eq!(val.unwrap().domain().unwrap(), "*.example.com");
+    }
+
+    #[test]
+    fn longest_domain_match() {
+        let mut index = PolicyIndex::new();
+        let rlp1 = build_ratelimit_policy(String::from("*.com"));
+        index.insert("*.com", rlp1);
+        let rlp2 = build_ratelimit_policy(String::from("*.example.com"));
+        index.insert("*.example.com", rlp2);
+
+        let val = index.get_longest_match_policy("test.example.com");
+        assert_eq!(val.is_some(), true);
+        assert_eq!(val.unwrap().domain().is_some(), true);
+        assert_eq!(val.unwrap().domain().unwrap(), "*.example.com");
+
+        let val = index.get_longest_match_policy("example.com");
+        assert_eq!(val.is_some(), true);
+        assert_eq!(val.unwrap().domain().is_some(), true);
+        assert_eq!(val.unwrap().domain().unwrap(), "*.com");
+    }
+
+    #[test]
+    fn global_wildcard_match_all() {
+        let mut index = PolicyIndex::new();
+        let rlp1 = build_ratelimit_policy(String::from("*"));
+        index.insert("*", rlp1);
+
+        let val = index.get_longest_match_policy("test.example.com");
+        assert_eq!(val.is_some(), true);
+        assert_eq!(val.unwrap().domain().is_some(), true);
+        assert_eq!(val.unwrap().domain().unwrap(), "*");
+    }
+}

--- a/src/policy_index.rs
+++ b/src/policy_index.rs
@@ -26,7 +26,7 @@ impl PolicyIndex {
     fn reverse_subdomain(subdomain: &str) -> String {
         let mut s = subdomain.to_string();
         s.push('.');
-        if s.chars().nth(0).unwrap() == '*' {
+        if s.starts_with('*') {
             s.remove(0);
         } else {
             s.insert(0, '$'); // $ is not a valid domain char
@@ -38,16 +38,15 @@ impl PolicyIndex {
 #[cfg(test)]
 mod tests {
     use crate::configuration::RateLimitPolicy;
-    use crate::glob::GlobPatternSet;
     use crate::policy_index::PolicyIndex;
 
-    fn build_ratelimit_policy(domain: &str) -> RateLimitPolicy {
+    fn build_ratelimit_policy(name: &str) -> RateLimitPolicy {
         RateLimitPolicy::new(
-            GlobPatternSet::default(),
-            None,
-            None,
-            None,
-            Some(String::from(domain)),
+            name.to_owned(),
+            "".to_owned(),
+            "".to_owned(),
+            Vec::new(),
+            Vec::new(),
         )
     }
 
@@ -68,7 +67,7 @@ mod tests {
 
         let val = index.get_longest_match_policy("example.com");
         assert!(val.is_some());
-        assert_eq!(val.unwrap().domain(), Some("rlp1"));
+        assert_eq!(val.unwrap().name, "rlp1");
     }
 
     #[test]
@@ -90,7 +89,7 @@ mod tests {
         let val = index.get_longest_match_policy("test.example.com");
 
         assert!(val.is_some());
-        assert_eq!(val.unwrap().domain(), Some("rlp1"));
+        assert_eq!(val.unwrap().name, "rlp1");
     }
 
     #[test]
@@ -103,11 +102,11 @@ mod tests {
 
         let val = index.get_longest_match_policy("test.example.com");
         assert!(val.is_some());
-        assert_eq!(val.unwrap().domain(), Some("rlp2"));
+        assert_eq!(val.unwrap().name, "rlp2");
 
         let val = index.get_longest_match_policy("example.com");
         assert!(val.is_some());
-        assert_eq!(val.unwrap().domain(), Some("rlp1"));
+        assert_eq!(val.unwrap().name, "rlp1");
     }
 
     #[test]
@@ -118,6 +117,6 @@ mod tests {
 
         let val = index.get_longest_match_policy("test.example.com");
         assert!(val.is_some());
-        assert_eq!(val.unwrap().domain(), Some("rlp1"));
+        assert_eq!(val.unwrap().name, "rlp1");
     }
 }


### PR DESCRIPTION
### What

Implements partially https://github.com/Kuadrant/kuadrant-controller/issues/129

New PluginConfiguration structure. 

Each rate limit policy has a logical name and a set of hostnames to activate it based on the incoming request’s host header.

The WASM-SHIM builds a tree based data structure holding the rate limit policies. The longest (sub)domain match is used to select the policy to be applied. Only one policy is being applied per invocation.

The plugin object contains a list of configurations to build a list of Envoy's RLS descriptors. These policy configurations are defined at

```
rate_limit_policies[*].gatewat_actions[*].configurations
```

For example:

```yaml
configurations:
- actions:
   - generic_key:
        descriptor_key: admin
        descriptor_value: "1"
```

Each configuration produces, at most, one descriptor. Depending on the incoming request, one configuration may or may not produce a rate limit descriptor.

Each policy configuration has associated, optionally, a set of rules to match. Rules allow matching `hosts` and/or `methods` and/or `paths`. Matching occurs when at least one rule applies against the incoming request. If rules are not set or empty, it is equivalent to matching all the requests.

For example:

```yaml
gateway_actions:
      - rules:
          - paths: ["/admin/toy"]
            methods: ["GET"]
            hosts: ["pets.toystore.com"]
        configurations:
          - actions:
            - generic_key:
                descriptor_key: admin
                descriptor_value: "1"
```

Each configuration object defines a list of actions. Each action may (or may not) produce a descriptor entry (descriptor list item).
If an action cannot append a descriptor entry, no descriptor is generated for the configuration.

The external rate limit service will be called when there is at least one not empty descriptor generated by the list of configurations.

Example of plugin configuration object

```yaml
failure_mode_deny: true
rate_limit_policies:
  - name: toystore
    rate_limit_domain: toystore-app
    upstream_cluster: rate-limit-cluster
    hostnames: ["*.toystore.com"]
    gateway_actions:
      - rules:
          - paths: ["/admin/toy"]
            methods: ["GET"]
            hosts: ["pets.toystore.com"]
        configurations:
          - actions:
            - generic_key:
                descriptor_key: admin
                descriptor_value: "1"
```

### Verification steps

* Start local testing env based on docker-compose
```
$ make development
```

Test rate limit policy `rlp-a`. The WASM filter should not call limitador (reason: actions should not genereate descriptors)

```
curl -H "Host: test.a.com" http://127.0.0.1:18000/get
```

Test rate limit policy `rlp-b`. The WASM filter should not call limitador (reason: rules do not match)

```
curl -H "Host: test.b.com" http://127.0.0.1:18000/get
```

Test rate limit policy `rlp-c`. The WASM filter should call limitador with 4 descriptors

```
curl -H "Host: test.c.com" -H "x-forwarded-for: 127.0.0.1" -H "My-Custom-Header-01: my-custom-header-value-01" -H "My-Custom-Header-02: my-custom-header-value-02" http://127.0.0.1:18000/get
```

The Limitador's logs should show RLS request with 4 descriptors

```
limitador_1  | [2022-06-27T23:50:33Z DEBUG limitador_server::envoy_rls::server] Request received: Request { metadata: MetadataMap { headers: {"te": "trailers", "grpc-timeout": "5000m", "content-type": "application/grpc", "x-envoy-internal": "true", "x-forwarded-for": "172.20.0.4", "x-envoy-expected-rq-timeout-ms": "5000"} }, message: RateLimitRequest { domain: "rls-domain-c", descriptors: [RateLimitDescriptor { entries: [Entry { key: "some_generic_key_for_c", value: "some_generic_value_for_c" }], limit: None }, RateLimitDescriptor { entries: [Entry { key: "remote_address", value: "127.0.0.1" }], limit: None }, RateLimitDescriptor { entries: [Entry { key: "header_match", value: "header_value_match_value" }], limit: None }, RateLimitDescriptor { entries: [Entry { key: "my-custom-header-key", value: "my-custom-header-value-02" }], limit: None }], hits_addend: 1 }, extensions: Extensions }
```

PR's added to the `new-design` branch:

* Policy index tree #14 
* New plugin config struct #19 
* HTTP context implementation with the new filter config struct #20 
*  README and local testing resources #21 