### PR TITLE
wasm binary version enhanced traces

### DIFF
--- a/.github/workflows/build-image.yaml
+++ b/.github/workflows/build-image.yaml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Add latest tag
         if: ${{ github.ref_name == env.MAIN_BRANCH_NAME }}
         id: add-latest-tag
@@ -30,6 +30,8 @@ jobs:
         with:
           image: wasm-shim
           tags: ${{ env.IMG_TAGS }}
+          build-args: |
+            GITHUB_SHA=${{ github.sha }}
           dockerfiles: |
             ./Dockerfile
       - name: Push Image

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -165,6 +165,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "const_format"
+version = "0.2.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3a214c7af3d04997541b18d432afaff4c455e79e2029079647e72fc2bd27673"
+dependencies = [
+ "const_format_proc_macros",
+]
+
+[[package]]
+name = "const_format_proc_macros"
+version = "0.2.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7f6ff08fd20f4f299298a28e2dfa8a8ba1036e6cd2460ac1de7b425d76f2500"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-xid",
+]
+
+[[package]]
 name = "cpp_demangle"
 version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1670,8 +1690,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-shim"
-version = "0.1.0"
+version = "0.5.0-dev"
 dependencies = [
+ "const_format",
  "log",
  "prost",
  "prost-types",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,10 +1,16 @@
 [package]
 name = "wasm-shim"
-version = "0.1.0"
+version = "0.5.0-dev"
 edition = "2021"
-authors = ["Rahul Anand <rahulanand16nov@gmail.com>"]
-description = "shim connecting envoy and authorino/limitador"
+authors = ["Alex Snaps <asnaps@redhat.com>", "Eguzki Astiz Lezaun <eguzki@redhat.com>", "Rahul Anand <rahulanand16nov@gmail.com>"]
+description = "Wasm module connecting envoy and authorino/limitador"
 license = "Apache-2.0"
+keywords = ["rate-limiting", "rate", "limiter", "envoy", "rls"]
+categories = ["web-programming"]
+homepage = "https://kuadrant.io"
+repository = "https://github.com/Kuadrant/wasm-shim"
+documentation = "https://kuadrant.io"
+readme = "README.md"
 
 [lib]
 crate-type = ["cdylib"]
@@ -24,6 +30,7 @@ protobuf = { version = "2.27", features = ["with-serde"] }
 thiserror = "1.0"
 regex = "1"
 radix_trie = "0.2.1"
+const_format = "0.2.31"
 
 [dev-dependencies]
 proxy-wasm-test-framework = { git = "https://github.com/Kuadrant/wasm-test-framework.git", branch = "kuadrant" }

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,9 @@
 
 FROM alpine:3.16 as wasm-shim-build
 
+ARG GITHUB_SHA
+ENV GITHUB_SHA=${GITHUB_SHA:-unknown}
+
 ARG RUSTC_VERSION=1.69.0
 RUN apk update \
     && apk upgrade \

--- a/src/filter/root_context.rs
+++ b/src/filter/root_context.rs
@@ -1,9 +1,16 @@
 use crate::configuration::{FilterConfig, PluginConfiguration};
 use crate::filter::http_context::Filter;
+use const_format::formatcp;
 use log::{info, warn};
 use proxy_wasm::traits::{Context, HttpContext, RootContext};
 use proxy_wasm::types::ContextType;
 use std::rc::Rc;
+
+const WASM_SHIM_VERSION: &str = env!("CARGO_PKG_VERSION");
+const WASM_SHIM_PROFILE: &str = env!("WASM_SHIM_PROFILE");
+const WASM_SHIM_FEATURES: &str = env!("WASM_SHIM_FEATURES");
+const WASM_SHIM_GIT_HASH: &str = env!("WASM_SHIM_GIT_HASH");
+const WASM_SHIM_HEADER: &str = "Kuadrant wasm module";
 
 pub struct FilterRoot {
     pub context_id: u32,
@@ -12,7 +19,18 @@ pub struct FilterRoot {
 
 impl RootContext for FilterRoot {
     fn on_vm_start(&mut self, _vm_configuration_size: usize) -> bool {
-        info!("root-context #{}: VM started", self.context_id);
+        let full_version: &'static str = formatcp!(
+            "v{} ({}) {} {}",
+            WASM_SHIM_VERSION,
+            WASM_SHIM_GIT_HASH,
+            WASM_SHIM_FEATURES,
+            WASM_SHIM_PROFILE,
+        );
+
+        info!(
+            "{} {} root-context #{}: VM started",
+            WASM_SHIM_HEADER, full_version, self.context_id
+        );
         true
     }
 


### PR DESCRIPTION
## What 

Generates log line with traceable version of the wasm module

```
Kuadrant wasm module v0.5.0-dev (7ea94e90) ["+with-serde"] release root-context #1: VM started
```

Format being:

```
v{VERSION} ({GIT_HASH}) {FEATURES} {PROFILE}
```

### Rules for *\<VERSION\>*

`main` branch no longer has meaningless `v0.1.0`. It has `v<next-unreleased-version>-dev`. So if the current release is `v0.4.0`, Cargo.toml file would have something like this

```toml
version = "0.5.0-dev"
```
that`dev` suffix means it is still under development. 

The v0.5.0 release process would have an extra step to bump the version to `version = "v0.5.0"` and main would be bumped to `Version = "v0.6.0-dev"`

### Rules for *\<GIT_HASH\>*

The build process first tries

```
GIT_SHA = `git rev-parse HEAD`
```

if it succeeded, it tries to check for "dirty" files (not committed files used in the build)

```
GIT_DIRTY = `git diff --stat`
```
So `GIT_HASH` is either 
```
GIT_HASH = $(GIT_SHA)
```
or
```
GIT_HASH = $(GIT_SHA)-dirty
```

If it fails (because there is no `git` in the build process), it tries to read env var `GITHUB_SHA`, so 

```
GIT_HASH = $(GITHUB_SHA)
```
It fallsback to `NO_SHA` when even the `GITHUB_SHA` env var does not exist.

These rules are implemented in https://github.com/Kuadrant/limitador

## Verification steps

* Build module with git available and no dirty files:
```
rm target/wasm32-unknown-unknown/release/wasm_shim.wasm
make development 2>&1 | grep "Kuadrant wasm module"
```
The output should be something like

```
envoy-1      | [2024-06-05 16:20:33.435][1][info][wasm] [source/extensions/common/wasm/context.cc:1167] wasm log kuadrant_wasm vm.sentinel.kuadrant_wasm: Kuadrant wasm module v0.5.0-dev (7ea94e90) ["+with-serde"] release root-context #1: VM started
```

highlighting here the important bits: `Kuadrant wasm module v0.5.0-dev (7ea94e90) ["+with-serde"] release`

* Build module with git available and some dirty files:

```
make stop-development
rm target/wasm32-unknown-unknown/release/wasm_shim.wasm
echo "extra line" >> README.md 
make development 2>&1 | grep "Kuadrant wasm module"
```
The output should be something like

```
envoy-1      | [2024-06-05 16:26:26.370][68][info][wasm] [source/extensions/common/wasm/context.cc:1167] wasm log kuadrant_wasm vm.sentinel.kuadrant_wasm: Kuadrant wasm module v0.5.0-dev (7ea94e90-dirty) ["+with-serde"] release root-context #1: VM started
```

highlighting here the important bits: `Kuadrant wasm module v0.5.0-dev (7ea94e90-dirty) ["+with-serde"] release`

* Build module when git is **not** available and `GITHUB_SHA=v10.0.0`

:rotating_light: make sure your git repo does not have anything pending to be pushed. It is better to follow these steps on a just cloned repo.

```
make stop-development
rm target/wasm32-unknown-unknown/release/wasm_shim.wasm
rm -rf .git
GITHUB_SHA=v10.0.0 make development 2>&1 | grep "Kuadrant wasm module"
```
The output should be something like

```
envoy-1      | [2024-06-05 16:29:49.065][1][info][wasm] [source/extensions/common/wasm/context.cc:1167] wasm log kuadrant_wasm vm.sentinel.kuadrant_wasm: Kuadrant wasm module v0.5.0-dev (v10.0.0) ["+with-serde"] release root-context #1: VM started
```

highlighting here the important bits: `Kuadrant wasm module v0.5.0-dev (v10.0.0) ["+with-serde"] release`