### PR TITLE
Refactoring actions

### DIFF
--- a/src/operation_dispatcher.rs
+++ b/src/operation_dispatcher.rs
@@ -1,6 +1,6 @@
 use crate::configuration::{Extension, ExtensionType, FailureMode};
 use crate::envoy::RateLimitDescriptor;
-use crate::policy::Policy;
+use crate::policy::Rule;
 use crate::service::grpc_message::GrpcMessageRequest;
 use crate::service::{GetMapValuesBytesFn, GrpcCallFn, GrpcServiceHandler};
 use protobuf::RepeatedField;
@@ -122,16 +122,17 @@ impl OperationDispatcher {
 
     pub fn build_operations(
         &self,
-        policy: &Policy,
+        domain: String, // TODO(didierofrivia): See if can work with &str
+        rule: &Rule,
         descriptors: RepeatedField<RateLimitDescriptor>,
     ) {
         let mut operations: Vec<Operation> = vec![];
-        policy.actions.iter().for_each(|action| {
+        rule.actions.iter().for_each(|action| {
             // TODO(didierofrivia): Error handling
             if let Some(service) = self.service_handlers.get(&action.extension) {
                 let message = GrpcMessageRequest::new(
                     service.get_extension_type(),
-                    policy.domain.clone(),
+                    domain.clone(),
                     descriptors.clone(),
                 );
                 operations.push(Operation::new(

--- a/src/policy_index.rs
+++ b/src/policy_index.rs
@@ -41,13 +41,7 @@ mod tests {
     use crate::policy_index::PolicyIndex;
 
     fn build_ratelimit_policy(name: &str) -> Policy {
-        Policy::new(
-            name.to_owned(),
-            "".to_owned(),
-            Vec::new(),
-            Vec::new(),
-            Vec::new(),
-        )
+        Policy::new(name.to_owned(), "".to_owned(), Vec::new(), Vec::new())
     }
 
     #[test]

--- a/tests/rate_limited.rs
+++ b/tests/rate_limited.rs
@@ -124,26 +124,19 @@ fn it_limits() {
                         }]
                     }
                 ],
-                "data": [
-                  {
-                    "static": {
-                      "key": "admin",
-                      "value": "1"
+                "actions": [
+                    {
+                        "extension": "limitador",
+                        "data": [
+                        {
+                            "static": {
+                              "key": "admin",
+                              "value": "1"
+                            }
+                        }]
                     }
-                  }
                 ]
-            }],
-            "actions": [
-                {
-                    "extension": "limitador",
-                    "data": {
-                        "static": {
-                            "key": "rlp-ns-A/rlp-name-A",
-                            "value": "1"
-                        }
-                    }
-                }
-            ]
+            }]
         }]
     }"#;
 
@@ -191,15 +184,15 @@ fn it_limits() {
         )
         .expect_log(
             Some(LogLevel::Debug),
-            Some("#2 get_property:  selector: request.url_path path: [\"request\", \"url_path\"]"),
+            Some("get_property:  selector: request.url_path path: [\"request\", \"url_path\"]"),
         )
         .expect_log(
             Some(LogLevel::Debug),
-            Some("#2 get_property:  selector: request.host path: [\"request\", \"host\"]"),
+            Some("get_property:  selector: request.host path: [\"request\", \"host\"]"),
         )
         .expect_log(
             Some(LogLevel::Debug),
-            Some("#2 get_property:  selector: request.method path: [\"request\", \"method\"]"),
+            Some("get_property:  selector: request.method path: [\"request\", \"method\"]"),
         )
         .expect_grpc_call(
             Some("limitador-cluster"),
@@ -290,26 +283,20 @@ fn it_passes_additional_headers() {
                         }]
                     }
                 ],
-                "data": [
-                  {
-                    "static": {
-                      "key": "admin",
-                      "value": "1"
+                "actions": [
+                    {
+                        "extension": "limitador",
+                        "data": [
+                          {
+                            "static": {
+                              "key": "admin",
+                              "value": "1"
+                            }
+                          }
+                        ]
                     }
-                  }
                 ]
-            }],
-            "actions": [
-                {
-                    "extension": "limitador",
-                    "data": {
-                        "static": {
-                            "key": "rlp-ns-A/rlp-name-A",
-                            "value": "1"
-                        }
-                    }
-                }
-            ]
+            }]
         }]
     }"#;
 
