### PR TITLE
New plugin config struct

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -53,6 +53,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
 
 [[package]]
+name = "endian-type"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c34f04666d835ff5d62e058c3995147c06f42fe86ff053337632bca83e42702d"
+
+[[package]]
 name = "fastrand"
 version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -131,6 +137,15 @@ name = "memchr"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
+
+[[package]]
+name = "nibble_vec"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77a5d83df9f36fe23f0c3648c6bbb8b0298bb5f1939c8f2704431371f4b84d43"
+dependencies = [
+ "smallvec",
+]
 
 [[package]]
 name = "once_cell"
@@ -241,6 +256,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "radix_trie"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c069c179fcdc6a2fe24d8d18305cf085fdbd4f922c041943e203685d6a1c58fd"
+dependencies = [
+ "endian-type",
+ "nibble_vec",
+]
+
+[[package]]
 name = "redox_syscall"
 version = "0.2.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -323,6 +348,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "smallvec"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc88c725d61fc6c3132893370cac4a0200e3fedf5da8331c570664b1987f5ca2"
+
+[[package]]
 name = "syn"
 version = "1.0.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -395,6 +426,7 @@ dependencies = [
  "protobuf",
  "protoc-rust",
  "proxy-wasm",
+ "radix_trie",
  "regex",
  "serde",
  "serde_json",

--- a/src/configuration.rs
+++ b/src/configuration.rs
@@ -1,77 +1,80 @@
 use crate::envoy::RLA_action_specifier;
-use crate::glob::GlobPatternSet;
+use crate::policy_index::PolicyIndex;
 use serde::Deserialize;
-use std::collections::HashMap;
-
-#[derive(Deserialize, Debug, Clone)]
-pub struct Operation {
-    #[serde(default)]
-    pub paths: GlobPatternSet,
-    #[serde(default)]
-    pub methods: GlobPatternSet,
-}
 
 #[derive(Deserialize, Debug, Clone)]
 pub struct Rule {
-    pub operations: Option<Vec<Operation>>,
+    pub paths: Option<Vec<String>>,
+    pub hosts: Option<Vec<String>>,
+    pub methods: Option<Vec<String>>,
+}
+
+#[derive(Deserialize, Debug, Clone)]
+pub struct Configuration {
     pub actions: Option<Vec<RLA_action_specifier>>,
 }
 
