### PR TITLE
Refactor pluginconfig

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,7 +171,7 @@ curl -H "Host: test.a.auth.com" http://127.0.0.1:8000/get -i
 ```
 
 ```sh
-curl -H "Host: test.a.auth.com" -H "Authorization: APIKEY ndyBzreUzF4zqDQsqSPMHkRhriEOtcRx" http://127.0.0.1:8000/get -i
+curl -H "Host: test.a.auth.com" -H "Authorization: APIKEY IAMALICE" http://127.0.0.1:8000/get -i
 # HTTP/1.1 200 OK
 ```
 
@@ -194,6 +194,23 @@ curl -H "Host: test.b.rlp.com" http://127.0.0.1:8000/get -i
 
 ```sh
 curl -H "Host: test.c.rlp.com" -H "x-forwarded-for: 127.0.0.1" -H "My-Custom-Header-01: my-custom-header-value-01" -H "x-dyn-user-id: bob" http://127.0.0.1:8000/get -i
+```
+
+* `multi-a` which defines two actions for authenticated ratelimiting.
+
+```sh
+curl -H "Host: test.a.multi.com" http://127.0.0.1:8000/get -i
+# HTTP/1.1 401 Unauthorized
+```
+
+Alice has 5 requests per 10 seconds:
+```sh
+while :; do curl --write-out '%{http_code}\n' --silent --output /dev/null -H "Authorization: APIKEY IAMALICE" -H "Host: test.a.multi.com" http://127.0.0.1:8000/get | grep -E --color "\b(429)\b|$"; sleep 1; done
+```
+
+Bob has 2 requests per 10 seconds:
+```sh
+while :; do curl --write-out '%{http_code}\n' --silent --output /dev/null -H "Authorization: APIKEY IAMBOB" -H "Host: test.a.multi.com" http://127.0.0.1:8000/get | grep -E --color "\b(429)\b|$"; sleep 1; done
 ```
 
 The expected descriptors:

--- a/src/attribute.rs
+++ b/src/attribute.rs
@@ -1,6 +1,10 @@
 use crate::configuration::Path;
 use chrono::{DateTime, FixedOffset};
+use log::{debug, error};
+use protobuf::well_known_types::Struct;
 use proxy_wasm::hostcalls;
+
+pub const KUADRANT_NAMESPACE: &str = "kuadrant";
 
 pub trait Attribute {
     fn parse(raw_attribute: Vec<u8>) -> Result<Self, String>
@@ -103,13 +107,135 @@ impl Attribute for DateTime<FixedOffset> {
     }
 }
 
-#[allow(dead_code)]
 pub fn get_attribute<T>(attr: &str) -> Result<T, String>
 where
     T: Attribute,
 {
     match hostcalls::get_property(Path::from(attr).tokens()) {
         Ok(Some(attribute_bytes)) => T::parse(attribute_bytes),
-        _ => Err(format!("get_attribute: not found: {}", attr)),
+        Ok(None) => Err(format!("get_attribute: not found or null: {attr}")),
+        Err(e) => Err(format!("get_attribute: error: {e:?}")),
+    }
+}
+
+pub fn set_attribute(attr: &str, value: &[u8]) {
+    match hostcalls::set_property(Path::from(attr).tokens(), Some(value)) {
+        Ok(_) => (),
+        Err(_) => error!("set_attribute: failed to set property {attr}"),
+    };
+}
+
+pub fn store_metadata(metastruct: &Struct) {
+    let metadata = process_metadata(metastruct, String::new());
+    for (key, value) in metadata {
+        let attr = format!("{KUADRANT_NAMESPACE}\\.{key}");
+        debug!("set_attribute: {attr} = {value}");
+        set_attribute(attr.as_str(), value.into_bytes().as_slice());
+    }
+}
+
+fn process_metadata(s: &Struct, prefix: String) -> Vec<(String, String)> {
+    let mut result = Vec::new();
+    for (key, value) in s.get_fields() {
+        let current_prefix = if prefix.is_empty() {
+            key.clone()
+        } else {
+            format!("{prefix}\\.{key}")
+        };
+
+        if value.has_string_value() {
+            result.push((current_prefix, value.get_string_value().to_string()));
+        } else if value.has_struct_value() {
+            let nested_struct = value.get_struct_value();
+            result.extend(process_metadata(nested_struct, current_prefix));
+        }
+    }
+    result
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::attribute::process_metadata;
+    use protobuf::well_known_types::{Struct, Value, Value_oneof_kind};
+    use std::collections::HashMap;
+
+    pub fn struct_from(values: Vec<(String, Value)>) -> Struct {
+        let mut hm = HashMap::new();
+        for (key, value) in values {
+            hm.insert(key, value);
+        }
+        Struct {
+            fields: hm,
+            unknown_fields: Default::default(),
+            cached_size: Default::default(),
+        }
+    }
+
+    pub fn string_value_from(value: String) -> Value {
+        Value {
+            kind: Some(Value_oneof_kind::string_value(value)),
+            unknown_fields: Default::default(),
+            cached_size: Default::default(),
+        }
+    }
+
+    pub fn struct_value_from(value: Struct) -> Value {
+        Value {
+            kind: Some(Value_oneof_kind::struct_value(value)),
+            unknown_fields: Default::default(),
+            cached_size: Default::default(),
+        }
+    }
+    #[test]
+    fn get_metadata_one() {
+        let metadata = struct_from(vec![(
+            "identity".to_string(),
+            struct_value_from(struct_from(vec![(
+                "userid".to_string(),
+                string_value_from("bob".to_string()),
+            )])),
+        )]);
+        let output = process_metadata(&metadata, String::new());
+        assert_eq!(output.len(), 1);
+        assert_eq!(
+            output,
+            vec![("identity\\.userid".to_string(), "bob".to_string())]
+        );
+    }
+
+    #[test]
+    fn get_metadata_two() {
+        let metadata = struct_from(vec![(
+            "identity".to_string(),
+            struct_value_from(struct_from(vec![
+                ("userid".to_string(), string_value_from("bob".to_string())),
+                ("type".to_string(), string_value_from("test".to_string())),
+            ])),
+        )]);
+        let output = process_metadata(&metadata, String::new());
+        assert_eq!(output.len(), 2);
+        assert!(output.contains(&("identity\\.userid".to_string(), "bob".to_string())));
+        assert!(output.contains(&("identity\\.type".to_string(), "test".to_string())));
+    }
+
+    #[test]
+    fn get_metadata_three() {
+        let metadata = struct_from(vec![
+            (
+                "identity".to_string(),
+                struct_value_from(struct_from(vec![(
+                    "userid".to_string(),
+                    string_value_from("bob".to_string()),
+                )])),
+            ),
+            (
+                "other_data".to_string(),
+                string_value_from("other_value".to_string()),
+            ),
+        ]);
+        let output = process_metadata(&metadata, String::new());
+        assert_eq!(output.len(), 2);
+        assert!(output.contains(&("identity\\.userid".to_string(), "bob".to_string())));
+        assert!(output.contains(&("other_data".to_string(), "other_value".to_string())));
     }
 }

--- a/src/configuration.rs
+++ b/src/configuration.rs
@@ -533,6 +533,7 @@ pub struct Extension {
 #[serde(rename_all = "camelCase")]
 pub struct Action {
     pub extension: String,
+    pub scope: String,
     #[allow(dead_code)]
     pub data: DataType,
 }
@@ -552,7 +553,6 @@ mod test {
         "policies": [
         {
             "name": "rlp-ns-A/rlp-name-A",
-            "domain": "rlp-ns-A/rlp-name-A",
             "hostnames": ["*.toystore.com", "example.com"],
             "rules": [
             {
@@ -591,6 +591,7 @@ mod test {
             "actions": [
                 {
                     "extension": "limitador",
+                    "scope": "rlp-ns-A/rlp-name-A",
                     "data": {
                         "static": {
                             "key": "rlp-ns-A/rlp-name-A",
@@ -681,7 +682,6 @@ mod test {
             "policies": [
             {
                 "name": "rlp-ns-A/rlp-name-A",
-                "domain": "rlp-ns-A/rlp-name-A",
                 "hostnames": ["*.toystore.com", "example.com"],
                 "rules": [
                 {
@@ -697,6 +697,7 @@ mod test {
                 "actions": [
                 {
                     "extension": "limitador",
+                    "scope": "rlp-ns-A/rlp-name-A",
                     "data": {
                         "static": {
                             "key": "rlp-ns-A/rlp-name-A",
@@ -747,7 +748,6 @@ mod test {
             "policies": [
             {
                 "name": "rlp-ns-A/rlp-name-A",
-                "domain": "rlp-ns-A/rlp-name-A",
                 "hostnames": ["*.toystore.com", "example.com"],
                 "rules": [
                 {
@@ -785,6 +785,7 @@ mod test {
                 "actions": [
                 {
                     "extension": "limitador",
+                    "scope": "rlp-ns-A/rlp-name-A",
                     "data": {
                         "static": {
                             "key": "rlp-ns-A/rlp-name-A",
@@ -842,7 +843,6 @@ mod test {
             "policies": [
             {
                 "name": "rlp-ns-A/rlp-name-A",
-                "domain": "rlp-ns-A/rlp-name-A",
                 "hostnames": ["*.toystore.com", "example.com"],
                 "rules": [
                 {
@@ -862,6 +862,7 @@ mod test {
                 "actions": [
                 {
                     "extension": "limitador",
+                    "scope": "rlp-ns-A/rlp-name-A",
                     "data": {
                         "static": {
                             "key": "rlp-ns-A/rlp-name-A",
@@ -902,7 +903,6 @@ mod test {
         "policies": [
         {
             "name": "rlp-ns-A/rlp-name-A",
-            "domain": "rlp-ns-A/rlp-name-A",
             "hostnames": ["*.toystore.com", "example.com"],
             "rules": [
             {
@@ -920,6 +920,7 @@ mod test {
             "actions": [
                 {
                     "extension": "limitador",
+                    "scope": "rlp-ns-A/rlp-name-A",
                     "data": {
                         "static": {
                             "key": "rlp-ns-A/rlp-name-A",
@@ -945,7 +946,6 @@ mod test {
         "policies": [
         {
             "name": "rlp-ns-A/rlp-name-A",
-            "domain": "rlp-ns-A/rlp-name-A",
             "service": "limitador-cluster",
             "hostnames": ["*.toystore.com", "example.com"],
             "rules": [
@@ -961,6 +961,7 @@ mod test {
             "actions": [
                 {
                     "extension": "limitador",
+                    "scope": "rlp-ns-A/rlp-name-A",
                     "data": {
                         "static": {
                             "key": "rlp-ns-A/rlp-name-A",
@@ -986,7 +987,6 @@ mod test {
             "policies": [
             {
                 "name": "rlp-ns-A/rlp-name-A",
-                "domain": "rlp-ns-A/rlp-name-A",
                 "hostnames": ["*.toystore.com", "example.com"],
                 "rules": [
                 {
@@ -1004,6 +1004,7 @@ mod test {
                 "actions": [
                 {
                     "extension": "limitador",
+                    "scope": "rlp-ns-A/rlp-name-A",
                     "data": {
                         "static": {
                             "key": "rlp-ns-A/rlp-name-A",

--- a/src/filter/http_context.rs
+++ b/src/filter/http_context.rs
@@ -30,17 +30,7 @@ impl Filter {
     }
 
     fn process_policy(&self, policy: &Policy) -> Action {
-        let descriptors = policy.build_descriptors(self);
-        if descriptors.is_empty() {
-            debug!(
-                "#{} process_rate_limit_policy: empty descriptors",
-                self.context_id
-            );
-            return Action::Continue;
-        }
-
-        self.operation_dispatcher
-            .build_operations(policy, descriptors);
+        self.operation_dispatcher.build_operations(policy, self);
 
         if let Some(operation) = self.operation_dispatcher.next() {
             match operation.get_result() {

--- a/src/filter/http_context.rs
+++ b/src/filter/http_context.rs
@@ -1,3 +1,4 @@
+use crate::attribute::store_metadata;
 use crate::configuration::{ExtensionType, FailureMode, FilterConfig};
 use crate::envoy::{CheckResponse_oneof_http_response, RateLimitResponse, RateLimitResponse_Code};
 use crate::operation_dispatcher::OperationDispatcher;
@@ -104,6 +105,9 @@ impl Filter {
         failure_mode: &FailureMode,
     ) {
         if let GrpcMessageResponse::Auth(check_response) = auth_resp {
+            // store dynamic metadata in filter state
+            store_metadata(check_response.get_dynamic_metadata());
+
             match check_response.http_response {
                 Some(CheckResponse_oneof_http_response::ok_response(ok_response)) => {
                     debug!(

--- a/src/operation_dispatcher.rs
+++ b/src/operation_dispatcher.rs
@@ -131,7 +131,7 @@ impl OperationDispatcher {
             if let Some(service) = self.service_handlers.get(&action.extension) {
                 let message = GrpcMessageRequest::new(
                     service.get_extension_type(),
-                    policy.domain.clone(),
+                    action.scope.clone(),
                     descriptors.clone(),
                 );
                 operations.push(Operation::new(

--- a/src/operation_dispatcher.rs
+++ b/src/operation_dispatcher.rs
@@ -1,11 +1,11 @@
-use crate::configuration::{Extension, ExtensionType, FailureMode};
+use crate::configuration::{Action, Extension, ExtensionType, FailureMode};
 use crate::policy::Rule;
 use crate::service::grpc_message::GrpcMessageRequest;
-use crate::service::{GetMapValuesBytesFn, GrpcCallFn, GrpcServiceHandler};
-use log::debug;
+use crate::service::{GetMapValuesBytesFn, GrpcCallFn, GrpcMessageBuildFn, GrpcServiceHandler};
+use log::error;
 use proxy_wasm::hostcalls;
 use proxy_wasm::types::{Bytes, MapType, Status};
-use std::cell::RefCell;
+use std::cell::{RefCell, RefMut};
 use std::collections::HashMap;
 use std::rc::Rc;
 use std::time::Duration;
@@ -27,9 +27,11 @@ impl State {
             _ => {}
         }
     }
-}
 
-type Procedure = (Rc<GrpcServiceHandler>, GrpcMessageRequest);
+    fn done(&mut self) {
+        *self = State::Done
+    }
+}
 
 #[allow(dead_code)]
 #[derive(Clone)]
@@ -37,34 +39,44 @@ pub(crate) struct Operation {
     state: State,
     result: Result<u32, Status>,
     extension: Rc<Extension>,
-    procedure: Procedure,
+    action: Action,
+    service: Rc<GrpcServiceHandler>,
     grpc_call_fn: GrpcCallFn,
     get_map_values_bytes_fn: GetMapValuesBytesFn,
+    grpc_message_build_fn: GrpcMessageBuildFn,
 }
 
 #[allow(dead_code)]
 impl Operation {
-    pub fn new(extension: Rc<Extension>, procedure: Procedure) -> Self {
+    pub fn new(extension: Rc<Extension>, action: Action, service: Rc<GrpcServiceHandler>) -> Self {
         Self {
             state: State::Pending,
             result: Ok(0), // Heuristics: zero represents that it's not been triggered, following `hostcalls` example
             extension,
-            procedure,
+            action,
+            service,
             grpc_call_fn,
             get_map_values_bytes_fn,
+            grpc_message_build_fn,
         }
     }
 
     fn trigger(&mut self) -> Result<u32, Status> {
         match self.state {
             State::Pending => {
-                self.result = self.procedure.0.send(
-                    self.get_map_values_bytes_fn,
-                    self.grpc_call_fn,
-                    self.procedure.1.clone(),
-                );
-                self.state.next();
-                self.result
+                if let Some(message) =
+                    (self.grpc_message_build_fn)(self.get_extension_type(), &self.action)
+                {
+                    self.result =
+                        self.service
+                            .send(self.get_map_values_bytes_fn, self.grpc_call_fn, message);
+                    self.state.next();
+                    self.result
+                } else {
+                    //todo: we need to move to and start the next action
+                    self.state.done();
+                    Ok(1234)
+                }
             }
             State::Waiting => {
                 self.state.next();
@@ -124,26 +136,10 @@ impl OperationDispatcher {
         for action in rule.actions.iter() {
             // TODO(didierofrivia): Error handling
             if let Some(service) = self.service_handlers.get(&action.extension) {
-                let descriptors = match service.get_extension_type() {
-                    ExtensionType::Auth => None,
-                    ExtensionType::RateLimit => {
-                        let desc = action.build_descriptors();
-                        if desc.is_empty() {
-                            debug!("process_policy: empty descriptors");
-                            continue;
-                        }
-                        Some(desc)
-                    }
-                };
-
-                let message = GrpcMessageRequest::new(
-                    service.get_extension_type(),
-                    action.scope.clone(),
-                    descriptors.clone(),
-                );
                 operations.push(Operation::new(
                     service.get_extension(),
-                    (Rc::clone(service), message),
+                    action.clone(),
+                    Rc::clone(service),
                 ))
             }
         }
@@ -166,27 +162,48 @@ impl OperationDispatcher {
     }
 
     pub fn next(&self) -> Option<Operation> {
-        let mut operations = self.operations.borrow_mut();
+        let operations = self.operations.borrow_mut();
+        self.step(operations)
+    }
+
+    fn step(&self, mut operations: RefMut<Vec<Operation>>) -> Option<Operation> {
         if let Some((i, operation)) = operations.iter_mut().enumerate().next() {
-            if let State::Done = operation.get_state() {
-                if let Ok(token_id) = operation.result {
-                    self.waiting_operations.borrow_mut().remove(&token_id);
-                } // If result was Err, means the operation wasn't indexed
-                operations.remove(i);
-                // The next op is now at `i`
-            }
-            if let Some(operation) = operations.get_mut(i) {
-                if let Ok(token_id) = operation.trigger() {
-                    if *operation.get_state() == State::Waiting {
-                        // We index only if it was just transitioned to Waiting after triggering
-                        self.waiting_operations
-                            .borrow_mut()
-                            .insert(token_id, operation.clone());
-                    } // TODO(didierofrivia): Decide on indexing the failed operations.
+            match operation.get_state() {
+                State::Pending => {
+                    match operation.trigger() {
+                        Ok(token_id) => {
+                            match operation.get_state() {
+                                State::Pending => {
+                                    panic!("Operation dispatcher reached an undefined state");
+                                }
+                                State::Waiting => {
+                                    // We index only if it was just transitioned to Waiting after triggering
+                                    self.waiting_operations
+                                        .borrow_mut()
+                                        .insert(token_id, operation.clone());
+                                    // TODO(didierofrivia): Decide on indexing the failed operations.
+                                    Some(operation.clone())
+                                }
+                                State::Done => self.step(operations),
+                            }
+                        }
+                        Err(status) => {
+                            error!("{status:?}");
+                            None
+                        }
+                    }
                 }
-                Some(operation.clone())
-            } else {
-                None
+                State::Waiting => {
+                    let _ = operation.trigger();
+                    Some(operation.clone())
+                }
+                State::Done => {
+                    if let Ok(token_id) = operation.result {
+                        self.waiting_operations.borrow_mut().remove(&token_id);
+                    } // If result was Err, means the operation wasn't indexed
+                    operations.remove(i);
+                    self.step(operations)
+                }
             }
         } else {
             None
@@ -216,6 +233,13 @@ fn get_map_values_bytes_fn(map_type: MapType, key: &str) -> Result<Option<Bytes>
     hostcalls::get_map_value_bytes(map_type, key)
 }
 
+fn grpc_message_build_fn(
+    extension_type: &ExtensionType,
+    action: &Action,
+) -> Option<GrpcMessageRequest> {
+    GrpcMessageRequest::new(extension_type, action)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -241,6 +265,13 @@ mod tests {
         Ok(Some(Vec::new()))
     }
 
+    fn grpc_message_build_fn_stub(
+        _extension_type: &ExtensionType,
+        _action: &Action,
+    ) -> Option<GrpcMessageRequest> {
+        Some(GrpcMessageRequest::RateLimit(build_message()))
+    }
+
     fn build_grpc_service_handler() -> GrpcServiceHandler {
         GrpcServiceHandler::new(Rc::new(Default::default()), Rc::new(Default::default()))
     }
@@ -264,12 +295,15 @@ mod tests {
                 endpoint: "local".to_string(),
                 failure_mode: FailureMode::Deny,
             }),
-            procedure: (
-                Rc::new(build_grpc_service_handler()),
-                GrpcMessageRequest::RateLimit(build_message()),
-            ),
+            action: Action {
+                extension: "local".to_string(),
+                scope: "".to_string(),
+                data: vec![],
+            },
+            service: Rc::new(build_grpc_service_handler()),
             grpc_call_fn: grpc_call_fn_stub,
             get_map_values_bytes_fn: get_map_values_bytes_fn_stub,
+            grpc_message_build_fn: grpc_message_build_fn_stub,
         }
     }
 

--- a/src/policy.rs
+++ b/src/policy.rs
@@ -1,24 +1,9 @@
-use crate::attribute::Attribute;
-use crate::configuration::{Action, DataItem, DataType, PatternExpression};
-use crate::envoy::{RateLimitDescriptor, RateLimitDescriptor_Entry};
-use crate::filter::http_context::Filter;
-use log::debug;
-use proxy_wasm::traits::Context;
+use crate::configuration::{Action, PatternExpression};
 use serde::Deserialize;
 
 #[derive(Deserialize, Debug, Clone)]
-#[serde(rename_all = "camelCase")]
-pub struct Condition {
-    pub all_of: Vec<PatternExpression>,
-}
-
-#[derive(Deserialize, Debug, Clone)]
 pub struct Rule {
-    //
-    #[serde(default)]
-    pub conditions: Vec<Condition>,
-    //
-    pub data: Vec<DataItem>,
+    pub conditions: Vec<PatternExpression>,
 }
 
 #[derive(Deserialize, Debug, Clone)]
@@ -44,131 +29,5 @@ impl Policy {
             rules,
             actions,
         }
-    }
-
-    pub fn build_descriptors(
-        &self,
-        filter: &Filter,
-    ) -> protobuf::RepeatedField<RateLimitDescriptor> {
-        self.rules
-            .iter()
-            .filter(|rule: &&Rule| self.filter_rule_by_conditions(filter, &rule.conditions))
-            // Mapping 1 Rule -> 1 Descriptor
-            // Filter out empty descriptors
-            .filter_map(|rule| self.build_single_descriptor(filter, &rule.data))
-            .collect()
-    }
-
-    fn filter_rule_by_conditions(&self, filter: &Filter, conditions: &[Condition]) -> bool {
-        if conditions.is_empty() {
-            // no conditions is equivalent to matching all the requests.
-            return true;
-        }
-
-        conditions
-            .iter()
-            .any(|condition| self.condition_applies(filter, condition))
-    }
-
-    fn condition_applies(&self, filter: &Filter, condition: &Condition) -> bool {
-        condition
-            .all_of
-            .iter()
-            .all(|pattern_expression| self.pattern_expression_applies(filter, pattern_expression))
-    }
-
-    fn pattern_expression_applies(&self, filter: &Filter, p_e: &PatternExpression) -> bool {
-        let attribute_path = p_e.path();
-        debug!(
-            "#{} get_property:  selector: {} path: {:?}",
-            filter.context_id, p_e.selector, attribute_path
-        );
-        let attribute_value = match filter.get_property(attribute_path) {
-            None => {
-                debug!(
-                    "#{} pattern_expression_applies:  selector not found: {}, defaulting to ``",
-                    filter.context_id, p_e.selector
-                );
-                b"".to_vec()
-            }
-            Some(attribute_bytes) => attribute_bytes,
-        };
-        match p_e.eval(attribute_value) {
-            Err(e) => {
-                debug!(
-                    "#{} pattern_expression_applies failed: {}",
-                    filter.context_id, e
-                );
-                false
-            }
-            Ok(result) => result,
-        }
-    }
-
-    fn build_single_descriptor(
-        &self,
-        filter: &Filter,
-        data_list: &[DataItem],
-    ) -> Option<RateLimitDescriptor> {
-        let mut entries = ::protobuf::RepeatedField::default();
-
-        // iterate over data items to allow any data item to skip the entire descriptor
-        for data in data_list.iter() {
-            match &data.item {
-                DataType::Static(static_item) => {
-                    let mut descriptor_entry = RateLimitDescriptor_Entry::new();
-                    descriptor_entry.set_key(static_item.key.to_owned());
-                    descriptor_entry.set_value(static_item.value.to_owned());
-                    entries.push(descriptor_entry);
-                }
-                DataType::Selector(selector_item) => {
-                    let descriptor_key = match &selector_item.key {
-                        None => selector_item.path().to_string(),
-                        Some(key) => key.to_owned(),
-                    };
-
-                    let attribute_path = selector_item.path();
-                    debug!(
-                        "#{} get_property:  selector: {} path: {:?}",
-                        filter.context_id, selector_item.selector, attribute_path
-                    );
-                    let value = match filter.get_property(attribute_path.tokens()) {
-                        None => {
-                            debug!(
-                                "#{} build_single_descriptor: selector not found: {}",
-                                filter.context_id, attribute_path
-                            );
-                            match &selector_item.default {
-                                None => return None, // skipping the entire descriptor
-                                Some(default_value) => default_value.clone(),
-                            }
-                        }
-                        // TODO(eastizle): not all fields are strings
-                        // https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/advanced/attributes
-                        Some(attribute_bytes) => match Attribute::parse(attribute_bytes) {
-                            Ok(attr_str) => attr_str,
-                            Err(e) => {
-                                debug!("#{} build_single_descriptor: failed to parse selector value: {}, error: {}",
-                                    filter.context_id, attribute_path, e);
-                                return None;
-                            }
-                        },
-                        // Alternative implementation (for rust >= 1.76)
-                        // Attribute::parse(attribute_bytes)
-                        //   .inspect_err(|e| debug!("#{} build_single_descriptor: failed to parse selector value: {}, error: {}",
-                        //           filter.context_id, attribute_path, e))
-                        //   .ok()?,
-                    };
-                    let mut descriptor_entry = RateLimitDescriptor_Entry::new();
-                    descriptor_entry.set_key(descriptor_key);
-                    descriptor_entry.set_value(value);
-                    entries.push(descriptor_entry);
-                }
-            }
-        }
-
-        let mut res = RateLimitDescriptor::new();
-        res.set_entries(entries);
-        Some(res)
     }
 }

--- a/src/policy.rs
+++ b/src/policy.rs
@@ -41,7 +41,7 @@ impl Policy {
 
         conditions
             .iter()
-            .any(|condition| self.pattern_expression_applies(condition))
+            .all(|condition| self.pattern_expression_applies(condition))
     }
 
     fn pattern_expression_applies(&self, p_e: &PatternExpression) -> bool {

--- a/src/policy.rs
+++ b/src/policy.rs
@@ -25,7 +25,6 @@ pub struct Rule {
 #[serde(rename_all = "camelCase")]
 pub struct Policy {
     pub name: String,
-    pub domain: String,
     pub hostnames: Vec<String>,
     pub rules: Vec<Rule>,
     pub actions: Vec<Action>,
@@ -35,14 +34,12 @@ impl Policy {
     #[cfg(test)]
     pub fn new(
         name: String,
-        domain: String,
         hostnames: Vec<String>,
         rules: Vec<Rule>,
         actions: Vec<Action>,
     ) -> Self {
         Policy {
             name,
-            domain,
             hostnames,
             rules,
             actions,

--- a/src/policy_index.rs
+++ b/src/policy_index.rs
@@ -41,13 +41,7 @@ mod tests {
     use crate::policy_index::PolicyIndex;
 
     fn build_ratelimit_policy(name: &str) -> Policy {
-        Policy::new(
-            name.to_owned(),
-            "".to_owned(),
-            Vec::new(),
-            Vec::new(),
-            Vec::new(),
-        )
+        Policy::new(name.to_owned(), Vec::new(), Vec::new(), Vec::new())
     }
 
     #[test]

--- a/src/policy_index.rs
+++ b/src/policy_index.rs
@@ -41,7 +41,7 @@ mod tests {
     use crate::policy_index::PolicyIndex;
 
     fn build_ratelimit_policy(name: &str) -> Policy {
-        Policy::new(name.to_owned(), Vec::new(), Vec::new(), Vec::new())
+        Policy::new(name.to_owned(), Vec::new(), Vec::new())
     }
 
     #[test]

--- a/src/service.rs
+++ b/src/service.rs
@@ -2,7 +2,7 @@ pub(crate) mod auth;
 pub(crate) mod grpc_message;
 pub(crate) mod rate_limit;
 
-use crate::configuration::{Extension, ExtensionType, FailureMode};
+use crate::configuration::{Action, Extension, ExtensionType, FailureMode};
 use crate::service::auth::{AUTH_METHOD_NAME, AUTH_SERVICE_NAME};
 use crate::service::grpc_message::GrpcMessageRequest;
 use crate::service::rate_limit::{RATELIMIT_METHOD_NAME, RATELIMIT_SERVICE_NAME};
@@ -63,6 +63,9 @@ pub type GrpcCallFn = fn(
 
 pub type GetMapValuesBytesFn = fn(map_type: MapType, key: &str) -> Result<Option<Bytes>, Status>;
 
+pub type GrpcMessageBuildFn =
+    fn(extension_type: &ExtensionType, action: &Action) -> Option<GrpcMessageRequest>;
+
 pub struct GrpcServiceHandler {
     service: Rc<GrpcService>,
     header_resolver: Rc<HeaderResolver>,
@@ -102,10 +105,6 @@ impl GrpcServiceHandler {
 
     pub fn get_extension(&self) -> Rc<Extension> {
         Rc::clone(&self.service.extension)
-    }
-
-    pub fn get_extension_type(&self) -> ExtensionType {
-        self.service.extension.extension_type.clone()
     }
 }
 

--- a/src/service/grpc_message.rs
+++ b/src/service/grpc_message.rs
@@ -127,12 +127,15 @@ impl GrpcMessageRequest {
     pub fn new(
         extension_type: ExtensionType,
         domain: String,
-        descriptors: protobuf::RepeatedField<RateLimitDescriptor>,
+        descriptors: Option<protobuf::RepeatedField<RateLimitDescriptor>>,
     ) -> Self {
         match extension_type {
-            ExtensionType::RateLimit => GrpcMessageRequest::RateLimit(
-                RateLimitService::request_message(domain.clone(), descriptors),
-            ),
+            ExtensionType::RateLimit => {
+                GrpcMessageRequest::RateLimit(RateLimitService::request_message(
+                    domain.clone(),
+                    descriptors.expect("rate limit message expects descriptors"),
+                ))
+            }
             ExtensionType::Auth => {
                 GrpcMessageRequest::Auth(AuthService::request_message(domain.clone()))
             }

--- a/tests/rate_limited.rs
+++ b/tests/rate_limited.rs
@@ -100,7 +100,6 @@ fn it_limits() {
         "policies": [
         {
             "name": "some-name",
-            "domain": "RLS-domain",
             "hostnames": ["*.toystore.com", "example.com"],
             "rules": [
             {
@@ -136,6 +135,7 @@ fn it_limits() {
             "actions": [
                 {
                     "extension": "limitador",
+                    "scope": "RLS-domain",
                     "data": {
                         "static": {
                             "key": "rlp-ns-A/rlp-name-A",
@@ -266,7 +266,6 @@ fn it_passes_additional_headers() {
         "policies": [
         {
             "name": "some-name",
-            "domain": "RLS-domain",
             "hostnames": ["*.toystore.com", "example.com"],
             "rules": [
             {
@@ -302,6 +301,7 @@ fn it_passes_additional_headers() {
             "actions": [
                 {
                     "extension": "limitador",
+                    "scope": "RLS-domain",
                     "data": {
                         "static": {
                             "key": "rlp-ns-A/rlp-name-A",
@@ -446,7 +446,6 @@ fn it_rate_limits_with_empty_conditions() {
         "policies": [
         {
             "name": "some-name",
-            "domain": "RLS-domain",
             "hostnames": ["*.com"],
             "rules": [
             {
@@ -462,6 +461,7 @@ fn it_rate_limits_with_empty_conditions() {
             "actions": [
                 {
                     "extension": "limitador",
+                    "scope": "RLS-domain",
                     "data": {
                         "static": {
                             "key": "rlp-ns-A/rlp-name-A",
@@ -574,7 +574,6 @@ fn it_does_not_rate_limits_when_selector_does_not_exist_and_misses_default_value
         "policies": [
         {
             "name": "some-name",
-            "domain": "RLS-domain",
             "hostnames": ["*.com"],
             "rules": [
             {
@@ -589,6 +588,7 @@ fn it_does_not_rate_limits_when_selector_does_not_exist_and_misses_default_value
             "actions": [
                 {
                     "extension": "limitador",
+                    "scope": "RLS-domain",
                     "data": {
                         "static": {
                             "key": "rlp-ns-A/rlp-name-A",

--- a/tests/rate_limited.rs
+++ b/tests/rate_limited.rs
@@ -601,7 +601,7 @@ fn it_does_not_rate_limits_when_selector_does_not_exist_and_misses_default_value
         )
         .expect_log(
             Some(LogLevel::Debug),
-            Some("process_policy: empty descriptors"),
+            Some("grpc_message_request: empty descriptors"),
         )
         .execute_and_expect(ReturnType::Action(Action::Continue))
         .unwrap();

--- a/tests/rate_limited.rs
+++ b/tests/rate_limited.rs
@@ -119,9 +119,8 @@ fn it_limits() {
                         "operator": "eq",
                         "value": "POST"
                     }
-                ]
-            }],
-            "actions": [
+                ],
+                "actions": [
                 {
                     "extension": "limitador",
                     "scope": "RLS-domain",
@@ -133,8 +132,8 @@ fn it_limits() {
                             }
                         }
                     ]
-                }
-            ]
+                }]
+            }]
         }]
     }"#;
 
@@ -176,21 +175,18 @@ fn it_limits() {
         .returning(Some("cars.toystore.com".as_bytes()))
         .expect_get_property(Some(vec!["request", "method"]))
         .returning(Some("POST".as_bytes()))
+        .expect_log(Some(LogLevel::Debug), Some("#2 policy selected some-name"))
         .expect_log(
             Some(LogLevel::Debug),
-            Some("#2 ratelimitpolicy selected some-name"),
+            Some("get_property:  selector: request.url_path path: [\"request\", \"url_path\"]"),
         )
         .expect_log(
             Some(LogLevel::Debug),
-            Some("#2 get_property:  selector: request.url_path path: [\"request\", \"url_path\"]"),
+            Some("get_property:  selector: request.host path: [\"request\", \"host\"]"),
         )
         .expect_log(
             Some(LogLevel::Debug),
-            Some("#2 get_property:  selector: request.host path: [\"request\", \"host\"]"),
-        )
-        .expect_log(
-            Some(LogLevel::Debug),
-            Some("#2 get_property:  selector: request.method path: [\"request\", \"method\"]"),
+            Some("get_property:  selector: request.method path: [\"request\", \"method\"]"),
         )
         .expect_grpc_call(
             Some("limitador-cluster"),
@@ -276,9 +272,8 @@ fn it_passes_additional_headers() {
                         "operator": "eq",
                         "value": "POST"
                     }
-                ]
-            }],
-            "actions": [
+                ],
+                "actions": [
                 {
                     "extension": "limitador",
                     "scope": "RLS-domain",
@@ -290,8 +285,8 @@ fn it_passes_additional_headers() {
                             }
                         }
                     ]
-                }
-            ]
+                }]
+            }]
         }]
     }"#;
 
@@ -333,21 +328,18 @@ fn it_passes_additional_headers() {
         .returning(Some("cars.toystore.com".as_bytes()))
         .expect_get_property(Some(vec!["request", "method"]))
         .returning(Some("POST".as_bytes()))
+        .expect_log(Some(LogLevel::Debug), Some("#2 policy selected some-name"))
         .expect_log(
             Some(LogLevel::Debug),
-            Some("#2 ratelimitpolicy selected some-name"),
+            Some("get_property:  selector: request.url_path path: [\"request\", \"url_path\"]"),
         )
         .expect_log(
             Some(LogLevel::Debug),
-            Some("#2 get_property:  selector: request.url_path path: [\"request\", \"url_path\"]"),
+            Some("get_property:  selector: request.host path: [\"request\", \"host\"]"),
         )
         .expect_log(
             Some(LogLevel::Debug),
-            Some("#2 get_property:  selector: request.host path: [\"request\", \"host\"]"),
-        )
-        .expect_log(
-            Some(LogLevel::Debug),
-            Some("#2 get_property:  selector: request.method path: [\"request\", \"method\"]"),
+            Some("get_property:  selector: request.method path: [\"request\", \"method\"]"),
         )
         .expect_grpc_call(
             Some("limitador-cluster"),
@@ -430,11 +422,9 @@ fn it_rate_limits_with_empty_conditions() {
             "name": "some-name",
             "hostnames": ["*.com"],
             "rules": [
-                {
-                    "conditions": []
-                }
-            ],
-            "actions": [
+            {
+                "conditions": [],
+                "actions": [
                 {
                     "extension": "limitador",
                     "scope": "RLS-domain",
@@ -446,8 +436,8 @@ fn it_rate_limits_with_empty_conditions() {
                             }
                         }
                     ]
-                }
-            ]
+                }]
+            }]
         }]
     }"#;
 
@@ -483,10 +473,7 @@ fn it_rate_limits_with_empty_conditions() {
         .returning(None)
         .expect_get_header_map_value(Some(MapType::HttpRequestHeaders), Some("baggage"))
         .returning(None)
-        .expect_log(
-            Some(LogLevel::Debug),
-            Some("#2 ratelimitpolicy selected some-name"),
-        )
+        .expect_log(Some(LogLevel::Debug), Some("#2 policy selected some-name"))
         .expect_grpc_call(
             Some("limitador-cluster"),
             Some("envoy.service.ratelimit.v3.RateLimitService"),
@@ -554,11 +541,9 @@ fn it_does_not_rate_limits_when_selector_does_not_exist_and_misses_default_value
             "name": "some-name",
             "hostnames": ["*.com"],
             "rules": [
-                {
-                    "conditions": []
-                }
-            ],
-            "actions": [
+            {
+                "conditions": [],
+                "actions": [
                 {
                     "extension": "limitador",
                     "scope": "RLS-domain",
@@ -569,8 +554,8 @@ fn it_does_not_rate_limits_when_selector_does_not_exist_and_misses_default_value
                             }
                         }
                     ]
-                }
-            ]
+                }]
+            }]
         }]
     }"#;
 
@@ -604,19 +589,19 @@ fn it_does_not_rate_limits_when_selector_does_not_exist_and_misses_default_value
         .returning(None)
         .expect_log(
             Some(LogLevel::Debug),
-            Some("#2 ratelimitpolicy selected some-name"),
+            Some("#2 policy selected some-name"),
         )
         .expect_log(
             Some(LogLevel::Debug),
-            Some("#2 get_property:  selector: unknown.path path: Path { tokens: [\"unknown\", \"path\"] }"),
+            Some("get_property:  selector: unknown.path path: Path { tokens: [\"unknown\", \"path\"] }"),
         )
         .expect_log(
             Some(LogLevel::Debug),
-            Some("#2 build_single_descriptor: selector not found: unknown.path"),
+            Some("build_single_descriptor: selector not found: unknown.path"),
         )
         .expect_log(
             Some(LogLevel::Debug),
-            Some("#2 process_rate_limit_policy: empty descriptors"),
+            Some("process_policy: empty descriptors"),
         )
         .execute_and_expect(ReturnType::Action(Action::Continue))
         .unwrap();

--- a/tests/rate_limited.rs
+++ b/tests/rate_limited.rs
@@ -163,31 +163,31 @@ fn it_limits() {
         .expect_log(Some(LogLevel::Debug), Some("#2 on_http_request_headers"))
         .expect_get_header_map_value(Some(MapType::HttpRequestHeaders), Some(":authority"))
         .returning(Some("cars.toystore.com"))
+        .expect_log(Some(LogLevel::Debug), Some("#2 policy selected some-name"))
+        .expect_log(
+            Some(LogLevel::Debug),
+            Some("get_property:  selector: request.url_path path: [\"request\", \"url_path\"]"),
+        )
+        .expect_get_property(Some(vec!["request", "url_path"]))
+        .returning(Some("/admin/toy".as_bytes()))
+        .expect_log(
+            Some(LogLevel::Debug),
+            Some("get_property:  selector: request.host path: [\"request\", \"host\"]"),
+        )
+        .expect_get_property(Some(vec!["request", "host"]))
+        .returning(Some("cars.toystore.com".as_bytes()))
+        .expect_log(
+            Some(LogLevel::Debug),
+            Some("get_property:  selector: request.method path: [\"request\", \"method\"]"),
+        )
+        .expect_get_property(Some(vec!["request", "method"]))
+        .returning(Some("POST".as_bytes()))
         .expect_get_header_map_value(Some(MapType::HttpRequestHeaders), Some("traceparent"))
         .returning(None)
         .expect_get_header_map_value(Some(MapType::HttpRequestHeaders), Some("tracestate"))
         .returning(None)
         .expect_get_header_map_value(Some(MapType::HttpRequestHeaders), Some("baggage"))
         .returning(None)
-        .expect_get_property(Some(vec!["request", "url_path"]))
-        .returning(Some("/admin/toy".as_bytes()))
-        .expect_get_property(Some(vec!["request", "host"]))
-        .returning(Some("cars.toystore.com".as_bytes()))
-        .expect_get_property(Some(vec!["request", "method"]))
-        .returning(Some("POST".as_bytes()))
-        .expect_log(Some(LogLevel::Debug), Some("#2 policy selected some-name"))
-        .expect_log(
-            Some(LogLevel::Debug),
-            Some("get_property:  selector: request.url_path path: [\"request\", \"url_path\"]"),
-        )
-        .expect_log(
-            Some(LogLevel::Debug),
-            Some("get_property:  selector: request.host path: [\"request\", \"host\"]"),
-        )
-        .expect_log(
-            Some(LogLevel::Debug),
-            Some("get_property:  selector: request.method path: [\"request\", \"method\"]"),
-        )
         .expect_grpc_call(
             Some("limitador-cluster"),
             Some("envoy.service.ratelimit.v3.RateLimitService"),
@@ -316,31 +316,31 @@ fn it_passes_additional_headers() {
         .expect_log(Some(LogLevel::Debug), Some("#2 on_http_request_headers"))
         .expect_get_header_map_value(Some(MapType::HttpRequestHeaders), Some(":authority"))
         .returning(Some("cars.toystore.com"))
+        .expect_log(Some(LogLevel::Debug), Some("#2 policy selected some-name"))
+        .expect_log(
+            Some(LogLevel::Debug),
+            Some("get_property:  selector: request.url_path path: [\"request\", \"url_path\"]"),
+        )
+        .expect_get_property(Some(vec!["request", "url_path"]))
+        .returning(Some("/admin/toy".as_bytes()))
+        .expect_log(
+            Some(LogLevel::Debug),
+            Some("get_property:  selector: request.host path: [\"request\", \"host\"]"),
+        )
+        .expect_get_property(Some(vec!["request", "host"]))
+        .returning(Some("cars.toystore.com".as_bytes()))
+        .expect_log(
+            Some(LogLevel::Debug),
+            Some("get_property:  selector: request.method path: [\"request\", \"method\"]"),
+        )
+        .expect_get_property(Some(vec!["request", "method"]))
+        .returning(Some("POST".as_bytes()))
         .expect_get_header_map_value(Some(MapType::HttpRequestHeaders), Some("traceparent"))
         .returning(None)
         .expect_get_header_map_value(Some(MapType::HttpRequestHeaders), Some("tracestate"))
         .returning(None)
         .expect_get_header_map_value(Some(MapType::HttpRequestHeaders), Some("baggage"))
         .returning(None)
-        .expect_get_property(Some(vec!["request", "url_path"]))
-        .returning(Some("/admin/toy".as_bytes()))
-        .expect_get_property(Some(vec!["request", "host"]))
-        .returning(Some("cars.toystore.com".as_bytes()))
-        .expect_get_property(Some(vec!["request", "method"]))
-        .returning(Some("POST".as_bytes()))
-        .expect_log(Some(LogLevel::Debug), Some("#2 policy selected some-name"))
-        .expect_log(
-            Some(LogLevel::Debug),
-            Some("get_property:  selector: request.url_path path: [\"request\", \"url_path\"]"),
-        )
-        .expect_log(
-            Some(LogLevel::Debug),
-            Some("get_property:  selector: request.host path: [\"request\", \"host\"]"),
-        )
-        .expect_log(
-            Some(LogLevel::Debug),
-            Some("get_property:  selector: request.method path: [\"request\", \"method\"]"),
-        )
         .expect_grpc_call(
             Some("limitador-cluster"),
             Some("envoy.service.ratelimit.v3.RateLimitService"),
@@ -467,13 +467,13 @@ fn it_rate_limits_with_empty_conditions() {
         .expect_log(Some(LogLevel::Debug), Some("#2 on_http_request_headers"))
         .expect_get_header_map_value(Some(MapType::HttpRequestHeaders), Some(":authority"))
         .returning(Some("a.com"))
+        .expect_log(Some(LogLevel::Debug), Some("#2 policy selected some-name"))
         .expect_get_header_map_value(Some(MapType::HttpRequestHeaders), Some("traceparent"))
         .returning(None)
         .expect_get_header_map_value(Some(MapType::HttpRequestHeaders), Some("tracestate"))
         .returning(None)
         .expect_get_header_map_value(Some(MapType::HttpRequestHeaders), Some("baggage"))
         .returning(None)
-        .expect_log(Some(LogLevel::Debug), Some("#2 policy selected some-name"))
         .expect_grpc_call(
             Some("limitador-cluster"),
             Some("envoy.service.ratelimit.v3.RateLimitService"),
@@ -585,8 +585,6 @@ fn it_does_not_rate_limits_when_selector_does_not_exist_and_misses_default_value
         .expect_log(Some(LogLevel::Debug), Some("#2 on_http_request_headers"))
         .expect_get_header_map_value(Some(MapType::HttpRequestHeaders), Some(":authority"))
         .returning(Some("a.com"))
-        .expect_get_property(Some(vec!["unknown", "path"]))
-        .returning(None)
         .expect_log(
             Some(LogLevel::Debug),
             Some("#2 policy selected some-name"),
@@ -595,6 +593,8 @@ fn it_does_not_rate_limits_when_selector_does_not_exist_and_misses_default_value
             Some(LogLevel::Debug),
             Some("get_property:  selector: unknown.path path: Path { tokens: [\"unknown\", \"path\"] }"),
         )
+        .expect_get_property(Some(vec!["unknown", "path"]))
+        .returning(None)
         .expect_log(
             Some(LogLevel::Debug),
             Some("build_single_descriptor: selector not found: unknown.path"),

--- a/tests/rate_limited.rs
+++ b/tests/rate_limited.rs
@@ -105,43 +105,34 @@ fn it_limits() {
             {
                 "conditions": [
                     {
-                        "allOf": [
-                        {
-                            "selector": "request.url_path",
-                            "operator": "startswith",
-                            "value": "/admin/toy"
-                        },
-                        {
-                            "selector": "request.host",
-                            "operator": "eq",
-                            "value": "cars.toystore.com"
-                        },
-                        {
-                            "selector": "request.method",
-                            "operator": "eq",
-                            "value": "POST"
-                        }]
+                        "selector": "request.url_path",
+                        "operator": "startswith",
+                        "value": "/admin/toy"
+                    },
+                    {
+                        "selector": "request.host",
+                        "operator": "eq",
+                        "value": "cars.toystore.com"
+                    },
+                    {
+                        "selector": "request.method",
+                        "operator": "eq",
+                        "value": "POST"
                     }
-                ],
-                "data": [
-                  {
-                    "static": {
-                      "key": "admin",
-                      "value": "1"
-                    }
-                  }
                 ]
             }],
             "actions": [
                 {
                     "extension": "limitador",
                     "scope": "RLS-domain",
-                    "data": {
-                        "static": {
-                            "key": "rlp-ns-A/rlp-name-A",
-                            "value": "1"
+                    "data": [
+                        {
+                            "static": {
+                                "key": "admin",
+                                "value": "1"
+                            }
                         }
-                    }
+                    ]
                 }
             ]
         }]
@@ -271,43 +262,34 @@ fn it_passes_additional_headers() {
             {
                 "conditions": [
                     {
-                        "allOf": [
-                        {
-                            "selector": "request.url_path",
-                            "operator": "startswith",
-                            "value": "/admin/toy"
-                        },
-                        {
-                            "selector": "request.host",
-                            "operator": "eq",
-                            "value": "cars.toystore.com"
-                        },
-                        {
-                            "selector": "request.method",
-                            "operator": "eq",
-                            "value": "POST"
-                        }]
+                        "selector": "request.url_path",
+                        "operator": "startswith",
+                        "value": "/admin/toy"
+                    },
+                    {
+                        "selector": "request.host",
+                        "operator": "eq",
+                        "value": "cars.toystore.com"
+                    },
+                    {
+                        "selector": "request.method",
+                        "operator": "eq",
+                        "value": "POST"
                     }
-                ],
-                "data": [
-                  {
-                    "static": {
-                      "key": "admin",
-                      "value": "1"
-                    }
-                  }
                 ]
             }],
             "actions": [
                 {
                     "extension": "limitador",
                     "scope": "RLS-domain",
-                    "data": {
-                        "static": {
-                            "key": "rlp-ns-A/rlp-name-A",
-                            "value": "1"
+                    "data": [
+                        {
+                            "static": {
+                                "key": "admin",
+                                "value": "1"
+                            }
                         }
-                    }
+                    ]
                 }
             ]
         }]
@@ -448,26 +430,22 @@ fn it_rate_limits_with_empty_conditions() {
             "name": "some-name",
             "hostnames": ["*.com"],
             "rules": [
-            {
-                "data": [
-                  {
-                    "static": {
-                      "key": "admin",
-                      "value": "1"
-                    }
-                  }
-                ]
-            }],
+                {
+                    "conditions": []
+                }
+            ],
             "actions": [
                 {
                     "extension": "limitador",
                     "scope": "RLS-domain",
-                    "data": {
-                        "static": {
-                            "key": "rlp-ns-A/rlp-name-A",
-                            "value": "1"
+                    "data": [
+                        {
+                            "static": {
+                                "key": "admin",
+                                "value": "1"
+                            }
                         }
-                    }
+                    ]
                 }
             ]
         }]
@@ -576,25 +554,21 @@ fn it_does_not_rate_limits_when_selector_does_not_exist_and_misses_default_value
             "name": "some-name",
             "hostnames": ["*.com"],
             "rules": [
-            {
-                "data": [
                 {
-                    "selector": {
-                        "selector": "unknown.path"
-                    }
+                    "conditions": []
                 }
-                ]
-            }],
+            ],
             "actions": [
                 {
                     "extension": "limitador",
                     "scope": "RLS-domain",
-                    "data": {
-                        "static": {
-                            "key": "rlp-ns-A/rlp-name-A",
-                            "value": "1"
+                    "data": [
+                        {
+                            "selector": {
+                                "selector": "unknown.path"
+                            }
                         }
-                    }
+                    ]
                 }
             ]
         }]

--- a/utils/deploy/authconfig.yaml
+++ b/utils/deploy/authconfig.yaml
@@ -7,22 +7,45 @@ spec:
   hosts:
     - effective-route-1
   authentication:
-    "friends":
+    "api-key-users":
       apiKey:
         selector:
           matchLabels:
-            group: friends
+            app: toystore
       credentials:
         authorizationHeader:
           prefix: APIKEY
+  response:
+    success:
+      dynamicMetadata:
+        "identity":
+          json:
+            properties:
+              "userid":
+                selector: auth.identity.metadata.annotations.secret\.kuadrant\.io/user-id
 ---
 apiVersion: v1
 kind: Secret
 metadata:
-  name: api-key-1
+  name: bob-key
   labels:
     authorino.kuadrant.io/managed-by: authorino
-    group: friends
+    app: toystore
+  annotations:
+    secret.kuadrant.io/user-id: bob
 stringData:
-  api_key: "ndyBzreUzF4zqDQsqSPMHkRhriEOtcRx"
+  api_key: "IAMBOB"
+type: Opaque
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: alice-key
+  labels:
+    authorino.kuadrant.io/managed-by: authorino
+    app: toystore
+  annotations:
+    secret.kuadrant.io/user-id: alice
+stringData:
+  api_key: "IAMALICE"
 type: Opaque

--- a/utils/deploy/envoy-notls.yaml
+++ b/utils/deploy/envoy-notls.yaml
@@ -161,14 +161,14 @@ data:
                                               "operator": "eq",
                                               "value": "/get"
                                             }
+                                          ],
+                                          "actions": [
+                                            {
+                                              "extension": "authorino",
+                                              "scope": "effective-route-1",
+                                              "data": []
+                                            }
                                           ]
-                                        }
-                                      ],
-                                      "actions": [
-                                        {
-                                          "extension": "authorino",
-                                          "scope": "effective-route-1",
-                                          "data": []
                                         }
                                       ]
                                     },
@@ -179,18 +179,18 @@ data:
                                       ],
                                       "rules": [
                                         {
-                                          "conditions": []
-                                        }
-                                      ],
-                                      "actions": [
-                                        {
-                                          "extension": "limitador",
-                                          "scope": "rlp-ns-A/rlp-name-A",
-                                          "data": [
+                                          "conditions": [],
+                                          "actions": [
                                             {
-                                              "selector": {
-                                                "selector": "unknown.path"
-                                              }
+                                              "extension": "limitador",
+                                              "scope": "rlp-ns-A/rlp-name-A",
+                                              "data": [
+                                                {
+                                                  "selector": {
+                                                    "selector": "unknown.path"
+                                                  }
+                                                }
+                                              ]
                                             }
                                           ]
                                         }
@@ -209,19 +209,19 @@ data:
                                               "operator": "startswith",
                                               "value": "/unknown-path"
                                             }
-                                          ]
-                                        }
-                                      ],
-                                      "actions": [
-                                        {
-                                          "extension": "limitador",
-                                          "scope": "rlp-ns-B/rlp-name-B",
-                                          "data": [
+                                          ],
+                                          "actions": [
                                             {
-                                              "static": {
-                                                "key": "rlp-ns-B/rlp-name-B/limit-not-to-be-activated",
-                                                "value": "1"
-                                              }
+                                              "extension": "limitador",
+                                              "scope": "rlp-ns-B/rlp-name-B",
+                                              "data": [
+                                                {
+                                                  "static": {
+                                                    "key": "rlp-ns-B/rlp-name-B/limit-not-to-be-activated",
+                                                    "value": "1"
+                                                  }
+                                                }
+                                              ]
                                             }
                                           ]
                                         }
@@ -250,35 +250,35 @@ data:
                                               "operator": "eq",
                                               "value": "GET"
                                             }
-                                          ]
-                                        }
-                                      ],
-                                      "actions": [
-                                        {
-                                          "extension": "limitador",
-                                          "scope": "rlp-ns-C/rlp-name-C",
-                                          "data": [
+                                          ],
+                                          "actions": [
                                             {
-                                              "static": {
-                                                "key": "limit_to_be_activated",
-                                                "value": "1"
-                                              }
-                                            },
-                                            {
-                                              "selector": {
-                                                "selector": "source.address"
-                                              }
-                                            },
-                                            {
-                                              "selector": {
-                                                "selector": "request.headers.My-Custom-Header-01"
-                                              }
-                                            },
-                                            {
-                                              "selector": {
-                                                "selector": "metadata.filter_metadata.envoy\\.filters\\.http\\.header_to_metadata.user_id",
-                                                "key": "user_id"
-                                              }
+                                              "extension": "limitador",
+                                              "scope": "rlp-ns-C/rlp-name-C",
+                                              "data": [
+                                                {
+                                                  "static": {
+                                                    "key": "limit_to_be_activated",
+                                                    "value": "1"
+                                                  }
+                                                },
+                                                {
+                                                  "selector": {
+                                                    "selector": "source.address"
+                                                  }
+                                                },
+                                                {
+                                                  "selector": {
+                                                    "selector": "request.headers.My-Custom-Header-01"
+                                                  }
+                                                },
+                                                {
+                                                  "selector": {
+                                                    "selector": "metadata.filter_metadata.envoy\\.filters\\.http\\.header_to_metadata.user_id",
+                                                    "key": "user_id"
+                                                  }
+                                                }
+                                              ]
                                             }
                                           ]
                                         }
@@ -297,24 +297,24 @@ data:
                                               "operator": "eq",
                                               "value": "/get"
                                             }
-                                          ]
-                                        }
-                                      ],
-                                      "actions": [
-                                        {
-                                          "extension": "authorino",
-                                          "scope": "effective-route-1",
-                                          "data": []
-                                        },
-                                        {
-                                          "extension": "limitador",
-                                          "scope": "multi-ns-A/multi-name-A",
-                                          "data": [
+                                          ],
+                                          "actions": [
                                             {
-                                              "selector": {
-                                                "selector": "filter_state.wasm\\.kuadrant\\.identity\\.userid",
-                                                "key": "user_id"
-                                              }
+                                              "extension": "authorino",
+                                              "scope": "effective-route-1",
+                                              "data": []
+                                            },
+                                            {
+                                              "extension": "limitador",
+                                              "scope": "multi-ns-A/multi-name-A",
+                                              "data": [
+                                                {
+                                                  "selector": {
+                                                    "selector": "filter_state.wasm\\.kuadrant\\.identity\\.userid",
+                                                    "key": "user_id"
+                                                  }
+                                                }
+                                              ]
                                             }
                                           ]
                                         }

--- a/utils/deploy/envoy-notls.yaml
+++ b/utils/deploy/envoy-notls.yaml
@@ -150,7 +150,6 @@ data:
                                   "policies": [
                                     {
                                       "name": "auth-ns-A/auth-name-A",
-                                      "domain": "effective-route-1",
                                       "hostnames": [
                                         "*.a.auth.com"
                                       ],
@@ -180,6 +179,7 @@ data:
                                       "actions": [
                                         {
                                           "extension": "authorino",
+                                          "scope": "effective-route-1",
                                           "data": {
                                             "static": {
                                               "key": "host",
@@ -191,7 +191,6 @@ data:
                                     },
                                     {
                                       "name": "rlp-ns-A/rlp-name-A",
-                                      "domain": "rlp-ns-A/rlp-name-A",
                                       "hostnames": [
                                         "*.a.rlp.com"
                                       ],
@@ -209,6 +208,7 @@ data:
                                       "actions": [
                                         {
                                           "extension": "limitador",
+                                          "scope": "rlp-ns-A/rlp-name-A",
                                           "data": {
                                             "static": {
                                               "key": "rlp-ns-A/rlp-name-A",
@@ -220,7 +220,6 @@ data:
                                     },
                                     {
                                       "name": "rlp-ns-B/rlp-name-B",
-                                      "domain": "rlp-ns-B/rlp-name-B",
                                       "hostnames": [
                                         "*.b.rlp.com"
                                       ],
@@ -250,6 +249,7 @@ data:
                                       "actions": [
                                         {
                                           "extension": "limitador",
+                                          "scope": "rlp-ns-B/rlp-name-B",
                                           "data": {
                                             "static": {
                                               "key": "rlp-ns-B/rlp-name-B",
@@ -261,7 +261,6 @@ data:
                                     },
                                     {
                                       "name": "rlp-ns-C/rlp-name-C",
-                                      "domain": "rlp-ns-C/rlp-name-C",
                                       "hostnames": [
                                         "*.c.rlp.com"
                                       ],
@@ -392,6 +391,7 @@ data:
                                       "actions": [
                                         {
                                           "extension": "limitador",
+                                          "scope": "rlp-ns-C/rlp-name-C",
                                           "data": {
                                             "static": {
                                               "key": "rlp-ns-C/rlp-name-C",

--- a/utils/deploy/envoy-notls.yaml
+++ b/utils/deploy/envoy-notls.yaml
@@ -283,6 +283,42 @@ data:
                                           ]
                                         }
                                       ]
+                                    },
+                                    {
+                                      "name": "multi-ns-A/multi-name-A",
+                                      "hostnames": [
+                                        "*.a.multi.com"
+                                      ],
+                                      "rules": [
+                                        {
+                                          "conditions": [
+                                            {
+                                              "selector": "request.path",
+                                              "operator": "eq",
+                                              "value": "/get"
+                                            }
+                                          ]
+                                        }
+                                      ],
+                                      "actions": [
+                                        {
+                                          "extension": "authorino",
+                                          "scope": "effective-route-1",
+                                          "data": []
+                                        },
+                                        {
+                                          "extension": "limitador",
+                                          "scope": "multi-ns-A/multi-name-A",
+                                          "data": [
+                                            {
+                                              "selector": {
+                                                "selector": "filter_state.wasm\\.kuadrant\\.identity\\.userid",
+                                                "key": "user_id"
+                                              }
+                                            }
+                                          ]
+                                        }
+                                      ]
                                     }
                                   ]
                                 }

--- a/utils/deploy/envoy-notls.yaml
+++ b/utils/deploy/envoy-notls.yaml
@@ -157,21 +157,9 @@ data:
                                         {
                                           "conditions": [
                                             {
-                                              "allOf": [
-                                                {
-                                                  "selector": "request.path",
-                                                  "operator": "eq",
-                                                  "value": "/get"
-                                                }
-                                              ]
-                                            }
-                                          ],
-                                          "data": [
-                                            {
-                                              "static": {
-                                                "key": "host",
-                                                "value": "effective-route-1"
-                                              }
+                                              "selector": "request.path",
+                                              "operator": "eq",
+                                              "value": "/get"
                                             }
                                           ]
                                         }
@@ -180,12 +168,7 @@ data:
                                         {
                                           "extension": "authorino",
                                           "scope": "effective-route-1",
-                                          "data": {
-                                            "static": {
-                                              "key": "host",
-                                              "value": "effective-route-1"
-                                            }
-                                          }
+                                          "data": []
                                         }
                                       ]
                                     },
@@ -196,6 +179,13 @@ data:
                                       ],
                                       "rules": [
                                         {
+                                          "conditions": []
+                                        }
+                                      ],
+                                      "actions": [
+                                        {
+                                          "extension": "limitador",
+                                          "scope": "rlp-ns-A/rlp-name-A",
                                           "data": [
                                             {
                                               "selector": {
@@ -203,18 +193,6 @@ data:
                                               }
                                             }
                                           ]
-                                        }
-                                      ],
-                                      "actions": [
-                                        {
-                                          "extension": "limitador",
-                                          "scope": "rlp-ns-A/rlp-name-A",
-                                          "data": {
-                                            "static": {
-                                              "key": "rlp-ns-A/rlp-name-A",
-                                              "value": "1"
-                                            }
-                                          }
                                         }
                                       ]
                                     },
@@ -227,21 +205,9 @@ data:
                                         {
                                           "conditions": [
                                             {
-                                              "allOf": [
-                                                {
-                                                  "selector": "request.url_path",
-                                                  "operator": "startswith",
-                                                  "value": "/unknown-path"
-                                                }
-                                              ]
-                                            }
-                                          ],
-                                          "data": [
-                                            {
-                                              "static": {
-                                                "key": "rlp-ns-B/rlp-name-B/limit-not-to-be-activated",
-                                                "value": "1"
-                                              }
+                                              "selector": "request.url_path",
+                                              "operator": "startswith",
+                                              "value": "/unknown-path"
                                             }
                                           ]
                                         }
@@ -250,12 +216,14 @@ data:
                                         {
                                           "extension": "limitador",
                                           "scope": "rlp-ns-B/rlp-name-B",
-                                          "data": {
-                                            "static": {
-                                              "key": "rlp-ns-B/rlp-name-B",
-                                              "value": "1"
+                                          "data": [
+                                            {
+                                              "static": {
+                                                "key": "rlp-ns-B/rlp-name-B/limit-not-to-be-activated",
+                                                "value": "1"
+                                              }
                                             }
-                                          }
+                                          ]
                                         }
                                       ]
                                     },
@@ -268,122 +236,19 @@ data:
                                         {
                                           "conditions": [
                                             {
-                                              "allOf": [
-                                                {
-                                                  "selector": "request.url_path",
-                                                  "operator": "startswith",
-                                                  "value": "/get"
-                                                },
-                                                {
-                                                  "selector": "request.host",
-                                                  "operator": "eq",
-                                                  "value": "test.c.rlp.com"
-                                                },
-                                                {
-                                                  "selector": "request.method",
-                                                  "operator": "eq",
-                                                  "value": "GET"
-                                                }
-                                              ]
-                                            }
-                                          ],
-                                          "data": [
+                                              "selector": "request.url_path",
+                                              "operator": "startswith",
+                                              "value": "/get"
+                                            },
                                             {
-                                              "static": {
-                                                "key": "limit_to_be_activated",
-                                                "value": "1"
-                                              }
-                                            }
-                                          ]
-                                        },
-                                        {
-                                          "conditions": [
+                                              "selector": "request.host",
+                                              "operator": "eq",
+                                              "value": "test.c.rlp.com"
+                                            },
                                             {
-                                              "allOf": [
-                                                {
-                                                  "selector": "request.url_path",
-                                                  "operator": "startswith",
-                                                  "value": "/get"
-                                                },
-                                                {
-                                                  "selector": "request.host",
-                                                  "operator": "eq",
-                                                  "value": "test.c.rlp.com"
-                                                },
-                                                {
-                                                  "selector": "request.method",
-                                                  "operator": "eq",
-                                                  "value": "GET"
-                                                }
-                                              ]
-                                            }
-                                          ],
-                                          "data": [
-                                            {
-                                              "selector": {
-                                                "selector": "source.address"
-                                              }
-                                            }
-                                          ]
-                                        },
-                                        {
-                                          "conditions": [
-                                            {
-                                              "allOf": [
-                                                {
-                                                  "selector": "request.url_path",
-                                                  "operator": "startswith",
-                                                  "value": "/get"
-                                                },
-                                                {
-                                                  "selector": "request.host",
-                                                  "operator": "eq",
-                                                  "value": "test.c.rlp.com"
-                                                },
-                                                {
-                                                  "selector": "request.method",
-                                                  "operator": "eq",
-                                                  "value": "GET"
-                                                }
-                                              ]
-                                            }
-                                          ],
-                                          "data": [
-                                            {
-                                              "selector": {
-                                                "selector": "request.headers.My-Custom-Header-01"
-                                              }
-                                            }
-                                          ]
-                                        },
-                                        {
-                                          "conditions": [
-                                            {
-                                              "allOf": [
-                                                {
-                                                  "selector": "request.url_path",
-                                                  "operator": "startswith",
-                                                  "value": "/get"
-                                                },
-                                                {
-                                                  "selector": "request.host",
-                                                  "operator": "eq",
-                                                  "value": "test.c.rlp.com"
-                                                },
-                                                {
-                                                  "selector": "request.method",
-                                                  "operator": "eq",
-                                                  "value": "GET"
-                                                }
-                                              ]
-                                            }
-                                          ],
-                                          "data": [
-                                            {
-                                              "selector": {
-                                                "selector": "metadata.filter_metadata.envoy\\.filters\\.http\\.header_to_metadata.user_id",
-                                                "key": "user_id"
-                                              }
+                                              "selector": "request.method",
+                                              "operator": "eq",
+                                              "value": "GET"
                                             }
                                           ]
                                         }
@@ -392,12 +257,30 @@ data:
                                         {
                                           "extension": "limitador",
                                           "scope": "rlp-ns-C/rlp-name-C",
-                                          "data": {
-                                            "static": {
-                                              "key": "rlp-ns-C/rlp-name-C",
-                                              "value": "1"
+                                          "data": [
+                                            {
+                                              "static": {
+                                                "key": "limit_to_be_activated",
+                                                "value": "1"
+                                              }
+                                            },
+                                            {
+                                              "selector": {
+                                                "selector": "source.address"
+                                              }
+                                            },
+                                            {
+                                              "selector": {
+                                                "selector": "request.headers.My-Custom-Header-01"
+                                              }
+                                            },
+                                            {
+                                              "selector": {
+                                                "selector": "metadata.filter_metadata.envoy\\.filters\\.http\\.header_to_metadata.user_id",
+                                                "key": "user_id"
+                                              }
                                             }
-                                          }
+                                          ]
                                         }
                                       ]
                                     }

--- a/utils/deploy/envoy-tls.yaml
+++ b/utils/deploy/envoy-tls.yaml
@@ -170,14 +170,14 @@ data:
                                               "operator": "eq",
                                               "value": "/get"
                                             }
+                                          ],
+                                          "actions": [
+                                            {
+                                              "extension": "authorino",
+                                              "scope": "effective-route-1",
+                                              "data": []
+                                            }
                                           ]
-                                        }
-                                      ],
-                                      "actions": [
-                                        {
-                                          "extension": "authorino",
-                                          "scope": "effective-route-1",
-                                          "data": []
                                         }
                                       ]
                                     },
@@ -188,18 +188,18 @@ data:
                                       ],
                                       "rules": [
                                         {
-                                          "conditions": []
-                                        }
-                                      ],
-                                      "actions": [
-                                        {
-                                          "extension": "limitador",
-                                          "scope": "rlp-ns-A/rlp-name-A",
-                                          "data": [
+                                          "conditions": [],
+                                          "actions": [
                                             {
-                                              "selector": {
-                                                "selector": "unknown.path"
-                                              }
+                                              "extension": "limitador",
+                                              "scope": "rlp-ns-A/rlp-name-A",
+                                              "data": [
+                                                {
+                                                  "selector": {
+                                                    "selector": "unknown.path"
+                                                  }
+                                                }
+                                              ]
                                             }
                                           ]
                                         }
@@ -218,19 +218,19 @@ data:
                                               "operator": "startswith",
                                               "value": "/unknown-path"
                                             }
-                                          ]
-                                        }
-                                      ],
-                                      "actions": [
-                                        {
-                                          "extension": "limitador",
-                                          "scope": "rlp-ns-B/rlp-name-B",
-                                          "data": [
+                                          ],
+                                          "actions": [
                                             {
-                                              "static": {
-                                                "key": "rlp-ns-B/rlp-name-B/limit-not-to-be-activated",
-                                                "value": "1"
-                                              }
+                                              "extension": "limitador",
+                                              "scope": "rlp-ns-B/rlp-name-B",
+                                              "data": [
+                                                {
+                                                  "static": {
+                                                    "key": "rlp-ns-B/rlp-name-B/limit-not-to-be-activated",
+                                                    "value": "1"
+                                                  }
+                                                }
+                                              ]
                                             }
                                           ]
                                         }
@@ -259,35 +259,35 @@ data:
                                               "operator": "eq",
                                               "value": "GET"
                                             }
-                                          ]
-                                        }
-                                      ],
-                                      "actions": [
-                                        {
-                                          "extension": "limitador",
-                                          "scope": "rlp-ns-C/rlp-name-C",
-                                          "data": [
+                                          ],
+                                          "actions": [
                                             {
-                                              "static": {
-                                                "key": "limit_to_be_activated",
-                                                "value": "1"
-                                              }
-                                            },
-                                            {
-                                              "selector": {
-                                                "selector": "source.address"
-                                              }
-                                            },
-                                            {
-                                              "selector": {
-                                                "selector": "request.headers.My-Custom-Header-01"
-                                              }
-                                            },
-                                            {
-                                              "selector": {
-                                                "selector": "metadata.filter_metadata.envoy\\.filters\\.http\\.header_to_metadata.user_id",
-                                                "key": "user_id"
-                                              }
+                                              "extension": "limitador",
+                                              "scope": "rlp-ns-C/rlp-name-C",
+                                              "data": [
+                                                {
+                                                  "static": {
+                                                    "key": "limit_to_be_activated",
+                                                    "value": "1"
+                                                  }
+                                                },
+                                                {
+                                                  "selector": {
+                                                    "selector": "source.address"
+                                                  }
+                                                },
+                                                {
+                                                  "selector": {
+                                                    "selector": "request.headers.My-Custom-Header-01"
+                                                  }
+                                                },
+                                                {
+                                                  "selector": {
+                                                    "selector": "metadata.filter_metadata.envoy\\.filters\\.http\\.header_to_metadata.user_id",
+                                                    "key": "user_id"
+                                                  }
+                                                }
+                                              ]
                                             }
                                           ]
                                         }
@@ -306,24 +306,24 @@ data:
                                               "operator": "eq",
                                               "value": "/get"
                                             }
-                                          ]
-                                        }
-                                      ],
-                                      "actions": [
-                                        {
-                                          "extension": "authorino",
-                                          "scope": "effective-route-1",
-                                          "data": []
-                                        },
-                                        {
-                                          "extension": "limitador",
-                                          "scope": "multi-ns-A/multi-name-A",
-                                          "data": [
+                                          ],
+                                          "actions": [
                                             {
-                                              "selector": {
-                                                "selector": "filter_state.wasm\\.kuadrant\\.identity\\.userid",
-                                                "key": "user_id"
-                                              }
+                                              "extension": "authorino",
+                                              "scope": "effective-route-1",
+                                              "data": []
+                                            },
+                                            {
+                                              "extension": "limitador",
+                                              "scope": "multi-ns-A/multi-name-A",
+                                              "data": [
+                                                {
+                                                  "selector": {
+                                                    "selector": "filter_state.wasm\\.kuadrant\\.identity\\.userid",
+                                                    "key": "user_id"
+                                                  }
+                                                }
+                                              ]
                                             }
                                           ]
                                         }

--- a/utils/deploy/envoy-tls.yaml
+++ b/utils/deploy/envoy-tls.yaml
@@ -166,21 +166,9 @@ data:
                                         {
                                           "conditions": [
                                             {
-                                              "allOf": [
-                                                {
-                                                  "selector": "request.path",
-                                                  "operator": "eq",
-                                                  "value": "/get"
-                                                }
-                                              ]
-                                            }
-                                          ],
-                                          "data": [
-                                            {
-                                              "static": {
-                                                "key": "host",
-                                                "value": "effective-route-1"
-                                              }
+                                              "selector": "request.path",
+                                              "operator": "eq",
+                                              "value": "/get"
                                             }
                                           ]
                                         }
@@ -189,12 +177,7 @@ data:
                                         {
                                           "extension": "authorino",
                                           "scope": "effective-route-1",
-                                          "data": {
-                                            "static": {
-                                              "key": "host",
-                                              "value": "effective-route-1"
-                                            }
-                                          }
+                                          "data": []
                                         }
                                       ]
                                     },
@@ -205,6 +188,13 @@ data:
                                       ],
                                       "rules": [
                                         {
+                                          "conditions": []
+                                        }
+                                      ],
+                                      "actions": [
+                                        {
+                                          "extension": "limitador",
+                                          "scope": "rlp-ns-A/rlp-name-A",
                                           "data": [
                                             {
                                               "selector": {
@@ -212,18 +202,6 @@ data:
                                               }
                                             }
                                           ]
-                                        }
-                                      ],
-                                      "actions": [
-                                        {
-                                          "extension": "limitador",
-                                          "scope": "rlp-ns-A/rlp-name-A",
-                                          "data": {
-                                            "static": {
-                                              "key": "rlp-ns-A/rlp-name-A",
-                                              "value": "1"
-                                            }
-                                          }
                                         }
                                       ]
                                     },
@@ -236,21 +214,9 @@ data:
                                         {
                                           "conditions": [
                                             {
-                                              "allOf": [
-                                                {
-                                                  "selector": "request.url_path",
-                                                  "operator": "startswith",
-                                                  "value": "/unknown-path"
-                                                }
-                                              ]
-                                            }
-                                          ],
-                                          "data": [
-                                            {
-                                              "static": {
-                                                "key": "rlp-ns-B/rlp-name-B/limit-not-to-be-activated",
-                                                "value": "1"
-                                              }
+                                              "selector": "request.url_path",
+                                              "operator": "startswith",
+                                              "value": "/unknown-path"
                                             }
                                           ]
                                         }
@@ -259,12 +225,14 @@ data:
                                         {
                                           "extension": "limitador",
                                           "scope": "rlp-ns-B/rlp-name-B",
-                                          "data": {
-                                            "static": {
-                                              "key": "rlp-ns-B/rlp-name-B",
-                                              "value": "1"
+                                          "data": [
+                                            {
+                                              "static": {
+                                                "key": "rlp-ns-B/rlp-name-B/limit-not-to-be-activated",
+                                                "value": "1"
+                                              }
                                             }
-                                          }
+                                          ]
                                         }
                                       ]
                                     },
@@ -277,122 +245,19 @@ data:
                                         {
                                           "conditions": [
                                             {
-                                              "allOf": [
-                                                {
-                                                  "selector": "request.url_path",
-                                                  "operator": "startswith",
-                                                  "value": "/get"
-                                                },
-                                                {
-                                                  "selector": "request.host",
-                                                  "operator": "eq",
-                                                  "value": "test.c.rlp.com"
-                                                },
-                                                {
-                                                  "selector": "request.method",
-                                                  "operator": "eq",
-                                                  "value": "GET"
-                                                }
-                                              ]
-                                            }
-                                          ],
-                                          "data": [
+                                              "selector": "request.url_path",
+                                              "operator": "startswith",
+                                              "value": "/get"
+                                            },
                                             {
-                                              "static": {
-                                                "key": "limit_to_be_activated",
-                                                "value": "1"
-                                              }
-                                            }
-                                          ]
-                                        },
-                                        {
-                                          "conditions": [
+                                              "selector": "request.host",
+                                              "operator": "eq",
+                                              "value": "test.c.rlp.com"
+                                            },
                                             {
-                                              "allOf": [
-                                                {
-                                                  "selector": "request.url_path",
-                                                  "operator": "startswith",
-                                                  "value": "/get"
-                                                },
-                                                {
-                                                  "selector": "request.host",
-                                                  "operator": "eq",
-                                                  "value": "test.c.rlp.com"
-                                                },
-                                                {
-                                                  "selector": "request.method",
-                                                  "operator": "eq",
-                                                  "value": "GET"
-                                                }
-                                              ]
-                                            }
-                                          ],
-                                          "data": [
-                                            {
-                                              "selector": {
-                                                "selector": "source.address"
-                                              }
-                                            }
-                                          ]
-                                        },
-                                        {
-                                          "conditions": [
-                                            {
-                                              "allOf": [
-                                                {
-                                                  "selector": "request.url_path",
-                                                  "operator": "startswith",
-                                                  "value": "/get"
-                                                },
-                                                {
-                                                  "selector": "request.host",
-                                                  "operator": "eq",
-                                                  "value": "test.c.rlp.com"
-                                                },
-                                                {
-                                                  "selector": "request.method",
-                                                  "operator": "eq",
-                                                  "value": "GET"
-                                                }
-                                              ]
-                                            }
-                                          ],
-                                          "data": [
-                                            {
-                                              "selector": {
-                                                "selector": "request.headers.My-Custom-Header-01"
-                                              }
-                                            }
-                                          ]
-                                        },
-                                        {
-                                          "conditions": [
-                                            {
-                                              "allOf": [
-                                                {
-                                                  "selector": "request.url_path",
-                                                  "operator": "startswith",
-                                                  "value": "/get"
-                                                },
-                                                {
-                                                  "selector": "request.host",
-                                                  "operator": "eq",
-                                                  "value": "test.c.rlp.com"
-                                                },
-                                                {
-                                                  "selector": "request.method",
-                                                  "operator": "eq",
-                                                  "value": "GET"
-                                                }
-                                              ]
-                                            }
-                                          ],
-                                          "data": [
-                                            {
-                                              "selector": {
-                                                "selector": "metadata.filter_metadata.envoy\\.filters\\.http\\.header_to_metadata.user_id",
-                                                "key": "user_id"
-                                              }
+                                              "selector": "request.method",
+                                              "operator": "eq",
+                                              "value": "GET"
                                             }
                                           ]
                                         }
@@ -401,12 +266,30 @@ data:
                                         {
                                           "extension": "limitador",
                                           "scope": "rlp-ns-C/rlp-name-C",
-                                          "data": {
-                                            "static": {
-                                              "key": "rlp-ns-C/rlp-name-C",
-                                              "value": "1"
+                                          "data": [
+                                            {
+                                              "static": {
+                                                "key": "limit_to_be_activated",
+                                                "value": "1"
+                                              }
+                                            },
+                                            {
+                                              "selector": {
+                                                "selector": "source.address"
+                                              }
+                                            },
+                                            {
+                                              "selector": {
+                                                "selector": "request.headers.My-Custom-Header-01"
+                                              }
+                                            },
+                                            {
+                                              "selector": {
+                                                "selector": "metadata.filter_metadata.envoy\\.filters\\.http\\.header_to_metadata.user_id",
+                                                "key": "user_id"
+                                              }
                                             }
-                                          }
+                                          ]
                                         }
                                       ]
                                     }

--- a/utils/deploy/envoy-tls.yaml
+++ b/utils/deploy/envoy-tls.yaml
@@ -292,6 +292,42 @@ data:
                                           ]
                                         }
                                       ]
+                                    },
+                                    {
+                                      "name": "multi-ns-A/multi-name-A",
+                                      "hostnames": [
+                                        "*.a.multi.com"
+                                      ],
+                                      "rules": [
+                                        {
+                                          "conditions": [
+                                            {
+                                              "selector": "request.path",
+                                              "operator": "eq",
+                                              "value": "/get"
+                                            }
+                                          ]
+                                        }
+                                      ],
+                                      "actions": [
+                                        {
+                                          "extension": "authorino",
+                                          "scope": "effective-route-1",
+                                          "data": []
+                                        },
+                                        {
+                                          "extension": "limitador",
+                                          "scope": "multi-ns-A/multi-name-A",
+                                          "data": [
+                                            {
+                                              "selector": {
+                                                "selector": "filter_state.wasm\\.kuadrant\\.identity\\.userid",
+                                                "key": "user_id"
+                                              }
+                                            }
+                                          ]
+                                        }
+                                      ]
                                     }
                                   ]
                                 }

--- a/utils/deploy/envoy-tls.yaml
+++ b/utils/deploy/envoy-tls.yaml
@@ -159,7 +159,6 @@ data:
                                   "policies": [
                                     {
                                       "name": "auth-ns-A/auth-name-A",
-                                      "domain": "effective-route-1",
                                       "hostnames": [
                                         "*.a.auth.com"
                                       ],
@@ -189,6 +188,7 @@ data:
                                       "actions": [
                                         {
                                           "extension": "authorino",
+                                          "scope": "effective-route-1",
                                           "data": {
                                             "static": {
                                               "key": "host",
@@ -200,7 +200,6 @@ data:
                                     },
                                     {
                                       "name": "rlp-ns-A/rlp-name-A",
-                                      "domain": "rlp-ns-A/rlp-name-A",
                                       "hostnames": [
                                         "*.a.rlp.com"
                                       ],
@@ -218,6 +217,7 @@ data:
                                       "actions": [
                                         {
                                           "extension": "limitador",
+                                          "scope": "rlp-ns-A/rlp-name-A",
                                           "data": {
                                             "static": {
                                               "key": "rlp-ns-A/rlp-name-A",
@@ -229,7 +229,6 @@ data:
                                     },
                                     {
                                       "name": "rlp-ns-B/rlp-name-B",
-                                      "domain": "rlp-ns-B/rlp-name-B",
                                       "hostnames": [
                                         "*.b.rlp.com"
                                       ],
@@ -259,6 +258,7 @@ data:
                                       "actions": [
                                         {
                                           "extension": "limitador",
+                                          "scope": "rlp-ns-B/rlp-name-B",
                                           "data": {
                                             "static": {
                                               "key": "rlp-ns-B/rlp-name-B",
@@ -270,7 +270,6 @@ data:
                                     },
                                     {
                                       "name": "rlp-ns-C/rlp-name-C",
-                                      "domain": "rlp-ns-C/rlp-name-C",
                                       "hostnames": [
                                         "*.c.rlp.com"
                                       ],
@@ -401,6 +400,7 @@ data:
                                       "actions": [
                                         {
                                           "extension": "limitador",
+                                          "scope": "rlp-ns-C/rlp-name-C",
                                           "data": {
                                             "static": {
                                               "key": "rlp-ns-C/rlp-name-C",

--- a/utils/docker-compose/limits.yaml
+++ b/utils/docker-compose/limits.yaml
@@ -6,3 +6,15 @@
     - "limit_to_be_activated == '1'"
     - "user_id == 'bob'"
   variables: []
+- namespace: multi-ns-A/multi-name-A
+  max_value: 5
+  seconds: 10
+  conditions:
+    - "user_id == 'alice'"
+  variables: []
+- namespace: multi-ns-A/multi-name-A
+  max_value: 2
+  seconds: 10
+  conditions:
+    - "user_id == 'bob'"
+  variables: []


### PR DESCRIPTION
## Changes

* Moved the `domain` field into the actions and renamed `scope`. This is the `host` for auth ContextExtensions and `domain` for ratelimit
* Started using the `data` field in the actions and removed the `data` field in rules

Example:

```yaml
---
extensions:
  limitador:
    type: ratelimit
    endpoint: limitador-cluster
    failureMode: deny
