### PR TITLE
Setup services from configuration

### DIFF
--- a/src/filter/http_context.rs
+++ b/src/filter/http_context.rs
@@ -1,4 +1,4 @@
-use crate::configuration::{ExtensionType, FailureMode, FilterConfig};
+use crate::configuration::{FailureMode, FilterConfig};
 use crate::envoy::{RateLimitResponse, RateLimitResponse_Code};
 use crate::policy::Policy;
 use crate::service::rate_limit::RateLimitService;
@@ -41,8 +41,7 @@ impl Filter {
         }
 
         let rls = GrpcServiceHandler::new(
-            ExtensionType::RateLimit,
-            rlp.service.clone(),
+            Rc::clone(&self.config.service),
             Rc::clone(&self.header_resolver),
         );
         let message = RateLimitService::message(rlp.domain.clone(), descriptors);

--- a/src/policy.rs
+++ b/src/policy.rs
@@ -26,24 +26,16 @@ pub struct Rule {
 pub struct Policy {
     pub name: String,
     pub domain: String,
-    pub service: String,
     pub hostnames: Vec<String>,
     pub rules: Vec<Rule>,
 }
 
 impl Policy {
     #[cfg(test)]
-    pub fn new(
-        name: String,
-        domain: String,
-        service: String,
-        hostnames: Vec<String>,
-        rules: Vec<Rule>,
-    ) -> Self {
+    pub fn new(name: String, domain: String, hostnames: Vec<String>, rules: Vec<Rule>) -> Self {
         Policy {
             name,
             domain,
-            service,
             hostnames,
             rules,
         }

--- a/src/policy_index.rs
+++ b/src/policy_index.rs
@@ -41,13 +41,7 @@ mod tests {
     use crate::policy_index::PolicyIndex;
 
     fn build_ratelimit_policy(name: &str) -> Policy {
-        Policy::new(
-            name.to_owned(),
-            "".to_owned(),
-            "".to_owned(),
-            Vec::new(),
-            Vec::new(),
-        )
+        Policy::new(name.to_owned(), "".to_owned(), Vec::new(), Vec::new())
     }
 
     #[test]

--- a/tests/rate_limited.rs
+++ b/tests/rate_limited.rs
@@ -29,8 +29,8 @@ fn it_loads() {
 
     let root_context = 1;
     let cfg = r#"{
-        "failureMode": "deny",
-        "rateLimitPolicies": []
+        "extensions": {},
+        "policies": []
     }"#;
 
     module
@@ -90,12 +90,17 @@ fn it_limits() {
 
     let root_context = 1;
     let cfg = r#"{
-        "failureMode": "deny",
-        "rateLimitPolicies": [
+        "extensions": {
+            "limitador": {
+                "type": "ratelimit",
+                "endpoint": "limitador-cluster",
+                "failureMode": "deny"
+            }
+        },
+        "policies": [
         {
             "name": "some-name",
             "domain": "RLS-domain",
-            "service": "limitador-cluster",
             "hostnames": ["*.toystore.com", "example.com"],
             "rules": [
             {
@@ -228,12 +233,17 @@ fn it_passes_additional_headers() {
 
     let root_context = 1;
     let cfg = r#"{
-        "failureMode": "deny",
-        "rateLimitPolicies": [
+        "extensions": {
+            "limitador": {
+                "type": "ratelimit",
+                "endpoint": "limitador-cluster",
+                "failureMode": "deny"
+            }
+        },
+        "policies": [
         {
             "name": "some-name",
             "domain": "RLS-domain",
-            "service": "limitador-cluster",
             "hostnames": ["*.toystore.com", "example.com"],
             "rules": [
             {
@@ -380,12 +390,17 @@ fn it_rate_limits_with_empty_conditions() {
 
     let root_context = 1;
     let cfg = r#"{
-        "failureMode": "deny",
-        "rateLimitPolicies": [
+        "extensions": {
+            "limitador": {
+                "type": "ratelimit",
+                "endpoint": "limitador-cluster",
+                "failureMode": "deny"
+            }
+        },
+        "policies": [
         {
             "name": "some-name",
             "domain": "RLS-domain",
-            "service": "limitador-cluster",
             "hostnames": ["*.com"],
             "rules": [
             {
@@ -492,12 +507,17 @@ fn it_does_not_rate_limits_when_selector_does_not_exist_and_misses_default_value
 
     let root_context = 1;
     let cfg = r#"{
-        "failureMode": "deny",
-        "rateLimitPolicies": [
+        "extensions": {
+            "limitador": {
+                "type": "ratelimit",
+                "endpoint": "limitador-cluster",
+                "failureMode": "deny"
+            }
+        },
+        "policies": [
         {
             "name": "some-name",
             "domain": "RLS-domain",
-            "service": "limitador-cluster",
             "hostnames": ["*.com"],
             "rules": [
             {


### PR DESCRIPTION
## Changes

Builds on top of the `GrpcServiceHandler` added previously to configure these at the plugin configuration stage:

Most of the fields in the `GrpcServiceHandler` had a lifetime that was for the duration of the wasm filter (the stuff read from configuration), but the lifetime of the header resolver is only for each http request. I've moved these fields out to a new `GrpcService`.

### `GrpcService`
* The `method` and `name` currently come from a static variable, so I'm using `&'static str` for these instead of `String` as I didn't want to create copies of these just to convert them back to references in `send`
* The `GrpcService` currently also contains the `failure_mode` now instead of storing this config-wide

### Update Configuration
* A new `extensions` field has been added to the `PluginConfiguration` that is defined as follows:
```json
"extensions": {
    "limitador": {
        "type": "ratelimit",
        "endpoint": "limitador-cluster",
        "failureMode": "deny"
    }
},
```
* I have updated the configuration to build the set of `GrpcServices` from the extensions deserialised in the initial step of the `TryFrom` - for now I'm storing them as an `Rc<HashMap<String,Rc<GrpcService>>>` - the `String` being the key of the extension that can be used to reference which service from the actions.
   * Perhaps we can iterate on this storage structure - I chose to use an `Rc` for the `HashMap` so that it can be re-used across all http requests as these are configured from the plugin config. However I also chose to have the `GrpcServices` as an `Rc` so that the ref can be cloned to each of the `GrpcServiceHandler`
* Currently this is used by taking the first `GrpcService` and using that as the service. Once we have an idea of how the actions will be defined we could retrieve the correct service for the action