### PR TITLE
logging enhancements

### DIFF
--- a/src/filter.rs
+++ b/src/filter.rs
@@ -31,7 +31,7 @@ extern "C" fn start() {
         proxy_wasm::hostcalls::log(LogLevel::Critical, &panic_info.to_string()).unwrap();
     }));
     proxy_wasm::set_root_context(|context_id| -> Box<dyn RootContext> {
-        info!("set_root_context #{}", context_id);
+        info!("#{} set_root_context", context_id);
         Box::new(FilterRoot {
             context_id,
             config: Rc::new(FilterConfig::new()),

--- a/src/filter/root_context.rs
+++ b/src/filter/root_context.rs
@@ -28,14 +28,14 @@ impl RootContext for FilterRoot {
         );
 
         info!(
-            "{} {} root-context #{}: VM started",
-            WASM_SHIM_HEADER, full_version, self.context_id
+            "#{} {} {}: VM started",
+            self.context_id, WASM_SHIM_HEADER, full_version
         );
         true
     }
 
     fn create_http_context(&self, context_id: u32) -> Option<Box<dyn HttpContext>> {
-        debug!("create_http_context #{}", context_id);
+        debug!("#{} create_http_context", context_id);
         Some(Box::new(Filter {
             context_id,
             config: Rc::clone(&self.config),
@@ -45,7 +45,7 @@ impl RootContext for FilterRoot {
     }
 
     fn on_configure(&mut self, _config_size: usize) -> bool {
-        info!("on_configure #{}", self.context_id);
+        info!("#{} on_configure", self.context_id);
         let configuration: Vec<u8> = match self.get_plugin_configuration() {
             Some(c) => c,
             None => return false,

--- a/src/filter/root_context.rs
+++ b/src/filter/root_context.rs
@@ -1,7 +1,7 @@
 use crate::configuration::{FilterConfig, PluginConfiguration};
 use crate::filter::http_context::Filter;
 use const_format::formatcp;
-use log::{info, warn};
+use log::{debug, info, warn};
 use proxy_wasm::traits::{Context, HttpContext, RootContext};
 use proxy_wasm::types::ContextType;
 use std::rc::Rc;
@@ -35,7 +35,7 @@ impl RootContext for FilterRoot {
     }
 
     fn create_http_context(&self, context_id: u32) -> Option<Box<dyn HttpContext>> {
-        info!("create_http_context #{}", context_id);
+        debug!("create_http_context #{}", context_id);
         Some(Box::new(Filter {
             context_id,
             config: Rc::clone(&self.config),

--- a/tests/rate_limited.rs
+++ b/tests/rate_limited.rs
@@ -35,12 +35,12 @@ fn it_loads() {
 
     module
         .call_proxy_on_context_create(root_context, 0)
-        .expect_log(Some(LogLevel::Info), Some("set_root_context #1"))
+        .expect_log(Some(LogLevel::Info), Some("#1 set_root_context"))
         .execute_and_expect(ReturnType::None)
         .unwrap();
     module
         .call_proxy_on_configure(root_context, 0)
-        .expect_log(Some(LogLevel::Info), Some("on_configure #1"))
+        .expect_log(Some(LogLevel::Info), Some("#1 on_configure"))
         .expect_get_buffer_bytes(Some(BufferType::PluginConfiguration))
         .returning(Some(cfg.as_bytes()))
         .expect_log(Some(LogLevel::Info), None)
@@ -50,13 +50,13 @@ fn it_loads() {
     let http_context = 2;
     module
         .call_proxy_on_context_create(http_context, root_context)
-        .expect_log(Some(LogLevel::Debug), Some("create_http_context #2"))
+        .expect_log(Some(LogLevel::Debug), Some("#2 create_http_context"))
         .execute_and_expect(ReturnType::None)
         .unwrap();
 
     module
         .call_proxy_on_request_headers(http_context, 0, false)
-        .expect_log(Some(LogLevel::Debug), Some("on_http_request_headers #2"))
+        .expect_log(Some(LogLevel::Debug), Some("#2 on_http_request_headers"))
         .expect_get_header_map_value(Some(MapType::HttpRequestHeaders), Some("traceparent"))
         .returning(None)
         .expect_get_header_map_value(Some(MapType::HttpRequestHeaders), Some("tracestate"))
@@ -67,14 +67,14 @@ fn it_loads() {
         .returning(Some("cars.toystore.com"))
         .expect_log(
             Some(LogLevel::Debug),
-            Some("Allowing request to pass because zero descriptors generated #2"),
+            Some("#2 allowing request to pass because zero descriptors generated"),
         )
         .execute_and_expect(ReturnType::Action(Action::Continue))
         .unwrap();
 
     module
         .call_proxy_on_response_headers(http_context, 0, false)
-        .expect_log(Some(LogLevel::Debug), Some("on_http_response_headers #2"))
+        .expect_log(Some(LogLevel::Debug), Some("#2 on_http_response_headers"))
         .execute_and_expect(ReturnType::Action(Action::Continue))
         .unwrap();
 }
@@ -139,12 +139,12 @@ fn it_limits() {
 
     module
         .call_proxy_on_context_create(root_context, 0)
-        .expect_log(Some(LogLevel::Info), Some("set_root_context #1"))
+        .expect_log(Some(LogLevel::Info), Some("#1 set_root_context"))
         .execute_and_expect(ReturnType::None)
         .unwrap();
     module
         .call_proxy_on_configure(root_context, 0)
-        .expect_log(Some(LogLevel::Info), Some("on_configure #1"))
+        .expect_log(Some(LogLevel::Info), Some("#1 on_configure"))
         .expect_get_buffer_bytes(Some(BufferType::PluginConfiguration))
         .returning(Some(cfg.as_bytes()))
         .expect_log(Some(LogLevel::Info), None)
@@ -154,13 +154,13 @@ fn it_limits() {
     let http_context = 2;
     module
         .call_proxy_on_context_create(http_context, root_context)
-        .expect_log(Some(LogLevel::Debug), Some("create_http_context #2"))
+        .expect_log(Some(LogLevel::Debug), Some("#2 create_http_context"))
         .execute_and_expect(ReturnType::None)
         .unwrap();
 
     module
         .call_proxy_on_request_headers(http_context, 0, false)
-        .expect_log(Some(LogLevel::Debug), Some("on_http_request_headers #2"))
+        .expect_log(Some(LogLevel::Debug), Some("#2 on_http_request_headers"))
         .expect_get_header_map_value(Some(MapType::HttpRequestHeaders), Some("traceparent"))
         .returning(None)
         .expect_get_header_map_value(Some(MapType::HttpRequestHeaders), Some("tracestate"))
@@ -177,7 +177,7 @@ fn it_limits() {
         .returning(Some("POST".as_bytes()))
         .expect_log(
             Some(LogLevel::Debug),
-            Some("ratelimitpolicy selected some-name #2"),
+            Some("#2 ratelimitpolicy selected some-name"),
         )
         .expect_grpc_call(
             Some("limitador-cluster"),
@@ -193,7 +193,7 @@ fn it_limits() {
         .returning(Some(42))
         .expect_log(
             Some(LogLevel::Debug),
-            Some("Initiated gRPC call (id# 42) to Limitador #2"),
+            Some("#2 initiated gRPC call (id# 42) to Limitador"),
         )
         .execute_and_expect(ReturnType::Action(Action::Pause))
         .unwrap();
@@ -203,7 +203,7 @@ fn it_limits() {
         .call_proxy_on_grpc_receive(http_context, 42, grpc_response.len() as i32)
         .expect_log(
             Some(LogLevel::Debug),
-            Some("on_grpc_call_response: received gRPC call response: token: 42, status: 0 #2"),
+            Some("#2 on_grpc_call_response: received gRPC call response: token: 42, status: 0"),
         )
         .expect_get_buffer_bytes(Some(BufferType::GrpcReceiveBuffer))
         .returning(Some(&grpc_response))
@@ -212,7 +212,7 @@ fn it_limits() {
 
     module
         .call_proxy_on_response_headers(http_context, 0, false)
-        .expect_log(Some(LogLevel::Debug), Some("on_http_response_headers #2"))
+        .expect_log(Some(LogLevel::Debug), Some("#2 on_http_response_headers"))
         .execute_and_expect(ReturnType::Action(Action::Continue))
         .unwrap();
 }
@@ -277,12 +277,12 @@ fn it_passes_additional_headers() {
 
     module
         .call_proxy_on_context_create(root_context, 0)
-        .expect_log(Some(LogLevel::Info), Some("set_root_context #1"))
+        .expect_log(Some(LogLevel::Info), Some("#1 set_root_context"))
         .execute_and_expect(ReturnType::None)
         .unwrap();
     module
         .call_proxy_on_configure(root_context, 0)
-        .expect_log(Some(LogLevel::Info), Some("on_configure #1"))
+        .expect_log(Some(LogLevel::Info), Some("#1 on_configure"))
         .expect_get_buffer_bytes(Some(BufferType::PluginConfiguration))
         .returning(Some(cfg.as_bytes()))
         .expect_log(Some(LogLevel::Info), None)
@@ -292,13 +292,13 @@ fn it_passes_additional_headers() {
     let http_context = 2;
     module
         .call_proxy_on_context_create(http_context, root_context)
-        .expect_log(Some(LogLevel::Debug), Some("create_http_context #2"))
+        .expect_log(Some(LogLevel::Debug), Some("#2 create_http_context"))
         .execute_and_expect(ReturnType::None)
         .unwrap();
 
     module
         .call_proxy_on_request_headers(http_context, 0, false)
-        .expect_log(Some(LogLevel::Debug), Some("on_http_request_headers #2"))
+        .expect_log(Some(LogLevel::Debug), Some("#2 on_http_request_headers"))
         .expect_get_header_map_value(Some(MapType::HttpRequestHeaders), Some("traceparent"))
         .returning(None)
         .expect_get_header_map_value(Some(MapType::HttpRequestHeaders), Some("tracestate"))
@@ -315,7 +315,7 @@ fn it_passes_additional_headers() {
         .returning(Some("POST".as_bytes()))
         .expect_log(
             Some(LogLevel::Debug),
-            Some("ratelimitpolicy selected some-name #2"),
+            Some("#2 ratelimitpolicy selected some-name"),
         )
         .expect_grpc_call(
             Some("limitador-cluster"),
@@ -331,7 +331,7 @@ fn it_passes_additional_headers() {
         .returning(Some(42))
         .expect_log(
             Some(LogLevel::Debug),
-            Some("Initiated gRPC call (id# 42) to Limitador #2"),
+            Some("#2 initiated gRPC call (id# 42) to Limitador"),
         )
         .execute_and_expect(ReturnType::Action(Action::Pause))
         .unwrap();
@@ -345,7 +345,7 @@ fn it_passes_additional_headers() {
         .call_proxy_on_grpc_receive(http_context, 42, grpc_response.len() as i32)
         .expect_log(
             Some(LogLevel::Debug),
-            Some("on_grpc_call_response: received gRPC call response: token: 42, status: 0 #2"),
+            Some("#2 on_grpc_call_response: received gRPC call response: token: 42, status: 0"),
         )
         .expect_get_buffer_bytes(Some(BufferType::GrpcReceiveBuffer))
         .returning(Some(&grpc_response))
@@ -354,7 +354,7 @@ fn it_passes_additional_headers() {
 
     module
         .call_proxy_on_response_headers(http_context, 0, false)
-        .expect_log(Some(LogLevel::Debug), Some("on_http_response_headers #2"))
+        .expect_log(Some(LogLevel::Debug), Some("#2 on_http_response_headers"))
         .expect_add_header_map_value(
             Some(MapType::HttpResponseHeaders),
             Some("test"),
@@ -409,12 +409,12 @@ fn it_rate_limits_with_empty_conditions() {
 
     module
         .call_proxy_on_context_create(root_context, 0)
-        .expect_log(Some(LogLevel::Info), Some("set_root_context #1"))
+        .expect_log(Some(LogLevel::Info), Some("#1 set_root_context"))
         .execute_and_expect(ReturnType::None)
         .unwrap();
     module
         .call_proxy_on_configure(root_context, 0)
-        .expect_log(Some(LogLevel::Info), Some("on_configure #1"))
+        .expect_log(Some(LogLevel::Info), Some("#1 on_configure"))
         .expect_get_buffer_bytes(Some(BufferType::PluginConfiguration))
         .returning(Some(cfg.as_bytes()))
         .expect_log(Some(LogLevel::Info), None)
@@ -424,13 +424,13 @@ fn it_rate_limits_with_empty_conditions() {
     let http_context = 2;
     module
         .call_proxy_on_context_create(http_context, root_context)
-        .expect_log(Some(LogLevel::Debug), Some("create_http_context #2"))
+        .expect_log(Some(LogLevel::Debug), Some("#2 create_http_context"))
         .execute_and_expect(ReturnType::None)
         .unwrap();
 
     module
         .call_proxy_on_request_headers(http_context, 0, false)
-        .expect_log(Some(LogLevel::Debug), Some("on_http_request_headers #2"))
+        .expect_log(Some(LogLevel::Debug), Some("#2 on_http_request_headers"))
         .expect_get_header_map_value(Some(MapType::HttpRequestHeaders), Some("traceparent"))
         .returning(None)
         .expect_get_header_map_value(Some(MapType::HttpRequestHeaders), Some("tracestate"))
@@ -441,7 +441,7 @@ fn it_rate_limits_with_empty_conditions() {
         .returning(Some("a.com"))
         .expect_log(
             Some(LogLevel::Debug),
-            Some("ratelimitpolicy selected some-name #2"),
+            Some("#2 ratelimitpolicy selected some-name"),
         )
         .expect_grpc_call(
             Some("limitador-cluster"),
@@ -457,7 +457,7 @@ fn it_rate_limits_with_empty_conditions() {
         .returning(Some(42))
         .expect_log(
             Some(LogLevel::Debug),
-            Some("Initiated gRPC call (id# 42) to Limitador #2"),
+            Some("#2 initiated gRPC call (id# 42) to Limitador"),
         )
         .execute_and_expect(ReturnType::Action(Action::Pause))
         .unwrap();
@@ -467,7 +467,7 @@ fn it_rate_limits_with_empty_conditions() {
         .call_proxy_on_grpc_receive(http_context, 42, grpc_response.len() as i32)
         .expect_log(
             Some(LogLevel::Debug),
-            Some("on_grpc_call_response: received gRPC call response: token: 42, status: 0 #2"),
+            Some("#2 on_grpc_call_response: received gRPC call response: token: 42, status: 0"),
         )
         .expect_get_buffer_bytes(Some(BufferType::GrpcReceiveBuffer))
         .returning(Some(&grpc_response))
@@ -476,7 +476,7 @@ fn it_rate_limits_with_empty_conditions() {
 
     module
         .call_proxy_on_response_headers(http_context, 0, false)
-        .expect_log(Some(LogLevel::Debug), Some("on_http_response_headers #2"))
+        .expect_log(Some(LogLevel::Debug), Some("#2 on_http_response_headers"))
         .execute_and_expect(ReturnType::Action(Action::Continue))
         .unwrap();
 }
@@ -520,12 +520,12 @@ fn it_does_not_rate_limits_when_selector_does_not_exist_and_misses_default_value
 
     module
         .call_proxy_on_context_create(root_context, 0)
-        .expect_log(Some(LogLevel::Info), Some("set_root_context #1"))
+        .expect_log(Some(LogLevel::Info), Some("#1 set_root_context"))
         .execute_and_expect(ReturnType::None)
         .unwrap();
     module
         .call_proxy_on_configure(root_context, 0)
-        .expect_log(Some(LogLevel::Info), Some("on_configure #1"))
+        .expect_log(Some(LogLevel::Info), Some("#1 on_configure"))
         .expect_get_buffer_bytes(Some(BufferType::PluginConfiguration))
         .returning(Some(cfg.as_bytes()))
         .expect_log(Some(LogLevel::Info), None)
@@ -535,13 +535,13 @@ fn it_does_not_rate_limits_when_selector_does_not_exist_and_misses_default_value
     let http_context = 2;
     module
         .call_proxy_on_context_create(http_context, root_context)
-        .expect_log(Some(LogLevel::Debug), Some("create_http_context #2"))
+        .expect_log(Some(LogLevel::Debug), Some("#2 create_http_context"))
         .execute_and_expect(ReturnType::None)
         .unwrap();
 
     module
         .call_proxy_on_request_headers(http_context, 0, false)
-        .expect_log(Some(LogLevel::Debug), Some("on_http_request_headers #2"))
+        .expect_log(Some(LogLevel::Debug), Some("#2 on_http_request_headers"))
         .expect_get_header_map_value(Some(MapType::HttpRequestHeaders), Some("traceparent"))
         .returning(None)
         .expect_get_header_map_value(Some(MapType::HttpRequestHeaders), Some("tracestate"))
@@ -554,22 +554,22 @@ fn it_does_not_rate_limits_when_selector_does_not_exist_and_misses_default_value
         .returning(None)
         .expect_log(
             Some(LogLevel::Debug),
-            Some("ratelimitpolicy selected some-name #2"),
+            Some("#2 ratelimitpolicy selected some-name"),
         )
         .expect_log(
             Some(LogLevel::Debug),
-            Some("build_single_descriptor: selector not found: unknown.path #2"),
+            Some("#2 build_single_descriptor: selector not found: unknown.path"),
         )
         .expect_log(
             Some(LogLevel::Debug),
-            Some("process_rate_limit_policy: empty descriptors #2"),
+            Some("#2 process_rate_limit_policy: empty descriptors"),
         )
         .execute_and_expect(ReturnType::Action(Action::Continue))
         .unwrap();
 
     module
         .call_proxy_on_response_headers(http_context, 0, false)
-        .expect_log(Some(LogLevel::Debug), Some("on_http_response_headers #2"))
+        .expect_log(Some(LogLevel::Debug), Some("#2 on_http_response_headers"))
         .execute_and_expect(ReturnType::Action(Action::Continue))
         .unwrap();
 }

--- a/tests/rate_limited.rs
+++ b/tests/rate_limited.rs
@@ -50,13 +50,13 @@ fn it_loads() {
     let http_context = 2;
     module
         .call_proxy_on_context_create(http_context, root_context)
-        .expect_log(Some(LogLevel::Info), Some("create_http_context #2"))
+        .expect_log(Some(LogLevel::Debug), Some("create_http_context #2"))
         .execute_and_expect(ReturnType::None)
         .unwrap();
 
     module
         .call_proxy_on_request_headers(http_context, 0, false)
-        .expect_log(Some(LogLevel::Info), Some("on_http_request_headers #2"))
+        .expect_log(Some(LogLevel::Debug), Some("on_http_request_headers #2"))
         .expect_get_header_map_value(Some(MapType::HttpRequestHeaders), Some("traceparent"))
         .returning(None)
         .expect_get_header_map_value(Some(MapType::HttpRequestHeaders), Some("tracestate"))
@@ -66,8 +66,8 @@ fn it_loads() {
         .expect_get_header_map_value(Some(MapType::HttpRequestHeaders), Some(":authority"))
         .returning(Some("cars.toystore.com"))
         .expect_log(
-            Some(LogLevel::Info),
-            Some("context #2: Allowing request to pass because zero descriptors generated"),
+            Some(LogLevel::Debug),
+            Some("Allowing request to pass because zero descriptors generated #2"),
         )
         .execute_and_expect(ReturnType::Action(Action::Continue))
         .unwrap();
@@ -154,13 +154,13 @@ fn it_limits() {
     let http_context = 2;
     module
         .call_proxy_on_context_create(http_context, root_context)
-        .expect_log(Some(LogLevel::Info), Some("create_http_context #2"))
+        .expect_log(Some(LogLevel::Debug), Some("create_http_context #2"))
         .execute_and_expect(ReturnType::None)
         .unwrap();
 
     module
         .call_proxy_on_request_headers(http_context, 0, false)
-        .expect_log(Some(LogLevel::Info), Some("on_http_request_headers #2"))
+        .expect_log(Some(LogLevel::Debug), Some("on_http_request_headers #2"))
         .expect_get_header_map_value(Some(MapType::HttpRequestHeaders), Some("traceparent"))
         .returning(None)
         .expect_get_header_map_value(Some(MapType::HttpRequestHeaders), Some("tracestate"))
@@ -175,6 +175,10 @@ fn it_limits() {
         .returning(Some("cars.toystore.com".as_bytes()))
         .expect_get_property(Some(vec!["request", "method"]))
         .returning(Some("POST".as_bytes()))
+        .expect_log(
+            Some(LogLevel::Debug),
+            Some("ratelimitpolicy selected some-name #2"),
+        )
         .expect_grpc_call(
             Some("limitador-cluster"),
             Some("envoy.service.ratelimit.v3.RateLimitService"),
@@ -188,8 +192,8 @@ fn it_limits() {
         )
         .returning(Some(42))
         .expect_log(
-            Some(LogLevel::Info),
-            Some("Initiated gRPC call (id# 42) to Limitador"),
+            Some(LogLevel::Debug),
+            Some("Initiated gRPC call (id# 42) to Limitador #2"),
         )
         .execute_and_expect(ReturnType::Action(Action::Pause))
         .unwrap();
@@ -198,8 +202,8 @@ fn it_limits() {
     module
         .call_proxy_on_grpc_receive(http_context, 42, grpc_response.len() as i32)
         .expect_log(
-            Some(LogLevel::Info),
-            Some("on_grpc_call_response #2: received gRPC call response: token: 42, status: 0"),
+            Some(LogLevel::Debug),
+            Some("on_grpc_call_response: received gRPC call response: token: 42, status: 0 #2"),
         )
         .expect_get_buffer_bytes(Some(BufferType::GrpcReceiveBuffer))
         .returning(Some(&grpc_response))
@@ -288,13 +292,13 @@ fn it_passes_additional_headers() {
     let http_context = 2;
     module
         .call_proxy_on_context_create(http_context, root_context)
-        .expect_log(Some(LogLevel::Info), Some("create_http_context #2"))
+        .expect_log(Some(LogLevel::Debug), Some("create_http_context #2"))
         .execute_and_expect(ReturnType::None)
         .unwrap();
 
     module
         .call_proxy_on_request_headers(http_context, 0, false)
-        .expect_log(Some(LogLevel::Info), Some("on_http_request_headers #2"))
+        .expect_log(Some(LogLevel::Debug), Some("on_http_request_headers #2"))
         .expect_get_header_map_value(Some(MapType::HttpRequestHeaders), Some("traceparent"))
         .returning(None)
         .expect_get_header_map_value(Some(MapType::HttpRequestHeaders), Some("tracestate"))
@@ -309,6 +313,10 @@ fn it_passes_additional_headers() {
         .returning(Some("cars.toystore.com".as_bytes()))
         .expect_get_property(Some(vec!["request", "method"]))
         .returning(Some("POST".as_bytes()))
+        .expect_log(
+            Some(LogLevel::Debug),
+            Some("ratelimitpolicy selected some-name #2"),
+        )
         .expect_grpc_call(
             Some("limitador-cluster"),
             Some("envoy.service.ratelimit.v3.RateLimitService"),
@@ -322,8 +330,8 @@ fn it_passes_additional_headers() {
         )
         .returning(Some(42))
         .expect_log(
-            Some(LogLevel::Info),
-            Some("Initiated gRPC call (id# 42) to Limitador"),
+            Some(LogLevel::Debug),
+            Some("Initiated gRPC call (id# 42) to Limitador #2"),
         )
         .execute_and_expect(ReturnType::Action(Action::Pause))
         .unwrap();
@@ -336,8 +344,8 @@ fn it_passes_additional_headers() {
     module
         .call_proxy_on_grpc_receive(http_context, 42, grpc_response.len() as i32)
         .expect_log(
-            Some(LogLevel::Info),
-            Some("on_grpc_call_response #2: received gRPC call response: token: 42, status: 0"),
+            Some(LogLevel::Debug),
+            Some("on_grpc_call_response: received gRPC call response: token: 42, status: 0 #2"),
         )
         .expect_get_buffer_bytes(Some(BufferType::GrpcReceiveBuffer))
         .returning(Some(&grpc_response))
@@ -416,13 +424,13 @@ fn it_rate_limits_with_empty_conditions() {
     let http_context = 2;
     module
         .call_proxy_on_context_create(http_context, root_context)
-        .expect_log(Some(LogLevel::Info), Some("create_http_context #2"))
+        .expect_log(Some(LogLevel::Debug), Some("create_http_context #2"))
         .execute_and_expect(ReturnType::None)
         .unwrap();
 
     module
         .call_proxy_on_request_headers(http_context, 0, false)
-        .expect_log(Some(LogLevel::Info), Some("on_http_request_headers #2"))
+        .expect_log(Some(LogLevel::Debug), Some("on_http_request_headers #2"))
         .expect_get_header_map_value(Some(MapType::HttpRequestHeaders), Some("traceparent"))
         .returning(None)
         .expect_get_header_map_value(Some(MapType::HttpRequestHeaders), Some("tracestate"))
@@ -431,6 +439,10 @@ fn it_rate_limits_with_empty_conditions() {
         .returning(None)
         .expect_get_header_map_value(Some(MapType::HttpRequestHeaders), Some(":authority"))
         .returning(Some("a.com"))
+        .expect_log(
+            Some(LogLevel::Debug),
+            Some("ratelimitpolicy selected some-name #2"),
+        )
         .expect_grpc_call(
             Some("limitador-cluster"),
             Some("envoy.service.ratelimit.v3.RateLimitService"),
@@ -444,8 +456,8 @@ fn it_rate_limits_with_empty_conditions() {
         )
         .returning(Some(42))
         .expect_log(
-            Some(LogLevel::Info),
-            Some("Initiated gRPC call (id# 42) to Limitador"),
+            Some(LogLevel::Debug),
+            Some("Initiated gRPC call (id# 42) to Limitador #2"),
         )
         .execute_and_expect(ReturnType::Action(Action::Pause))
         .unwrap();
@@ -454,8 +466,8 @@ fn it_rate_limits_with_empty_conditions() {
     module
         .call_proxy_on_grpc_receive(http_context, 42, grpc_response.len() as i32)
         .expect_log(
-            Some(LogLevel::Info),
-            Some("on_grpc_call_response #2: received gRPC call response: token: 42, status: 0"),
+            Some(LogLevel::Debug),
+            Some("on_grpc_call_response: received gRPC call response: token: 42, status: 0 #2"),
         )
         .expect_get_buffer_bytes(Some(BufferType::GrpcReceiveBuffer))
         .returning(Some(&grpc_response))
@@ -523,13 +535,13 @@ fn it_does_not_rate_limits_when_selector_does_not_exist_and_misses_default_value
     let http_context = 2;
     module
         .call_proxy_on_context_create(http_context, root_context)
-        .expect_log(Some(LogLevel::Info), Some("create_http_context #2"))
+        .expect_log(Some(LogLevel::Debug), Some("create_http_context #2"))
         .execute_and_expect(ReturnType::None)
         .unwrap();
 
     module
         .call_proxy_on_request_headers(http_context, 0, false)
-        .expect_log(Some(LogLevel::Info), Some("on_http_request_headers #2"))
+        .expect_log(Some(LogLevel::Debug), Some("on_http_request_headers #2"))
         .expect_get_header_map_value(Some(MapType::HttpRequestHeaders), Some("traceparent"))
         .returning(None)
         .expect_get_header_map_value(Some(MapType::HttpRequestHeaders), Some("tracestate"))
@@ -542,11 +554,15 @@ fn it_does_not_rate_limits_when_selector_does_not_exist_and_misses_default_value
         .returning(None)
         .expect_log(
             Some(LogLevel::Debug),
-            Some("[context_id: 2]: selector not found: unknown.path"),
+            Some("ratelimitpolicy selected some-name #2"),
         )
         .expect_log(
             Some(LogLevel::Debug),
-            Some("[context_id: 2] empty descriptors"),
+            Some("build_single_descriptor: selector not found: unknown.path #2"),
+        )
+        .expect_log(
+            Some(LogLevel::Debug),
+            Some("process_rate_limit_policy: empty descriptors #2"),
         )
         .execute_and_expect(ReturnType::Action(Action::Continue))
         .unwrap();


### PR DESCRIPTION
### What

- http context logging at `debug` level. 
- http context id consistent for all loggers with the format `#{}` at the end of the log line.
- Fix clippy complaining about rate limit policy name not being used. Added the name to a log line (at debug level).