### PR TITLE
Timeout configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ extensions:
     type: auth
     endpoint: auth-cluster
     failureMode: deny
+    timeout: 10ms
   ratelimit-ext:
     type: ratelimit
     endpoint: ratelimit-cluster

--- a/src/configuration.rs
+++ b/src/configuration.rs
@@ -675,13 +675,13 @@ mod test {
             "authorino": {
                 "type": "auth",
                 "endpoint": "authorino-cluster",
-                "failureMode": "deny"
+                "failureMode": "deny",
                 "timeout": "24ms"
             },
             "limitador": {
                 "type": "ratelimit",
                 "endpoint": "limitador-cluster",
-                "failureMode": "allow"
+                "failureMode": "allow",
                 "timeout": "42ms"
             }
         },
@@ -753,7 +753,7 @@ mod test {
             assert_eq!(auth_extension.extension_type, ExtensionType::Auth);
             assert_eq!(auth_extension.endpoint, "authorino-cluster");
             assert_eq!(auth_extension.failure_mode, FailureMode::Deny);
-            assert_eq!(auth_extension.timeout, Timeout(Duration::from_millis(24)));
+            assert_eq!(auth_extension.timeout, Timeout(Duration::from_millis(24)))
         } else {
             panic!()
         }
@@ -762,7 +762,7 @@ mod test {
             assert_eq!(rl_extension.extension_type, ExtensionType::RateLimit);
             assert_eq!(rl_extension.endpoint, "limitador-cluster");
             assert_eq!(rl_extension.failure_mode, FailureMode::Allow);
-            assert_eq!(rl_extension.timeout, Timeout(Duration::from_millis(42)));
+            assert_eq!(rl_extension.timeout, Timeout(Duration::from_millis(42)))
         } else {
             panic!()
         }

--- a/src/operation_dispatcher.rs
+++ b/src/operation_dispatcher.rs
@@ -60,9 +60,12 @@ impl Operation {
     fn trigger(&self) -> Result<u32, Status> {
         if let Some(message) = (self.grpc_message_build_fn)(self.get_extension_type(), &self.action)
         {
-            let res = self
-                .service
-                .send(self.get_map_values_bytes_fn, self.grpc_call_fn, message);
+            let res = self.service.send(
+                self.get_map_values_bytes_fn,
+                self.grpc_call_fn,
+                message,
+                self.extension.timeout.0,
+            );
             self.set_result(res);
             self.next_state();
             res
@@ -229,6 +232,7 @@ fn grpc_message_build_fn(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::configuration::Timeout;
     use crate::envoy::RateLimitRequest;
     use protobuf::RepeatedField;
     use std::time::Duration;
@@ -283,6 +287,7 @@ mod tests {
                 extension_type,
                 endpoint: "local".to_string(),
                 failure_mode: FailureMode::Deny,
+                timeout: Timeout(Duration::from_millis(42)),
             }),
             action: Action {
                 extension: "local".to_string(),

--- a/src/service.rs
+++ b/src/service.rs
@@ -125,6 +125,7 @@ impl GrpcServiceHandler {
         get_map_values_bytes_fn: GetMapValuesBytesFn,
         grpc_call_fn: GrpcCallFn,
         message: GrpcMessageRequest,
+        timeout: Duration,
     ) -> Result<u32, Status> {
         let msg = Message::write_to_bytes(&message).unwrap();
         let metadata = self
@@ -140,7 +141,7 @@ impl GrpcServiceHandler {
             self.service.method(),
             metadata,
             Some(&msg),
-            Duration::from_secs(5),
+            timeout,
         )
     }
 

--- a/tests/auth.rs
+++ b/tests/auth.rs
@@ -9,7 +9,8 @@ const CONFIG: &str = r#"{
             "authorino": {
                 "type": "auth",
                 "endpoint": "authorino-cluster",
-                "failureMode": "deny"
+                "failureMode": "deny",
+                "timeout": "5s"
             }
         },
         "policies": [

--- a/tests/multi.rs
+++ b/tests/multi.rs
@@ -10,12 +10,14 @@ const CONFIG: &str = r#"{
             "authorino": {
                 "type": "auth",
                 "endpoint": "authorino-cluster",
-                "failureMode": "deny"
+                "failureMode": "deny",
+                "timeout": "5s"
             },
             "limitador": {
                 "type": "ratelimit",
                 "endpoint": "limitador-cluster",
-                "failureMode": "deny"
+                "failureMode": "deny",
+                "timeout": "5s"
             }
         },
         "policies": [

--- a/tests/rate_limited.rs
+++ b/tests/rate_limited.rs
@@ -87,7 +87,8 @@ fn it_limits() {
             "limitador": {
                 "type": "ratelimit",
                 "endpoint": "limitador-cluster",
-                "failureMode": "deny"
+                "failureMode": "deny",
+                "timeout": "5s"
             }
         },
         "policies": [
@@ -242,7 +243,8 @@ fn it_passes_additional_headers() {
             "limitador": {
                 "type": "ratelimit",
                 "endpoint": "limitador-cluster",
-                "failureMode": "deny"
+                "failureMode": "deny",
+                "timeout": "5s"
             }
         },
         "policies": [
@@ -411,7 +413,8 @@ fn it_rate_limits_with_empty_conditions() {
             "limitador": {
                 "type": "ratelimit",
                 "endpoint": "limitador-cluster",
-                "failureMode": "deny"
+                "failureMode": "deny",
+                "timeout": "5s"
             }
         },
         "policies": [
@@ -529,7 +532,8 @@ fn it_does_not_rate_limits_when_selector_does_not_exist_and_misses_default_value
             "limitador": {
                 "type": "ratelimit",
                 "endpoint": "limitador-cluster",
-                "failureMode": "deny"
+                "failureMode": "deny",
+                "timeout": "5s"
             }
         },
         "policies": [


### PR DESCRIPTION
Closes https://github.com/Kuadrant/wasm-shim/issues/93

**Example config:**

```yaml
extensions:
  limitador:
    type: "ratelimit",
    endpoint: "limitador-cluster",
    failureMode: "deny",
    timeout: "5s"
policies:
...
```

The timeout value must be string, and must be in the format of a duration. Default to `20ms`

**Examples of valid timeout values:**
* 1ms parses as 1 millisecond
* 1.5ms parses as 1 millisecond and 500 microseconds
* 5s parses as 5 seconds

