### PR TITLE
Refactoring for external auth. Vol I

### DIFF
--- a/src/configuration.rs
+++ b/src/configuration.rs
@@ -485,7 +485,7 @@ pub struct Rule {
 
 #[derive(Deserialize, Debug, Clone)]
 #[serde(rename_all = "camelCase")]
-pub struct RateLimitPolicy {
+pub struct Policy {
     pub name: String,
     pub domain: String,
     pub service: String,
@@ -493,7 +493,7 @@ pub struct RateLimitPolicy {
     pub rules: Vec<Rule>,
 }
 
-impl RateLimitPolicy {
+impl Policy {
     #[cfg(test)]
     pub fn new(
         name: String,
@@ -502,7 +502,7 @@ impl RateLimitPolicy {
         hostnames: Vec<String>,
         rules: Vec<Rule>,
     ) -> Self {
-        RateLimitPolicy {
+        Policy {
             name,
             domain,
             service,
@@ -533,7 +533,7 @@ impl TryFrom<PluginConfiguration> for FilterConfig {
     fn try_from(config: PluginConfiguration) -> Result<Self, Self::Error> {
         let mut index = PolicyIndex::new();
 
-        for rlp in config.rate_limit_policies.iter() {
+        for rlp in config.policies.iter() {
             for rule in &rlp.rules {
                 for datum in &rule.data {
                     let result = datum.item.compile();
@@ -572,7 +572,8 @@ pub enum FailureMode {
 #[derive(Deserialize, Debug, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct PluginConfiguration {
-    pub rate_limit_policies: Vec<RateLimitPolicy>,
+    #[serde(rename = "rateLimitPolicies")]
+    pub policies: Vec<Policy>,
     // Deny/Allow request when faced with an irrecoverable failure.
     pub failure_mode: FailureMode,
 }
@@ -635,9 +636,9 @@ mod test {
         assert!(res.is_ok());
 
         let filter_config = res.unwrap();
-        assert_eq!(filter_config.rate_limit_policies.len(), 1);
+        assert_eq!(filter_config.policies.len(), 1);
 
-        let rules = &filter_config.rate_limit_policies[0].rules;
+        let rules = &filter_config.policies[0].rules;
         assert_eq!(rules.len(), 1);
 
         let conditions = &rules[0].conditions;
@@ -689,7 +690,7 @@ mod test {
         assert!(res.is_ok());
 
         let filter_config = res.unwrap();
-        assert_eq!(filter_config.rate_limit_policies.len(), 0);
+        assert_eq!(filter_config.policies.len(), 0);
     }
 
     #[test]
@@ -722,9 +723,9 @@ mod test {
         assert!(res.is_ok());
 
         let filter_config = res.unwrap();
-        assert_eq!(filter_config.rate_limit_policies.len(), 1);
+        assert_eq!(filter_config.policies.len(), 1);
 
-        let rules = &filter_config.rate_limit_policies[0].rules;
+        let rules = &filter_config.policies[0].rules;
         assert_eq!(rules.len(), 1);
 
         let data_items = &rules[0].data;
@@ -794,9 +795,9 @@ mod test {
         assert!(res.is_ok());
 
         let filter_config = res.unwrap();
-        assert_eq!(filter_config.rate_limit_policies.len(), 1);
+        assert_eq!(filter_config.policies.len(), 1);
 
-        let rules = &filter_config.rate_limit_policies[0].rules;
+        let rules = &filter_config.policies[0].rules;
         assert_eq!(rules.len(), 1);
 
         let conditions = &rules[0].conditions;
@@ -855,9 +856,9 @@ mod test {
         assert!(res.is_ok());
 
         let filter_config = res.unwrap();
-        assert_eq!(filter_config.rate_limit_policies.len(), 1);
+        assert_eq!(filter_config.policies.len(), 1);
 
-        let rules = &filter_config.rate_limit_policies[0].rules;
+        let rules = &filter_config.policies[0].rules;
         assert_eq!(rules.len(), 1);
 
         let conditions = &rules[0].conditions;

--- a/src/configuration.rs
+++ b/src/configuration.rs
@@ -1,3 +1,4 @@
+use crate::policy::Policy;
 use crate::policy_index::PolicyIndex;
 use cel_interpreter::objects::ValueType;
 use cel_interpreter::{Context, Expression, Value};
@@ -465,50 +466,6 @@ pub fn type_of(path: &str) -> Option<ValueType> {
         "request.raw_body" => Some(ValueType::Bytes),
         "auth.identity" => Some(ValueType::Bytes),
         _ => None,
-    }
-}
-
-#[derive(Deserialize, Debug, Clone)]
-#[serde(rename_all = "camelCase")]
-pub struct Condition {
-    pub all_of: Vec<PatternExpression>,
-}
-
-#[derive(Deserialize, Debug, Clone)]
-pub struct Rule {
-    //
-    #[serde(default)]
-    pub conditions: Vec<Condition>,
-    //
-    pub data: Vec<DataItem>,
-}
-
-#[derive(Deserialize, Debug, Clone)]
-#[serde(rename_all = "camelCase")]
-pub struct Policy {
-    pub name: String,
-    pub domain: String,
-    pub service: String,
-    pub hostnames: Vec<String>,
-    pub rules: Vec<Rule>,
-}
-
-impl Policy {
-    #[cfg(test)]
-    pub fn new(
-        name: String,
-        domain: String,
-        service: String,
-        hostnames: Vec<String>,
-        rules: Vec<Rule>,
-    ) -> Self {
-        Policy {
-            name,
-            domain,
-            service,
-            hostnames,
-            rules,
-        }
     }
 }
 

--- a/src/filter.rs
+++ b/src/filter.rs
@@ -1,4 +1,4 @@
-mod http_context;
+pub(crate) mod http_context;
 mod root_context;
 
 #[cfg_attr(

--- a/src/filter/http_context.rs
+++ b/src/filter/http_context.rs
@@ -1,11 +1,7 @@
-use crate::configuration::{
-    Condition, DataItem, DataType, FailureMode, FilterConfig, PatternExpression, Policy, Rule,
-};
-use crate::envoy::{
-    RateLimitDescriptor, RateLimitDescriptor_Entry, RateLimitRequest, RateLimitResponse,
-    RateLimitResponse_Code,
-};
+use crate::configuration::{FailureMode, FilterConfig};
+use crate::envoy::{RateLimitRequest, RateLimitResponse, RateLimitResponse_Code};
 use crate::filter::http_context::TracingHeader::{Baggage, Traceparent, Tracestate};
+use crate::policy::Policy;
 use log::{debug, warn};
 use protobuf::Message;
 use proxy_wasm::traits::{Context, HttpContext};
@@ -59,7 +55,7 @@ impl Filter {
     }
 
     fn process_rate_limit_policy(&self, rlp: &Policy) -> Action {
-        let descriptors = self.build_descriptors(rlp);
+        let descriptors = rlp.build_descriptors(self);
         if descriptors.is_empty() {
             debug!(
                 "#{} process_rate_limit_policy: empty descriptors",
@@ -104,114 +100,6 @@ impl Filter {
                 Action::Continue
             }
         }
-    }
-
-    fn build_descriptors(&self, rlp: &Policy) -> protobuf::RepeatedField<RateLimitDescriptor> {
-        rlp.rules
-            .iter()
-            .filter(|rule: &&Rule| self.filter_rule_by_conditions(&rule.conditions))
-            // Mapping 1 Rule -> 1 Descriptor
-            // Filter out empty descriptors
-            .filter_map(|rule| self.build_single_descriptor(&rule.data))
-            .collect()
-    }
-
-    fn filter_rule_by_conditions(&self, conditions: &[Condition]) -> bool {
-        if conditions.is_empty() {
-            // no conditions is equivalent to matching all the requests.
-            return true;
-        }
-
-        conditions
-            .iter()
-            .any(|condition| self.condition_applies(condition))
-    }
-
-    fn condition_applies(&self, condition: &Condition) -> bool {
-        condition
-            .all_of
-            .iter()
-            .all(|pattern_expression| self.pattern_expression_applies(pattern_expression))
-    }
-
-    fn pattern_expression_applies(&self, p_e: &PatternExpression) -> bool {
-        let attribute_path = p_e.path();
-        let attribute_value = match self.get_property(attribute_path) {
-            None => {
-                debug!(
-                    "#{} pattern_expression_applies:  selector not found: {}, defaulting to ``",
-                    self.context_id, p_e.selector
-                );
-                b"".to_vec()
-            }
-            Some(attribute_bytes) => attribute_bytes,
-        };
-        match p_e.eval(attribute_value) {
-            Err(e) => {
-                debug!(
-                    "#{} pattern_expression_applies failed: {}",
-                    self.context_id, e
-                );
-                false
-            }
-            Ok(result) => result,
-        }
-    }
-
-    fn build_single_descriptor(&self, data_list: &[DataItem]) -> Option<RateLimitDescriptor> {
-        let mut entries = ::protobuf::RepeatedField::default();
-
-        // iterate over data items to allow any data item to skip the entire descriptor
-        for data in data_list.iter() {
-            match &data.item {
-                DataType::Static(static_item) => {
-                    let mut descriptor_entry = RateLimitDescriptor_Entry::new();
-                    descriptor_entry.set_key(static_item.key.to_owned());
-                    descriptor_entry.set_value(static_item.value.to_owned());
-                    entries.push(descriptor_entry);
-                }
-                DataType::Selector(selector_item) => {
-                    let descriptor_key = match &selector_item.key {
-                        None => selector_item.path().to_string(),
-                        Some(key) => key.to_owned(),
-                    };
-
-                    let attribute_path = selector_item.path();
-                    let value = match self.get_property(attribute_path.tokens()) {
-                        None => {
-                            debug!(
-                                "#{} build_single_descriptor: selector not found: {}",
-                                self.context_id, attribute_path
-                            );
-                            match &selector_item.default {
-                                None => return None, // skipping the entire descriptor
-                                Some(default_value) => default_value.clone(),
-                            }
-                        }
-                        // TODO(eastizle): not all fields are strings
-                        // https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/advanced/attributes
-                        Some(attribute_bytes) => match String::from_utf8(attribute_bytes) {
-                            Err(e) => {
-                                debug!(
-                                    "#{} build_single_descriptor: failed to parse selector value: {}, error: {}",
-                                    self.context_id, attribute_path, e
-                                );
-                                return None;
-                            }
-                            Ok(attribute_value) => attribute_value,
-                        },
-                    };
-                    let mut descriptor_entry = RateLimitDescriptor_Entry::new();
-                    descriptor_entry.set_key(descriptor_key);
-                    descriptor_entry.set_value(value);
-                    entries.push(descriptor_entry);
-                }
-            }
-        }
-
-        let mut res = RateLimitDescriptor::new();
-        res.set_entries(entries);
-        Some(res)
     }
 
     fn handle_error_on_grpc_response(&self) {

--- a/src/filter/http_context.rs
+++ b/src/filter/http_context.rs
@@ -1,6 +1,5 @@
 use crate::configuration::{
-    Condition, DataItem, DataType, FailureMode, FilterConfig, PatternExpression, RateLimitPolicy,
-    Rule,
+    Condition, DataItem, DataType, FailureMode, FilterConfig, PatternExpression, Policy, Rule,
 };
 use crate::envoy::{
     RateLimitDescriptor, RateLimitDescriptor_Entry, RateLimitRequest, RateLimitResponse,
@@ -59,7 +58,7 @@ impl Filter {
         }
     }
 
-    fn process_rate_limit_policy(&self, rlp: &RateLimitPolicy) -> Action {
+    fn process_rate_limit_policy(&self, rlp: &Policy) -> Action {
         let descriptors = self.build_descriptors(rlp);
         if descriptors.is_empty() {
             debug!(
@@ -107,10 +106,7 @@ impl Filter {
         }
     }
 
-    fn build_descriptors(
-        &self,
-        rlp: &RateLimitPolicy,
-    ) -> protobuf::RepeatedField<RateLimitDescriptor> {
+    fn build_descriptors(&self, rlp: &Policy) -> protobuf::RepeatedField<RateLimitDescriptor> {
         rlp.rules
             .iter()
             .filter(|rule: &&Rule| self.filter_rule_by_conditions(&rule.conditions))

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,7 @@ mod configuration;
 mod envoy;
 mod filter;
 mod glob;
+mod policy;
 mod policy_index;
 
 #[cfg(test)]

--- a/src/policy.rs
+++ b/src/policy.rs
@@ -1,0 +1,165 @@
+use crate::configuration::{DataItem, DataType, PatternExpression};
+use crate::envoy::{RateLimitDescriptor, RateLimitDescriptor_Entry};
+use crate::filter::http_context::Filter;
+use log::debug;
+use proxy_wasm::traits::Context;
+use serde::Deserialize;
+
+#[derive(Deserialize, Debug, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct Condition {
+    pub all_of: Vec<PatternExpression>,
+}
+
+#[derive(Deserialize, Debug, Clone)]
+pub struct Rule {
+    //
+    #[serde(default)]
+    pub conditions: Vec<Condition>,
+    //
+    pub data: Vec<DataItem>,
+}
+
+#[derive(Deserialize, Debug, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct Policy {
+    pub name: String,
+    pub domain: String,
+    pub service: String,
+    pub hostnames: Vec<String>,
+    pub rules: Vec<Rule>,
+}
+
+impl Policy {
+    #[cfg(test)]
+    pub fn new(
+        name: String,
+        domain: String,
+        service: String,
+        hostnames: Vec<String>,
+        rules: Vec<Rule>,
+    ) -> Self {
+        Policy {
+            name,
+            domain,
+            service,
+            hostnames,
+            rules,
+        }
+    }
+
+    pub fn build_descriptors(
+        &self,
+        filter: &Filter,
+    ) -> protobuf::RepeatedField<RateLimitDescriptor> {
+        self.rules
+            .iter()
+            .filter(|rule: &&Rule| self.filter_rule_by_conditions(filter, &rule.conditions))
+            // Mapping 1 Rule -> 1 Descriptor
+            // Filter out empty descriptors
+            .filter_map(|rule| self.build_single_descriptor(filter, &rule.data))
+            .collect()
+    }
+
+    fn filter_rule_by_conditions(&self, filter: &Filter, conditions: &[Condition]) -> bool {
+        if conditions.is_empty() {
+            // no conditions is equivalent to matching all the requests.
+            return true;
+        }
+
+        conditions
+            .iter()
+            .any(|condition| self.condition_applies(filter, condition))
+    }
+
+    fn condition_applies(&self, filter: &Filter, condition: &Condition) -> bool {
+        condition
+            .all_of
+            .iter()
+            .all(|pattern_expression| self.pattern_expression_applies(filter, pattern_expression))
+    }
+
+    fn pattern_expression_applies(&self, filter: &Filter, p_e: &PatternExpression) -> bool {
+        let attribute_path = p_e.path();
+        let attribute_value = match filter.get_property(attribute_path) {
+            None => {
+                debug!(
+                    "#{} pattern_expression_applies:  selector not found: {}, defaulting to ``",
+                    filter.context_id, p_e.selector
+                );
+                b"".to_vec()
+            }
+            Some(attribute_bytes) => attribute_bytes,
+        };
+        match p_e.eval(attribute_value) {
+            Err(e) => {
+                debug!(
+                    "#{} pattern_expression_applies failed: {}",
+                    filter.context_id, e
+                );
+                false
+            }
+            Ok(result) => result,
+        }
+    }
+
+    fn build_single_descriptor(
+        &self,
+        filter: &Filter,
+        data_list: &[DataItem],
+    ) -> Option<RateLimitDescriptor> {
+        let mut entries = ::protobuf::RepeatedField::default();
+
+        // iterate over data items to allow any data item to skip the entire descriptor
+        for data in data_list.iter() {
+            match &data.item {
+                DataType::Static(static_item) => {
+                    let mut descriptor_entry = RateLimitDescriptor_Entry::new();
+                    descriptor_entry.set_key(static_item.key.to_owned());
+                    descriptor_entry.set_value(static_item.value.to_owned());
+                    entries.push(descriptor_entry);
+                }
+                DataType::Selector(selector_item) => {
+                    let descriptor_key = match &selector_item.key {
+                        None => selector_item.path().to_string(),
+                        Some(key) => key.to_owned(),
+                    };
+
+                    let attribute_path = selector_item.path();
+                    let value = match filter.get_property(attribute_path.tokens()) {
+                        None => {
+                            debug!(
+                                "#{} build_single_descriptor: selector not found: {}",
+                                filter.context_id, attribute_path
+                            );
+                            match &selector_item.default {
+                                None => return None, // skipping the entire descriptor
+                                Some(default_value) => default_value.clone(),
+                            }
+                        }
+                        // TODO(eastizle): not all fields are strings
+                        // https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/advanced/attributes
+                        Some(attribute_bytes) => match String::from_utf8(attribute_bytes) {
+                            Err(e) => {
+                                debug!(
+                                    "#{} build_single_descriptor: failed to parse selector value: {}, error: {}",
+                                    filter.context_id, attribute_path, e
+                                );
+                                return None;
+                            }
+                            Ok(attribute_value) => attribute_value,
+                        },
+                    };
+                    let mut descriptor_entry = RateLimitDescriptor_Entry::new();
+                    descriptor_entry.set_key(descriptor_key);
+                    descriptor_entry.set_value(value);
+                    entries.push(descriptor_entry);
+                }
+            }
+        }
+
+        let mut res = RateLimitDescriptor::new();
+        res.set_entries(entries);
+        Some(res)
+    }
+}

--- a/src/policy_index.rs
+++ b/src/policy_index.rs
@@ -1,9 +1,9 @@
 use radix_trie::Trie;
 
-use crate::configuration::RateLimitPolicy;
+use crate::configuration::Policy;
 
 pub struct PolicyIndex {
-    raw_tree: Trie<String, RateLimitPolicy>,
+    raw_tree: Trie<String, Policy>,
 }
 
 impl PolicyIndex {
@@ -13,12 +13,12 @@ impl PolicyIndex {
         }
     }
 
-    pub fn insert(&mut self, subdomain: &str, policy: RateLimitPolicy) {
+    pub fn insert(&mut self, subdomain: &str, policy: Policy) {
         let rev = Self::reverse_subdomain(subdomain);
         self.raw_tree.insert(rev, policy);
     }
 
-    pub fn get_longest_match_policy(&self, subdomain: &str) -> Option<&RateLimitPolicy> {
+    pub fn get_longest_match_policy(&self, subdomain: &str) -> Option<&Policy> {
         let rev = Self::reverse_subdomain(subdomain);
         self.raw_tree.get_ancestor_value(&rev)
     }
@@ -37,11 +37,11 @@ impl PolicyIndex {
 
 #[cfg(test)]
 mod tests {
-    use crate::configuration::RateLimitPolicy;
+    use crate::configuration::Policy;
     use crate::policy_index::PolicyIndex;
 
-    fn build_ratelimit_policy(name: &str) -> RateLimitPolicy {
-        RateLimitPolicy::new(
+    fn build_ratelimit_policy(name: &str) -> Policy {
+        Policy::new(
             name.to_owned(),
             "".to_owned(),
             "".to_owned(),

--- a/src/policy_index.rs
+++ b/src/policy_index.rs
@@ -1,6 +1,6 @@
 use radix_trie::Trie;
 
-use crate::configuration::Policy;
+use crate::policy::Policy;
 
 pub struct PolicyIndex {
     raw_tree: Trie<String, Policy>,
@@ -37,7 +37,7 @@ impl PolicyIndex {
 
 #[cfg(test)]
 mod tests {
-    use crate::configuration::Policy;
+    use crate::policy::Policy;
     use crate::policy_index::PolicyIndex;
 
     fn build_ratelimit_policy(name: &str) -> Policy {


### PR DESCRIPTION
This PR is the first of hopefully not too many that aims to re-arrange and open the code in order to implement External Auth.

Notes:
* Renames `RateLimitPolicy` struct to `Policy`
* Keeps config with `rateLimitPolicies` field, but renames it to  `policies` field within the struct `PluginConfiguration` when deserializing.
* Delegates the building of descriptors to the `Policy` instead of `Filter`
* Missing configuration change, TODO alongside a PR to Kuadrant Operator. Its still functional since it's serde::renaming the field