-impl Rule {
-    pub fn operations(&self) -> Option<&[Operation]> {
-        self.operations.as_deref()
-    }
-
-    pub fn actions(&self) -> Option<&[RLA_action_specifier]> {
-        self.actions.as_deref()
-    }
+#[derive(Deserialize, Debug, Clone)]
+pub struct GatewayAction {
+    pub rules: Option<Vec<Rule>>,
+    pub configurations: Option<Vec<Configuration>>,
 }
 
 #[derive(Deserialize, Debug, Clone)]
 pub struct RateLimitPolicy {
-    #[serde(default)]
-    hosts: GlobPatternSet,
-    rules: Option<Vec<Rule>>,
-    global_actions: Option<Vec<RLA_action_specifier>>,
-    upstream_cluster: Option<String>,
-    domain: Option<String>,
+    pub name: String,
+    pub rate_limit_domain: String,
+    pub upstream_cluster: String,
+    pub hostnames: Vec<String>,
+    pub gateway_actions: Vec<GatewayAction>,
 }
 
 impl RateLimitPolicy {
+    #[cfg(test)]
     pub fn new(
-        hosts: GlobPatternSet,
-        rules: Option<Vec<Rule>>,
-        global_actions: Option<Vec<RLA_action_specifier>>,
-        upstream_cluster: Option<String>,
-        domain: Option<String>,
+        name: String,
+        rate_limit_domain: String,
+        upstream_cluster: String,
+        hostnames: Vec<String>,
+        gateway_actions: Vec<GatewayAction>,
     ) -> Self {
         RateLimitPolicy {
-            hosts,
-            rules,
-            global_actions,
+            name,
+            rate_limit_domain,
             upstream_cluster,
-            domain,
+            hostnames,
+            gateway_actions,
+        }
+    }
+}
+
+pub struct FilterConfig {
+    pub index: PolicyIndex,
+    // Deny request when faced with an irrecoverable failure.
+    pub failure_mode_deny: bool,
+}
+
+impl FilterConfig {
+    pub fn new() -> Self {
+        Self {
+            index: PolicyIndex::new(),
+            failure_mode_deny: true,
         }
     }
 
-    pub fn rules(&self) -> Option<&[Rule]> {
-        self.rules.as_deref()
-    }
+    pub fn from(config: PluginConfiguration) -> Self {
+        let mut index = PolicyIndex::new();
 
-    pub fn hosts(&self) -> &GlobPatternSet {
-        &self.hosts
-    }
+        for rlp in config.rate_limit_policies.iter() {
+            for hostname in rlp.hostnames.iter() {
+                index.insert(hostname, rlp.clone());
+            }
+        }
 
-    pub fn global_actions(&self) -> Option<&[RLA_action_specifier]> {
-        self.global_actions.as_deref()
-    }
-
-    pub fn upstream_cluster(&self) -> Option<&str> {
-        self.upstream_cluster.as_deref()
-    }
-
-    pub fn domain(&self) -> Option<&str> {
-        self.domain.as_deref()
+        Self {
+            index,
+            failure_mode_deny: config.failure_mode_deny,
+        }
     }
 }
 
@@ -80,68 +83,74 @@ impl RateLimitPolicy {
 // to sort through ratelimitpolicies and then further operations.
 
 #[derive(Deserialize, Debug, Clone)]
-pub struct FilterConfig {
-    ratelimitpolicies: HashMap<String, RateLimitPolicy>,
+pub struct PluginConfiguration {
+    pub rate_limit_policies: Vec<RateLimitPolicy>,
     // Deny request when faced with an irrecoverable failure.
-    failure_mode_deny: bool,
-}
-
-impl FilterConfig {
-    pub fn new() -> Self {
-        FilterConfig {
-            ratelimitpolicies: HashMap::new(),
-            failure_mode_deny: true,
-        }
-    }
-
-    pub fn ratelimitpolicies(&self) -> &HashMap<String, RateLimitPolicy> {
-        &self.ratelimitpolicies
-    }
-
-    pub fn failure_mode_deny(&self) -> bool {
-        self.failure_mode_deny
-    }
+    pub failure_mode_deny: bool,
 }
 
 #[cfg(test)]
 mod test {
     use super::*;
 
+    const CONFIG: &str = r#"{
+        "failure_mode_deny": true,
+        "rate_limit_policies": [
+        {
+            "name": "some-name",
+            "rate_limit_domain": "RLS-domain",
+            "upstream_cluster": "limitador-cluster",
+            "hostnames": ["*.toystore.com", "example.com"],
+            "gateway_actions": [
+            {
+                "rules": [
+                {
+                    "paths": ["/admin/toy"],
+                    "hosts": ["cars.toystore.com"],
+                    "methods": ["POST"]
+                }],
+                "configurations": [
+                {
+                    "actions": [
+                    {
+                        "generic_key": {
+                            "descriptor_key": "admin",
+                            "descriptor_value": "1"
+                        }
+                    }
+                    ]
+                }
+                ]
+            }
+            ]
+        }
+        ]
+    }"#;
+
     #[test]
     fn parse_config() {
-        const CONFIG: &str = r#"{
-            "failure_mode_deny": true,
-            "ratelimitpolicies": {
-                "default-toystore": {
-                    "hosts": ["*.toystore.com"],
-                    "rules": [{
-                        "operations": [{
-                            "paths": ["/toy*"],
-                            "methods": ["GET"]
-                        }],
-                        "actions": [{
-                            "generic_key": {
-                                "descriptor_value": "yes",
-                                "descriptor_key": "get-toy"
-                            }
-                        }]
-                    }],
-                    "global_actions": [{
-                        "generic_key": {
-                            "descriptor_value": "yes",
-                            "descriptor_key": "vhost-level"
-                        }
-                    }],
-                    "upstream_cluster": "outbound|8080||limitador.kuadrant-system.svc.cluster.local",
-                    "domain": "toystore"
-                }
-            }
-        }"#;
-
-        let res = serde_json::from_str::<FilterConfig>(CONFIG);
+        let res = serde_json::from_str::<PluginConfiguration>(CONFIG);
         if let Err(ref e) = res {
             eprintln!("{}", e);
         }
         assert!(res.is_ok());
+    }
+
+    #[test]
+    fn filter_config_from_configuration() {
+        let res = serde_json::from_str::<PluginConfiguration>(CONFIG);
+        assert!(res.is_ok());
+
+        let filter_config = FilterConfig::from(res.unwrap());
+        let rlp_option = filter_config.index.get_longest_match_policy("example.com");
+        assert!(rlp_option.is_some());
+
+        let rlp_option = filter_config
+            .index
+            .get_longest_match_policy("test.toystore.com");
+        assert!(rlp_option.is_some());
+
+        let rlp_option = filter_config.index.get_longest_match_policy("unknown");
+        assert!(rlp_option.is_none());
     }
 }

--- a/src/filter.rs
+++ b/src/filter.rs
@@ -20,18 +20,21 @@ mod root_context;
 // This is a C interface, so make it explicit in the fn signature (and avoid mangling)
 extern "C" fn start() {
     use crate::configuration::FilterConfig;
+    use log::info;
     use proxy_wasm::traits::RootContext;
     use proxy_wasm::types::LogLevel;
     use root_context::FilterRoot;
+    use std::rc::Rc;
 
     proxy_wasm::set_log_level(LogLevel::Trace);
     std::panic::set_hook(Box::new(|panic_info| {
         proxy_wasm::hostcalls::log(LogLevel::Critical, &panic_info.to_string()).unwrap();
     }));
     proxy_wasm::set_root_context(|context_id| -> Box<dyn RootContext> {
+        info!("set_root_context #{}", context_id);
         Box::new(FilterRoot {
             context_id,
-            config: FilterConfig::new(),
+            config: Rc::new(FilterConfig::new()),
         })
     });
 }

--- a/src/filter/http_context.rs
+++ b/src/filter/http_context.rs
@@ -7,6 +7,7 @@ use log::{debug, info, warn};
 use protobuf::Message;
 use proxy_wasm::traits::{Context, HttpContext};
 use proxy_wasm::types::Action;
+use std::rc::Rc;
 use std::time::Duration;
 
 const RATELIMIT_SERVICE_NAME: &str = "envoy.service.ratelimit.v3.RateLimitService";
@@ -24,7 +25,7 @@ struct RequestInfo {
 
 pub struct Filter {
     pub context_id: u32,
-    pub config: FilterConfig,
+    pub config: Rc<FilterConfig>,
 }
 
 impl Filter {


### PR DESCRIPTION
### What

New PluginConfiguration structure. 

Each rate limit policy has a logical name and a set of hostnames to activate it based on the incoming request’s host header.

The policy contains a list of configurations to build a list of Envoy's RLS descriptors. 

Each configuration has associated, optionally, a set of rules to match. Rules allow matching `hosts` and/or `methods` and/or `paths`. 

Each configuration object defines a list of actions to produce descriptor entries.

Example of plugin configuration object

```yaml
failure_mode_deny: true
rate_limit_policies:
  - name: toystore
    rate_limit_domain: toystore-app
    upstream_cluster: rate-limit-cluster
    hostnames: ["*.toystore.com"]
    gateway_actions:
      - rules:
          - paths: ["/admin/toy"]
            methods: ["GET"]
            hosts: ["pets.toystore.com"]
        configurations:
          - actions:
            - generic_key:
                descriptor_key: admin
                descriptor_value: "1"
```

For the context, the replaced plugin configuration object:

```yaml
#  The filter’s behaviour in case the rate limiting service does not respond back. When it is set to true, Envoy will not allow traffic in case of communication failure between rate limiting service and the proxy.
failure_mode_deny: true 
ratelimitpolicies:
  default/toystore: # rate limit policy {NAMESPACE/NAME}
    hosts: # HTTPRoute hostnames
      - '*.toystore.com'
    rules: # route level actions
      - operations:
          - paths:
              - /admin/toy
            methods:
              - POST
              - DELETE
        actions:
          - generic_key:
              descriptor_value: yes
              descriptor_key: admin
    global_actions: # virtualHost level actions
      - generic_key:
          descriptor_value: yes
          descriptor_key: vhaction
    upstream_cluster: rate-limit-cluster # Limitador address reference
    domain: toystore-app # RLS protocol domain value
```

Update highlights:
* [*minor*] rate_limit_policies is a list instead of a map indexed by the name/namespace.
* [*major*] no distinction between "rules" and global actions
* [*major*] more aligned with RLS: multiple descriptors structured by "rate limit configurations" with matching rules https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/route/v3/route_components.proto#envoy-v3-api-field-config-route-v3-virtualhost-rate-limits

Note: It is expected that the code does not compile and tests do not pass. This PR tries to include only the minimum changes for the struct update. New PR's coming soon to add completeness.