### PR TITLE
Process auth CheckResponse

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,6 +167,12 @@ There is then a single auth policy defined for e2e testing:
 
 ```sh
 curl -H "Host: test.a.auth.com" http://127.0.0.1:8000/get -i
+# HTTP/1.1 401 Unauthorized
+```
+
+```sh
+curl -H "Host: test.a.auth.com" -H "Authorization: APIKEY ndyBzreUzF4zqDQsqSPMHkRhriEOtcRx" http://127.0.0.1:8000/get -i
+# HTTP/1.1 200 OK
 ```
 
 And three rate limit policies defined for e2e testing:

--- a/src/envoy/mod.rs
+++ b/src/envoy/mod.rs
@@ -37,7 +37,7 @@ pub use {
         AttributeContext_Request,
     },
     base::Metadata,
-    external_auth::{CheckRequest, DeniedHttpResponse, OkHttpResponse},
+    external_auth::{CheckRequest, CheckResponse, CheckResponse_oneof_http_response},
     ratelimit::{RateLimitDescriptor, RateLimitDescriptor_Entry},
     rls::{RateLimitRequest, RateLimitResponse, RateLimitResponse_Code},
 };

--- a/src/filter/http_context.rs
+++ b/src/filter/http_context.rs
@@ -116,7 +116,10 @@ impl Filter {
         if let GrpcMessageResponse::Auth(check_response) = auth_resp {
             match check_response.http_response {
                 Some(CheckResponse_oneof_http_response::ok_response(ok_response)) => {
-                    debug!("Handling OkHttpResponse...");
+                    debug!(
+                        "#{} process_auth_grpc_response: received OkHttpResponse",
+                        self.context_id
+                    );
 
                     ok_response
                         .get_response_headers_to_add()
@@ -129,7 +132,10 @@ impl Filter {
                         });
                 }
                 Some(CheckResponse_oneof_http_response::denied_response(denied_response)) => {
-                    debug!("Handling DeniedHttpResponse...");
+                    debug!(
+                        "#{} process_auth_grpc_response: received DeniedHttpResponse",
+                        self.context_id
+                    );
 
                     let mut response_headers = vec![];
                     denied_response.get_headers().iter().for_each(|header| {

--- a/src/service/auth.rs
+++ b/src/service/auth.rs
@@ -22,27 +22,9 @@ impl AuthService {
         AuthService::build_check_req(ce_host)
     }
 
-    pub fn response_message(
-        res_body_bytes: &Bytes,
-        status_code: u32,
-    ) -> GrpcMessageResult<GrpcMessageResponse> {
-        if status_code % 2 == 0 {
-            AuthService::response_message_ok(res_body_bytes)
-        } else {
-            AuthService::response_message_denied(res_body_bytes)
-        }
-    }
-
-    fn response_message_ok(res_body_bytes: &Bytes) -> GrpcMessageResult<GrpcMessageResponse> {
+    pub fn response_message(res_body_bytes: &Bytes) -> GrpcMessageResult<GrpcMessageResponse> {
         match Message::parse_from_bytes(res_body_bytes) {
-            Ok(res) => Ok(GrpcMessageResponse::AuthOk(res)),
-            Err(e) => Err(e),
-        }
-    }
-
-    fn response_message_denied(res_body_bytes: &Bytes) -> GrpcMessageResult<GrpcMessageResponse> {
-        match Message::parse_from_bytes(res_body_bytes) {
-            Ok(res) => Ok(GrpcMessageResponse::AuthDenied(res)),
+            Ok(res) => Ok(GrpcMessageResponse::Auth(res)),
             Err(e) => Err(e),
         }
     }

--- a/src/service/grpc_message.rs
+++ b/src/service/grpc_message.rs
@@ -1,7 +1,6 @@
 use crate::configuration::ExtensionType;
 use crate::envoy::{
-    CheckRequest, DeniedHttpResponse, OkHttpResponse, RateLimitDescriptor, RateLimitRequest,
-    RateLimitResponse,
+    CheckRequest, CheckResponse, RateLimitDescriptor, RateLimitRequest, RateLimitResponse,
 };
 use crate::service::auth::AuthService;
 use crate::service::rate_limit::RateLimitService;
@@ -143,8 +142,7 @@ impl GrpcMessageRequest {
 
 #[derive(Clone, Debug)]
 pub enum GrpcMessageResponse {
-    AuthOk(OkHttpResponse),
-    AuthDenied(DeniedHttpResponse),
+    Auth(CheckResponse),
     RateLimit(RateLimitResponse),
 }
 
@@ -163,80 +161,70 @@ impl Clear for GrpcMessageResponse {
 impl Message for GrpcMessageResponse {
     fn descriptor(&self) -> &'static MessageDescriptor {
         match self {
-            GrpcMessageResponse::AuthOk(res) => res.descriptor(),
-            GrpcMessageResponse::AuthDenied(res) => res.descriptor(),
+            GrpcMessageResponse::Auth(res) => res.descriptor(),
             GrpcMessageResponse::RateLimit(res) => res.descriptor(),
         }
     }
 
     fn is_initialized(&self) -> bool {
         match self {
-            GrpcMessageResponse::AuthOk(res) => res.is_initialized(),
-            GrpcMessageResponse::AuthDenied(res) => res.is_initialized(),
+            GrpcMessageResponse::Auth(res) => res.is_initialized(),
             GrpcMessageResponse::RateLimit(res) => res.is_initialized(),
         }
     }
 
     fn merge_from(&mut self, is: &mut CodedInputStream) -> ProtobufResult<()> {
         match self {
-            GrpcMessageResponse::AuthOk(res) => res.merge_from(is),
-            GrpcMessageResponse::AuthDenied(res) => res.merge_from(is),
+            GrpcMessageResponse::Auth(res) => res.merge_from(is),
             GrpcMessageResponse::RateLimit(res) => res.merge_from(is),
         }
     }
 
     fn write_to_with_cached_sizes(&self, os: &mut CodedOutputStream) -> ProtobufResult<()> {
         match self {
-            GrpcMessageResponse::AuthOk(res) => res.write_to_with_cached_sizes(os),
-            GrpcMessageResponse::AuthDenied(res) => res.write_to_with_cached_sizes(os),
+            GrpcMessageResponse::Auth(res) => res.write_to_with_cached_sizes(os),
             GrpcMessageResponse::RateLimit(res) => res.write_to_with_cached_sizes(os),
         }
     }
 
     fn write_to_bytes(&self) -> ProtobufResult<Vec<u8>> {
         match self {
-            GrpcMessageResponse::AuthOk(res) => res.write_to_bytes(),
-            GrpcMessageResponse::AuthDenied(res) => res.write_to_bytes(),
+            GrpcMessageResponse::Auth(res) => res.write_to_bytes(),
             GrpcMessageResponse::RateLimit(res) => res.write_to_bytes(),
         }
     }
 
     fn compute_size(&self) -> u32 {
         match self {
-            GrpcMessageResponse::AuthOk(res) => res.compute_size(),
-            GrpcMessageResponse::AuthDenied(res) => res.compute_size(),
+            GrpcMessageResponse::Auth(res) => res.compute_size(),
             GrpcMessageResponse::RateLimit(res) => res.compute_size(),
         }
     }
 
     fn get_cached_size(&self) -> u32 {
         match self {
-            GrpcMessageResponse::AuthOk(res) => res.get_cached_size(),
-            GrpcMessageResponse::AuthDenied(res) => res.get_cached_size(),
+            GrpcMessageResponse::Auth(res) => res.get_cached_size(),
             GrpcMessageResponse::RateLimit(res) => res.get_cached_size(),
         }
     }
 
     fn get_unknown_fields(&self) -> &UnknownFields {
         match self {
-            GrpcMessageResponse::AuthOk(res) => res.get_unknown_fields(),
-            GrpcMessageResponse::AuthDenied(res) => res.get_unknown_fields(),
+            GrpcMessageResponse::Auth(res) => res.get_unknown_fields(),
             GrpcMessageResponse::RateLimit(res) => res.get_unknown_fields(),
         }
     }
 
     fn mut_unknown_fields(&mut self) -> &mut UnknownFields {
         match self {
-            GrpcMessageResponse::AuthOk(res) => res.mut_unknown_fields(),
-            GrpcMessageResponse::AuthDenied(res) => res.mut_unknown_fields(),
+            GrpcMessageResponse::Auth(res) => res.mut_unknown_fields(),
             GrpcMessageResponse::RateLimit(res) => res.mut_unknown_fields(),
         }
     }
 
     fn as_any(&self) -> &dyn Any {
         match self {
-            GrpcMessageResponse::AuthOk(res) => res.as_any(),
-            GrpcMessageResponse::AuthDenied(res) => res.as_any(),
+            GrpcMessageResponse::Auth(res) => res.as_any(),
             GrpcMessageResponse::RateLimit(res) => res.as_any(),
         }
     }
@@ -263,11 +251,10 @@ impl GrpcMessageResponse {
     pub fn new(
         extension_type: &ExtensionType,
         res_body_bytes: &Bytes,
-        status_code: u32,
     ) -> GrpcMessageResult<GrpcMessageResponse> {
         match extension_type {
             ExtensionType::RateLimit => RateLimitService::response_message(res_body_bytes),
-            ExtensionType::Auth => AuthService::response_message(res_body_bytes, status_code),
+            ExtensionType::Auth => AuthService::response_message(res_body_bytes),
         }
     }
 }

--- a/tests/rate_limited.rs
+++ b/tests/rate_limited.rs
@@ -215,7 +215,7 @@ fn it_limits() {
         .returning(Some(42))
         .expect_log(
             Some(LogLevel::Debug),
-            Some("#2 initiated gRPC call (id# 42) to Limitador"),
+            Some("#2 initiated gRPC call (id# 42)"),
         )
         .execute_and_expect(ReturnType::Action(Action::Pause))
         .unwrap();
@@ -381,7 +381,7 @@ fn it_passes_additional_headers() {
         .returning(Some(42))
         .expect_log(
             Some(LogLevel::Debug),
-            Some("#2 initiated gRPC call (id# 42) to Limitador"),
+            Some("#2 initiated gRPC call (id# 42)"),
         )
         .execute_and_expect(ReturnType::Action(Action::Pause))
         .unwrap();
@@ -523,7 +523,7 @@ fn it_rate_limits_with_empty_conditions() {
         .returning(Some(42))
         .expect_log(
             Some(LogLevel::Debug),
-            Some("#2 initiated gRPC call (id# 42) to Limitador"),
+            Some("#2 initiated gRPC call (id# 42)"),
         )
         .execute_and_expect(ReturnType::Action(Action::Pause))
         .unwrap();

--- a/utils/deploy/envoy-notls.yaml
+++ b/utils/deploy/envoy-notls.yaml
@@ -150,7 +150,7 @@ data:
                                   "policies": [
                                     {
                                       "name": "auth-ns-A/auth-name-A",
-                                      "domain": "auth-ns-A/auth-name-A",
+                                      "domain": "effective-route-1",
                                       "hostnames": [
                                         "*.a.auth.com"
                                       ],

--- a/utils/deploy/envoy-tls.yaml
+++ b/utils/deploy/envoy-tls.yaml
@@ -159,7 +159,7 @@ data:
                                   "policies": [
                                     {
                                       "name": "auth-ns-A/auth-name-A",
-                                      "domain": "auth-ns-A/auth-name-A",
+                                      "domain": "effective-route-1",
                                       "hostnames": [
                                         "*.a.auth.com"
                                       ],


### PR DESCRIPTION
## Changes

Process the `CheckResponse` from the auth service.

## Verification

* Build and deploy locally

```sh
make build && make local-setup
```

* Port-forward and watch logs in different terminals:

```sh
kubectl port-forward --namespace default deployment/envoy 8000:8000
kubectl logs -f deployment/envoy
kubectl logs -f deployment/authorino
```

* Make some requests based on the default authconfig:

```sh
curl -H "Host: test.a.auth.com" http://127.0.0.1:8000/get -i
# HTTP/1.1 401 Unauthorized
```

```sh
curl -H "Host: test.a.auth.com" -H "Authorization: APIKEY ndyBzreUzF4zqDQsqSPMHkRhriEOtcRx" http://127.0.0.1:8000/get -i
# HTTP/1.1 200 OK
```

See in envoy logs the `/Check` call and in Authorino the processing of the request.