### PR TITLE
Move attribute parsing to attribute trait

### DIFF
--- a/src/attribute.rs
+++ b/src/attribute.rs
@@ -104,6 +104,7 @@ impl Attribute for DateTime<FixedOffset> {
     }
 }
 
+#[allow(dead_code)]
 pub fn get_attribute<T>(f: &Filter, attr: &str) -> Result<T, String>
 where
     T: Attribute,

--- a/src/attribute.rs
+++ b/src/attribute.rs
@@ -24,7 +24,7 @@ impl Attribute for i64 {
     fn parse(raw_attribute: Vec<u8>) -> Result<Self, String> {
         if raw_attribute.len() != 8 {
             return Err(format!(
-                "Int value expected to be 8 bytes, but got {}",
+                "parse: Int value expected to be 8 bytes, but got {}",
                 raw_attribute.len()
             ));
         }
@@ -40,7 +40,7 @@ impl Attribute for u64 {
     fn parse(raw_attribute: Vec<u8>) -> Result<Self, String> {
         if raw_attribute.len() != 8 {
             return Err(format!(
-                "UInt value expected to be 8 bytes, but got {}",
+                "parse: UInt value expected to be 8 bytes, but got {}",
                 raw_attribute.len()
             ));
         }
@@ -56,7 +56,7 @@ impl Attribute for f64 {
     fn parse(raw_attribute: Vec<u8>) -> Result<Self, String> {
         if raw_attribute.len() != 8 {
             return Err(format!(
-                "Float value expected to be 8 bytes, but got {}",
+                "parse: Float value expected to be 8 bytes, but got {}",
                 raw_attribute.len()
             ));
         }
@@ -78,7 +78,7 @@ impl Attribute for bool {
     fn parse(raw_attribute: Vec<u8>) -> Result<Self, String> {
         if raw_attribute.len() != 1 {
             return Err(format!(
-                "Bool value expected to be 1 byte, but got {}",
+                "parse: Bool value expected to be 1 byte, but got {}",
                 raw_attribute.len()
             ));
         }

--- a/src/attribute.rs
+++ b/src/attribute.rs
@@ -1,0 +1,118 @@
+use crate::configuration::Path;
+use crate::filter::http_context::Filter;
+use chrono::{DateTime, FixedOffset};
+use proxy_wasm::traits::Context;
+
+pub trait Attribute {
+    fn parse(raw_attribute: Vec<u8>) -> Result<Self, String>
+    where
+        Self: Sized;
+}
+
+impl Attribute for String {
+    fn parse(raw_attribute: Vec<u8>) -> Result<Self, String> {
+        String::from_utf8(raw_attribute).map_err(|err| {
+            format!(
+                "parse: failed to parse selector String value, error: {}",
+                err
+            )
+        })
+    }
+}
+
+impl Attribute for i64 {
+    fn parse(raw_attribute: Vec<u8>) -> Result<Self, String> {
+        if raw_attribute.len() != 8 {
+            return Err(format!(
+                "Int value expected to be 8 bytes, but got {}",
+                raw_attribute.len()
+            ));
+        }
+        Ok(i64::from_le_bytes(
+            raw_attribute[..8]
+                .try_into()
+                .expect("This has to be 8 bytes long!"),
+        ))
+    }
+}
+
+impl Attribute for u64 {
+    fn parse(raw_attribute: Vec<u8>) -> Result<Self, String> {
+        if raw_attribute.len() != 8 {
+            return Err(format!(
+                "UInt value expected to be 8 bytes, but got {}",
+                raw_attribute.len()
+            ));
+        }
+        Ok(u64::from_le_bytes(
+            raw_attribute[..8]
+                .try_into()
+                .expect("This has to be 8 bytes long!"),
+        ))
+    }
+}
+
+impl Attribute for f64 {
+    fn parse(raw_attribute: Vec<u8>) -> Result<Self, String> {
+        if raw_attribute.len() != 8 {
+            return Err(format!(
+                "Float value expected to be 8 bytes, but got {}",
+                raw_attribute.len()
+            ));
+        }
+        Ok(f64::from_le_bytes(
+            raw_attribute[..8]
+                .try_into()
+                .expect("This has to be 8 bytes long!"),
+        ))
+    }
+}
+
+impl Attribute for Vec<u8> {
+    fn parse(raw_attribute: Vec<u8>) -> Result<Self, String> {
+        Ok(raw_attribute)
+    }
+}
+
+impl Attribute for bool {
+    fn parse(raw_attribute: Vec<u8>) -> Result<Self, String> {
+        if raw_attribute.len() != 1 {
+            return Err(format!(
+                "Bool value expected to be 1 byte, but got {}",
+                raw_attribute.len()
+            ));
+        }
+        Ok(raw_attribute[0] & 1 == 1)
+    }
+}
+
+impl Attribute for DateTime<FixedOffset> {
+    fn parse(raw_attribute: Vec<u8>) -> Result<Self, String> {
+        if raw_attribute.len() != 8 {
+            return Err(format!(
+                "parse: Timestamp expected to be 8 bytes, but got {}",
+                raw_attribute.len()
+            ));
+        }
+
+        let nanos = i64::from_le_bytes(
+            raw_attribute.as_slice()[..8]
+                .try_into()
+                .expect("This has to be 8 bytes long!"),
+        );
+        Ok(DateTime::from_timestamp_nanos(nanos).into())
+    }
+}
+
+pub fn get_attribute<T>(f: &Filter, attr: &str) -> Result<T, String>
+where
+    T: Attribute,
+{
+    match f.get_property(Path::from(attr).tokens()) {
+        None => Err(format!(
+            "#{} get_attribute: not found: {}",
+            f.context_id, attr
+        )),
+        Some(attribute_bytes) => T::parse(attribute_bytes),
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,4 @@
+mod attribute;
 mod configuration;
 mod envoy;
 mod filter;

--- a/src/policy.rs
+++ b/src/policy.rs
@@ -1,4 +1,4 @@
-use crate::attribute::get_attribute;
+use crate::attribute::Attribute;
 use crate::configuration::{DataItem, DataType, PatternExpression};
 use crate::envoy::{RateLimitDescriptor, RateLimitDescriptor_Entry};
 use crate::filter::http_context::Filter;
@@ -126,7 +126,25 @@ impl Policy {
                         Some(key) => key.to_owned(),
                     };
 
-                    let value = get_attribute(filter, selector_item.selector.as_str()).ok()?;
+                    let attribute_path = selector_item.path();
+                    let value = match filter.get_property(attribute_path.tokens()) {
+                        None => {
+                            debug!(
+                                "#{} build_single_descriptor: selector not found: {}",
+                                filter.context_id, attribute_path
+                            );
+                            match &selector_item.default {
+                                None => return None, // skipping the entire descriptor
+                                Some(default_value) => default_value.clone(),
+                            }
+                        }
+                        // TODO(eastizle): not all fields are strings
+                        // https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/advanced/attributes
+                        Some(attribute_bytes) => Attribute::parse(attribute_bytes)
+                            .inspect_err(|e| debug!("#{} build_single_descriptor: failed to parse selector value: {}, error: {}",
+                                    filter.context_id, attribute_path, e))
+                            .ok()?,
+                    };
                     let mut descriptor_entry = RateLimitDescriptor_Entry::new();
                     descriptor_entry.set_key(descriptor_key);
                     descriptor_entry.set_value(value);


### PR DESCRIPTION
(builds on top of #64 refactoring-1-bis)

For the auth implementation I wanted to be able to retrieve/parse the different attributes from `filter.get_property` without need to evaluate a `PatternExpression` so I decided to move this to it's own trait with an implementation for each type (where the implementation comes from the original one within the pattern expression).

This then introduces a generic `get_attribute` function which can be used like this

```
get_attribute(filter, "request.host")
```

To return a `Result<String,String>` in this case with the property.

Looking for all feedback as I'm unsure if this is the correct approach to do this.