### PR TITLE
Refactoring operation dispatcher

### DIFF
--- a/src/filter/root_context.rs
+++ b/src/filter/root_context.rs
@@ -55,7 +55,7 @@ impl RootContext for FilterRoot {
             context_id,
             config: Rc::clone(&self.config),
             response_headers_to_add: Vec::default(),
-            operation_dispatcher: OperationDispatcher::new(service_handlers),
+            operation_dispatcher: OperationDispatcher::new(service_handlers).into(),
         }))
     }
 


### PR DESCRIPTION
This PR cleans a bit the work done for the operation dispatcher. Among the changes:

* `Operations` store its status and result in RefCell for interior mut
* `OperationDispatcher` keeps a `Vec` of `Rc<Operation>`, then indexes cloning the `Rc` **instead** of cloning the entire object.
* Removed `get_current_operation_result` fn that wasn't used.