### PR TITLE
README and local testing resources

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -136,8 +136,10 @@ update-protobufs:
 #	cd vendor-protobufs/data-plane-api/envoy/type/ && \
 #	touch tmp && git merge-file ./matcher/v3/metadata.proto ./tmp ./metadata/v3/metadata.proto --own && rm tmp
 
+RUST_SOURCES := $(shell find $(PROJECT_PATH)/src -name '*.rs')
+
 $(WASM_RELEASE_PATH): export BUILD = release
-$(WASM_RELEASE_PATH):
+$(WASM_RELEASE_PATH): $(RUST_SOURCES)
 	make -C $(PROJECT_PATH) -f $(MKFILE_PATH) build
 
 development: $(WASM_RELEASE_PATH)

--- a/deploy/docker-compose/envoy.yaml
+++ b/deploy/docker-compose/envoy.yaml
@@ -42,45 +42,121 @@ static_resources:
                       value: >
                         {
                           "failure_mode_deny": true,
-                          "ratelimitpolicies": {
-                            "default-toystore": {
-                              "hosts": [
-                                "*"
-                              ],
-                              "rules": [
+                          "rate_limit_policies": [
+                            {
+                              "name": "rlp-a",
+                              "rate_limit_domain": "rls-domain-a",
+                              "upstream_cluster": "limitador",
+                              "hostnames": ["*.a.com"],
+                              "gateway_actions": [
                                 {
-                                  "operations": [
+                                  "configurations": [
                                     {
-                                      "paths": [
-                                        "/get"
-                                      ],
-                                      "methods": [
-                                        "GET"
+                                      "actions": [
+                                        {
+                                          "request_headers": {
+                                            "header_name": "not-existing-header",
+                                            "skip_if_absent": true,
+                                            "descriptor_key": "my-not-existing-header"
+                                          }
+                                        }
                                       ]
-                                    }
-                                  ],
-                                  "actions": [
-                                    {
-                                      "generic_key": {
-                                        "descriptor_value": "1",
-                                        "descriptor_key": "admin"
-                                      }
                                     }
                                   ]
                                 }
-                              ],
-                              "global_actions": [
-                                {
-                                  "generic_key": {
-                                    "descriptor_value": "1",
-                                    "descriptor_key": "vhaction"
-                                  }
-                                }
-                              ],
+                              ]
+                            },
+                            {
+                              "name": "rlp-b",
+                              "rate_limit_domain": "rls-domain-b",
                               "upstream_cluster": "limitador",
-                              "domain": "toystore-app"
+                              "hostnames": ["*.b.com"],
+                              "gateway_actions": [
+                                {
+                                  "rules": [
+                                    {
+                                      "paths": ["/not/exising/path"]
+                                    }
+                                  ],
+                                  "configurations": [
+                                    {
+                                      "actions": [
+                                        {
+                                          "generic_key": {
+                                            "descriptor_key": "some_generic_key",
+                                            "descriptor_value": "some_generic_value"
+                                          }
+                                        }
+                                      ]
+                                    }
+                                  ]
+                                }
+                              ]
+                            },
+                            {
+                              "name": "rlp-c",
+                              "rate_limit_domain": "rls-domain-c",
+                              "upstream_cluster": "limitador",
+                              "hostnames": ["*.c.com"],
+                              "gateway_actions": [
+                                {
+                                  "rules": [
+                                    {
+                                      "paths": ["/get"],
+                                      "hosts": ["test.c.com"],
+                                      "method": ["GET"]
+                                    }
+                                  ],
+                                  "configurations": [
+                                    {
+                                      "actions": [
+                                        {
+                                          "generic_key": {
+                                            "descriptor_key": "some_generic_key_for_c",
+                                            "descriptor_value": "some_generic_value_for_c"
+                                          }
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "actions": [
+                                        {
+                                          "remote_address": {}
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "actions": [
+                                        {
+                                          "header_value_match": {
+                                            "descriptor_value": "header_value_match_value",
+                                            "headers": [
+                                              {
+                                                "name": "My-Custom-Header-01",
+                                                "exact_match": "my-custom-header-value",
+                                                "invert_match": false
+                                              }
+                                            ]
+                                          }
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "actions": [
+                                        {
+                                          "request_headers": {
+                                            "header_name": "My-Custom-Header-02",
+                                            "skip_if_absent": true,
+                                            "descriptor_key": "my-custom-header-key"
+                                          }
+                                        }
+                                      ]
+                                    }
+                                  ]
+                                }
+                              ]
                             }
-                          }
+                          ]
                         }
               - name: envoy.filters.http.router
   clusters:


### PR DESCRIPTION
This PR depends on the HTTP context implementation in https://github.com/Kuadrant/wasm-shim/pull/20

### What

* Updated README.md with local testing doc
* Envoy configuration with the new plugin config struct object

### Verification steps

* Start local testing env based on docker-compose
```
$ make development
```

Test rate limit policy `rlp-a`. The WASM filter should not call limitador (reason: actions should not genereate descriptors)

```
curl -H "Host: test.a.com" http://127.0.0.1:18000/get
```

Test rate limit policy `rlp-b`. The WASM filter should not call limitador (reason: rules do not match)

```
curl -H "Host: test.b.com" http://127.0.0.1:18000/get
```

Test rate limit policy `rlp-c`. The WASM filter should call limitador with 4 descriptors

```
curl -H "Host: test.c.com" -H "x-forwarded-for: 127.0.0.1" -H "My-Custom-Header-01: my-custom-header-value-01" -H "My-Custom-Header-02: my-custom-header-value-02" http://127.0.0.1:18000/get
```

The Limitador's logs should show RLS request with 4 descriptors

```
limitador_1  | [2022-06-27T23:50:33Z DEBUG limitador_server::envoy_rls::server] Request received: Request { metadata: MetadataMap { headers: {"te": "trailers", "grpc-timeout": "5000m", "content-type": "application/grpc", "x-envoy-internal": "true", "x-forwarded-for": "172.20.0.4", "x-envoy-expected-rq-timeout-ms": "5000"} }, message: RateLimitRequest { domain: "rls-domain-c", descriptors: [RateLimitDescriptor { entries: [Entry { key: "some_generic_key_for_c", value: "some_generic_value_for_c" }], limit: None }, RateLimitDescriptor { entries: [Entry { key: "remote_address", value: "127.0.0.1" }], limit: None }, RateLimitDescriptor { entries: [Entry { key: "header_match", value: "header_value_match_value" }], limit: None }, RateLimitDescriptor { entries: [Entry { key: "my-custom-header-key", value: "my-custom-header-value-02" }], limit: None }], hits_addend: 1 }, extensions: Extensions }
```