@@ -357,15 +344,15 @@ fn it_passes_additional_headers() {
         )
         .expect_log(
             Some(LogLevel::Debug),
-            Some("#2 get_property:  selector: request.url_path path: [\"request\", \"url_path\"]"),
+            Some("get_property:  selector: request.url_path path: [\"request\", \"url_path\"]"),
         )
         .expect_log(
             Some(LogLevel::Debug),
-            Some("#2 get_property:  selector: request.host path: [\"request\", \"host\"]"),
+            Some("get_property:  selector: request.host path: [\"request\", \"host\"]"),
         )
         .expect_log(
             Some(LogLevel::Debug),
-            Some("#2 get_property:  selector: request.method path: [\"request\", \"method\"]"),
+            Some("get_property:  selector: request.method path: [\"request\", \"method\"]"),
         )
         .expect_grpc_call(
             Some("limitador-cluster"),
@@ -450,26 +437,19 @@ fn it_rate_limits_with_empty_conditions() {
             "hostnames": ["*.com"],
             "rules": [
             {
-                "data": [
-                  {
-                    "static": {
-                      "key": "admin",
-                      "value": "1"
-                    }
-                  }
-                ]
-            }],
-            "actions": [
+                "actions": [
                 {
                     "extension": "limitador",
-                    "data": {
+                    "data": [
+                      {
                         "static": {
-                            "key": "rlp-ns-A/rlp-name-A",
-                            "value": "1"
+                          "key": "admin",
+                          "value": "1"
                         }
-                    }
-                }
-            ]
+                      }
+                    ]
+                }]
+            }]
         }]
     }"#;
 
@@ -578,25 +558,19 @@ fn it_does_not_rate_limits_when_selector_does_not_exist_and_misses_default_value
             "hostnames": ["*.com"],
             "rules": [
             {
-                "data": [
-                {
-                    "selector": {
-                        "selector": "unknown.path"
+                "actions": [
+                    {
+                        "extension": "limitador",
+                        "data": [
+                            {
+                                "selector": {
+                                    "selector": "unknown.path"
+                                }
+                            }
+                        ]
                     }
-                }
                 ]
-            }],
-            "actions": [
-                {
-                    "extension": "limitador",
-                    "data": {
-                        "static": {
-                            "key": "rlp-ns-A/rlp-name-A",
-                            "value": "1"
-                        }
-                    }
-                }
-            ]
+            }]
         }]
     }"#;
 
@@ -634,15 +608,15 @@ fn it_does_not_rate_limits_when_selector_does_not_exist_and_misses_default_value
         )
         .expect_log(
             Some(LogLevel::Debug),
-            Some("#2 get_property:  selector: unknown.path path: Path { tokens: [\"unknown\", \"path\"] }"),
+            Some("get_property:  selector: unknown.path path: Path { tokens: [\"unknown\", \"path\"] }"),
         )
         .expect_log(
             Some(LogLevel::Debug),
-            Some("#2 build_single_descriptor: selector not found: unknown.path"),
+            Some("build_single_descriptor: selector not found: unknown.path"),
         )
         .expect_log(
             Some(LogLevel::Debug),
-            Some("#2 process_rate_limit_policy: empty descriptors"),
+            Some("#2 process_policy: empty descriptors"),
         )
         .execute_and_expect(ReturnType::Action(Action::Continue))
         .unwrap();


### PR DESCRIPTION
This PR is yet another step closer to get https://github.com/Kuadrant/wasm-shim/issues/58 done.

Now `Actions` reside within a given `Rule`. The logic behind this change is that actions are dependant of the rule that matches, and not a set of actions for all of them.

* Only 1 Rule applies and provides a set of actions
* The building of the descriptors needed for RL is not relying on `Filter` anymore
* Also, the rule matching and descriptors use `hostcalls::get_property` directly


Notes:
* Since we are not passing down the `Filter` anymore for building the descriptors, we are not logging the `context_id` when getting de properties.