### PR TITLE
clippy fix

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -1,4 +1,10 @@
-fn main() -> Result<(), Box<dyn std::error::Error>> {
+use std::error::Error;
+
+fn main() -> Result<(), Box<dyn Error>> {
+    generate_protobuf()
+}
+
+fn generate_protobuf() -> Result<(), Box<dyn Error>> {
     let custom = protoc_rust::Customize {
         serde_derive: Some(true),
         ..Default::default()
@@ -6,7 +12,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     protoc_rust::Codegen::new()
         .out_dir("src/envoy")
         .customize(custom)
-        .inputs(&[
+        .inputs([
             "vendor-protobufs/data-plane-api/envoy/service/auth/v3/external_auth.proto",
             "vendor-protobufs/data-plane-api/envoy/service/ratelimit/v3/rls.proto",
             "vendor-protobufs/data-plane-api/envoy/service/auth/v3/attribute_context.proto",
@@ -39,7 +45,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             "vendor-protobufs/udpa/xds/core/v3/authority.proto",
             "vendor-protobufs/data-plane-api/envoy/type/tracing/v3/custom_tag.proto",
         ])
-        .includes(&[
+        .includes([
             "vendor-protobufs/data-plane-api/",
             "vendor-protobufs/protoc-gen-validate/",
             "vendor-protobufs/udpa/",


### PR DESCRIPTION
### what

Starting with Rustc 1.65 (`rustc 1.65.0 (897e37553 2022-11-02) (from rustc 1.64.0 (a55dd71d5 2022-09-19))`), clippy complained about a needless borrow

```rust
error: the borrowed expression implements the required traits
  --> build.rs:9:17
   |
9  |           .inputs(&[
   |  _________________^
10 | |             "vendor-protobufs/data-plane-api/envoy/service/auth/v3/external_auth.proto",
11 | |             "vendor-protobufs/data-plane-api/envoy/service/ratelimit/v3/rls.proto",
12 | |             "vendor-protobufs/data-plane-api/envoy/service/auth/v3/attribute_context.proto",
...  |
40 | |             "vendor-protobufs/data-plane-api/envoy/type/tracing/v3/custom_tag.proto",
41 | |         ])
   | |_________^
   |
   = note: `-D clippy::needless-borrow` implied by `-D warnings`
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_borrow
```