policies:
  - name: rlp-ns-A/rlp-name-A
    hostnames:
      - '*.toystore.com'
      - example.com
    rules:
      - conditions:
          - selector: request.path
            operator: eq
            value: /admin/toy
          - selector: request.method
            operator: eq
            value: POST
          - selector: request.host
            operator: eq
            value: cars.toystore.com
    actions:
      - extension: limitador
        scope: rlp-ns-A/rlp-name-A
        data:
          - static:
              key: rlp-ns-A/rlp-name-A
              value: "1"
          - selector:
              selector: auth.metadata.username
```

#### In progress

* [x] Move actions into the rules (merged from @didierofrivia in #88)
* [x] Store dynamic metadata from auth in the `filter_state` so it can be retrieved by other actions
* [x] Build the ratelimit descriptors at action time rather than beforehand so we can retrieve aforementioned `filter_state`


## Verification:

Use the new guide in the README to verify multi-action setup:

```
make build && make local-setup
```

Port-forward envoy and watch the logs for all services:
```
kubectl port-forward --namespace default deployment/envoy 8000:8000
kubectl logs -f deployment/envoy
kubectl logs -f deployment/authorino
kubectl logs -f deployment/limitador
```

Test the authenticated rate limiting:
```
curl -H "Host: test.a.multi.com" http://127.0.0.1:8000/get -i
# HTTP/1.1 401 Unauthorized
```

Alice has 5 requests per 10 seconds:
```
while :; do curl --write-out '%{http_code}\n' --silent --output /dev/null -H "Authorization: APIKEY IAMALICE" -H "Host: test.a.multi.com" http://127.0.0.1:8000/get | grep -E --color "\b(429)\b|$"; sleep 1; done
```

Bob has 2 requests per 10 seconds:
```
while :; do curl --write-out '%{http_code}\n' --silent --output /dev/null -H "Authorization: APIKEY IAMBOB" -H "Host: test.a.multi.com" http://127.0.0.1:8000/get | grep -E --color "\b(429)\b|$"; sleep 1; done
```