### PR TITLE
policy.rs: refactor unstable .inspect_err feature for rust <=1.75

### DIFF
--- a/src/policy.rs
+++ b/src/policy.rs
@@ -140,10 +140,19 @@ impl Policy {
                         }
                         // TODO(eastizle): not all fields are strings
                         // https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/advanced/attributes
-                        Some(attribute_bytes) => Attribute::parse(attribute_bytes)
-                            .inspect_err(|e| debug!("#{} build_single_descriptor: failed to parse selector value: {}, error: {}",
-                                    filter.context_id, attribute_path, e))
-                            .ok()?,
+                        Some(attribute_bytes) => match Attribute::parse(attribute_bytes) {
+                            Ok(attr_str) => attr_str,
+                            Err(e) => {
+                                debug!("#{} build_single_descriptor: failed to parse selector value: {}, error: {}",
+                                    filter.context_id, attribute_path, e);
+                                return None;
+                            }
+                        },
+                        // Alternative implementation (for rust >= 1.76)
+                        // Attribute::parse(attribute_bytes)
+                        //   .inspect_err(|e| debug!("#{} build_single_descriptor: failed to parse selector value: {}, error: {}",
+                        //           filter.context_id, attribute_path, e))
+                        //   .ok()?,
                     };
                     let mut descriptor_entry = RateLimitDescriptor_Entry::new();
                     descriptor_entry.set_key(descriptor_key);


### PR DESCRIPTION
`Result`'s `inspect_err` method is unstable for rust <= 1.75, leading to 

```
82.22 error[E0658]: use of unstable library feature 'result_option_inspect'
82.22    --> src/policy.rs:144:30
82.22     |
82.22 144 | ...                   .inspect_err(|e| debug!("#{} build_single_descriptor: failed to parse selector value: {}, error: {}",
82.22     |                        ^^^^^^^^^^^
82.22     |
82.22     = note: see issue #91345 <https://github.com/rust-lang/rust/issues/91345> for more information
```

This is a workaround to enable build rust on 1.75