### PR TITLE
docker image with git sha only for pushes on main branch

### DIFF
--- a/.github/workflows/build-image.yaml
+++ b/.github/workflows/build-image.yaml
@@ -5,9 +5,10 @@ on:
   push:
     branches: ['*']
     tags: ['*']
+  workflow_dispatch: {}
 
 env:
-  IMG_TAGS: ${{ github.sha }} ${{ github.ref_name }}
+  IMG_TAGS: ${{ github.ref_name }}
   IMG_REGISTRY_HOST: quay.io
   IMG_REGISTRY_ORG: kuadrant
   MAIN_BRANCH_NAME: main
@@ -19,11 +20,16 @@ jobs:
     steps:
       - name: Check out code
         uses: actions/checkout@v4
-      - name: Add latest tag
+      - name: Add latest tag for the main branch
         if: ${{ github.ref_name == env.MAIN_BRANCH_NAME }}
         id: add-latest-tag
         run: |
           echo "IMG_TAGS=latest ${{ env.IMG_TAGS }}" >> $GITHUB_ENV
+      - name: Add git sha tag for the main branch
+        if: ${{ github.ref_name == env.MAIN_BRANCH_NAME }}
+        id: add-git-sha-tag
+        run: |
+          echo "IMG_TAGS=${{ github.sha }} ${{ env.IMG_TAGS }}" >> $GITHUB_ENV
       - name: Build Image
         id: build-image
         uses: redhat-actions/buildah-build@v2


### PR DESCRIPTION
### What

Temporary fix as docker images with git sha tags from branches other than main is causing issues on the nightly build of kuadrant. TL;RD: kuadrant nightly release pipeline is picking the latest (based on `last_modified` attribute) image with git sha *like* tags. When wasm-shim docker images with git sha tag are being created for branches, those were sometimes being picked for nightly tests instead of the `HEAD` of `main`. 