### PR TITLE
Config revamp

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ actionSets:
     actions:
     - service: ratelimit-service
       scope: rlp-ns-A/rlp-name-A
+      conditions: []
       data:
       - selector:
           selector: request.headers.My-Custom-Header

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ extensions:
     type: ratelimit
     endpoint: ratelimit-cluster
     failureMode: deny
-policies:
+actionSets:
   - name: rlp-ns-A/rlp-name-A
     hostnames: [ "*.toystore.com" ]
     rules:
@@ -163,7 +163,7 @@ To expose the envoy endpoint run the following:
 kubectl port-forward --namespace default deployment/envoy 8000:8000
 ```
 
-There is then a single auth policy defined for e2e testing:
+There is then a single auth action set defined for e2e testing:
 
 * `auth-a` which defines auth is required for requests to `/get` for the `AuthConfig` with `effective-route-1`
 
@@ -177,7 +177,7 @@ curl -H "Host: test.a.auth.com" -H "Authorization: APIKEY IAMALICE" http://127.0
 # HTTP/1.1 200 OK
 ```
 
-And some rate limit policies defined for e2e testing:
+And some rate limit action sets defined for e2e testing:
 
 * `rlp-a`: Only one data item. Data selector should not generate return any value. Thus, descriptor should be empty and
   rate limiting service should **not** be called.

--- a/README.md
+++ b/README.md
@@ -34,15 +34,15 @@ actionSets:
       - selector: request.method
         operator: eq
         value: GET
-      actions:
-      - extension: ratelimit-ext
-        scope: rlp-ns-A/rlp-name-A
-        data:
-          - selector:
-              selector: request.headers.My-Custom-Header
-          - static:
-              key: admin
-              value: "1"
+    actions:
+    - extension: ratelimit-ext
+      scope: rlp-ns-A/rlp-name-A
+      data:
+      - selector:
+          selector: request.headers.My-Custom-Header
+      - static:
+          key: admin
+          value: "1"
 ```
 
 ## Features

--- a/README.md
+++ b/README.md
@@ -10,13 +10,13 @@ A Proxy-Wasm module written in Rust, acting as a shim between Envoy and Limitado
 Following is a sample configuration used by the shim.
 
 ```yaml
-extensions:
-  auth-ext:
+services:
+  auth-service:
     type: auth
     endpoint: auth-cluster
     failureMode: deny
     timeout: 10ms
-  ratelimit-ext:
+  ratelimit-service:
     type: ratelimit
     endpoint: ratelimit-cluster
     failureMode: deny
@@ -35,7 +35,7 @@ actionSets:
         operator: eq
         value: GET
     actions:
-    - extension: ratelimit-ext
+    - service: ratelimit-service
       scope: rlp-ns-A/rlp-name-A
       data:
       - selector:

--- a/README.md
+++ b/README.md
@@ -22,8 +22,8 @@ extensions:
     failureMode: deny
 actionSets:
   - name: rlp-ns-A/rlp-name-A
-    hostnames: [ "*.toystore.com" ]
     routeRuleConditions:
+      hostnames: [ "*.toystore.com" ]
       matches:
       - selector: request.url_path
         operator: startswith

--- a/README.md
+++ b/README.md
@@ -23,18 +23,17 @@ extensions:
 actionSets:
   - name: rlp-ns-A/rlp-name-A
     hostnames: [ "*.toystore.com" ]
-    rules:
-    - conditions:
-      - allOf:
-        - selector: request.url_path
-          operator: startswith
-          value: /get
-        - selector: request.host
-          operator: eq
-          value: test.toystore.com
-        - selector: request.method
-          operator: eq
-          value: GET
+    routeRuleConditions:
+      matches:
+      - selector: request.url_path
+        operator: startswith
+        value: /get
+      - selector: request.host
+        operator: eq
+        value: test.toystore.com
+      - selector: request.method
+        operator: eq
+        value: GET
       actions:
       - extension: ratelimit-ext
         scope: rlp-ns-A/rlp-name-A

--- a/e2e/remote-address/README.md
+++ b/e2e/remote-address/README.md
@@ -14,10 +14,10 @@ The Wasm configuration defines a set of rules for `*.example.com`.
 ```yaml
 {
     "name": "ratelimit-source",
-    "hostnames": [
-        "*.example.com"
-    ],
     "routeRuleConditions": {
+        "hostnames": [
+          "*.example.com"
+        ],
         "matches": [
             {
                 "selector": "source.remote_address",

--- a/e2e/remote-address/README.md
+++ b/e2e/remote-address/README.md
@@ -24,21 +24,21 @@ The Wasm configuration defines a set of rules for `*.example.com`.
                 "operator": "neq",
                 "value": "50.0.0.1"
             }
-        ],
-        "actions": [
-            {
-                "extension": "limitador",
-                "scope": "ratelimit-source",
-                "data": [
-                    {
-                        "selector": {
-                            "selector": "source.remote_address"
-                        }
-                    }
-                ]
-            }
         ]
-    }
+    },
+    "actions": [
+        {
+            "extension": "limitador",
+            "scope": "ratelimit-source",
+            "data": [
+                {
+                    "selector": {
+                        "selector": "source.remote_address"
+                    }
+                }
+            ]
+        }
+    ]
 }
 ```
 

--- a/e2e/remote-address/README.md
+++ b/e2e/remote-address/README.md
@@ -28,7 +28,7 @@ The Wasm configuration defines a set of rules for `*.example.com`.
     },
     "actions": [
         {
-            "extension": "limitador",
+            "service": "limitador",
             "scope": "ratelimit-source",
             "data": [
                 {

--- a/e2e/remote-address/README.md
+++ b/e2e/remote-address/README.md
@@ -17,34 +17,28 @@ The Wasm configuration defines a set of rules for `*.example.com`.
     "hostnames": [
         "*.example.com"
     ],
-    "rules": [
-        {
-            "conditions": [
-                {
-                    "allOf": [
+    "routeRuleConditions": {
+        "matches": [
+            {
+                "selector": "source.remote_address",
+                "operator": "neq",
+                "value": "50.0.0.1"
+            }
+        ],
+        "actions": [
+            {
+                "extension": "limitador",
+                "scope": "ratelimit-source",
+                "data": [
                     {
-                        "selector": "source.remote_address",
-                        "operator": "neq",
-                        "value": "50.0.0.1"
-                    }
-                    ]
-                }
-            ],
-            "actions": [
-                {
-                    "extension": "limitador",
-                    "scope": "ratelimit-source",
-                    "data": [
-                        {
-                            "selector": {
-                                "selector": "source.remote_address"
-                            }
+                        "selector": {
+                            "selector": "source.remote_address"
                         }
-                    ]
-                }
-            ]
-        }
-    ]
+                    }
+                ]
+            }
+        ]
+    }
 }
 ```
 

--- a/e2e/remote-address/envoy.yaml
+++ b/e2e/remote-address/envoy.yaml
@@ -56,34 +56,28 @@ static_resources:
                               "hostnames": [
                                 "*.example.com"
                               ],
-                              "rules": [
-                                {
-                                  "conditions": [
-                                    {
-                                      "allOf": [
-                                        {
-                                          "selector": "source.remote_address",
-                                          "operator": "neq",
-                                          "value": "50.0.0.1"
+                              "routeRuleConditions": {
+                                "matches": [
+                                  {
+                                    "selector": "source.remote_address",
+                                    "operator": "neq",
+                                    "value": "50.0.0.1"
+                                  }
+                                ],
+                                "actions": [
+                                  {
+                                    "extension": "limitador",
+                                    "scope": "ratelimit-source",
+                                    "data": [
+                                      {
+                                        "selector": {
+                                          "selector": "source.remote_address"
                                         }
-                                      ]
-                                    }
-                                  ],
-                                  "actions": [
-                                    {
-                                      "extension": "limitador",
-                                      "scope": "ratelimit-source",
-                                      "data": [
-                                        {
-                                          "selector": {
-                                            "selector": "source.remote_address"
-                                          }
-                                        }
-                                      ]
-                                    }
-                                  ]
-                                }
-                              ]
+                                      }
+                                    ]
+                                  }
+                                ]
+                              }
                             }
                           ]
                         }

--- a/e2e/remote-address/envoy.yaml
+++ b/e2e/remote-address/envoy.yaml
@@ -63,21 +63,21 @@ static_resources:
                                     "operator": "neq",
                                     "value": "50.0.0.1"
                                   }
-                                ],
-                                "actions": [
-                                  {
-                                    "extension": "limitador",
-                                    "scope": "ratelimit-source",
-                                    "data": [
-                                      {
-                                        "selector": {
-                                          "selector": "source.remote_address"
-                                        }
-                                      }
-                                    ]
-                                  }
                                 ]
-                              }
+                              },
+                              "actions": [
+                                {
+                                  "extension": "limitador",
+                                  "scope": "ratelimit-source",
+                                  "data": [
+                                    {
+                                      "selector": {
+                                        "selector": "source.remote_address"
+                                      }
+                                    }
+                                  ]
+                                }
+                              ]
                             }
                           ]
                         }

--- a/e2e/remote-address/envoy.yaml
+++ b/e2e/remote-address/envoy.yaml
@@ -43,7 +43,7 @@ static_resources:
                       "@type": "type.googleapis.com/google.protobuf.StringValue"
                       value: >
                         {
-                          "extensions": {
+                          "services": {
                             "limitador": {
                               "type": "ratelimit",
                               "endpoint": "limitador",
@@ -67,7 +67,7 @@ static_resources:
                               },
                               "actions": [
                                 {
-                                  "extension": "limitador",
+                                  "service": "limitador",
                                   "scope": "ratelimit-source",
                                   "data": [
                                     {

--- a/e2e/remote-address/envoy.yaml
+++ b/e2e/remote-address/envoy.yaml
@@ -53,10 +53,10 @@ static_resources:
                           "actionSets": [
                             {
                               "name": "ratelimit-source",
-                              "hostnames": [
-                                "*.example.com"
-                              ],
                               "routeRuleConditions": {
+                                "hostnames": [
+                                  "*.example.com"
+                                ],
                                 "matches": [
                                   {
                                     "selector": "source.remote_address",

--- a/e2e/remote-address/envoy.yaml
+++ b/e2e/remote-address/envoy.yaml
@@ -50,7 +50,7 @@ static_resources:
                               "failureMode": "deny"
                             }
                           },
-                          "policies": [
+                          "actionSets": [
                             {
                               "name": "ratelimit-source",
                               "hostnames": [

--- a/src/configuration.rs
+++ b/src/configuration.rs
@@ -425,7 +425,7 @@ impl TryFrom<PluginConfiguration> for FilterConfig {
                     return Err(result.err().unwrap());
                 }
             }
-            for action in &action_set.route_rule_conditions.actions {
+            for action in &action_set.actions {
                 for datum in &action.data {
                     let result = datum.item.compile();
                     if result.is_err() {
@@ -652,29 +652,29 @@ mod test {
                     "selector": "request.host",
                     "operator": "eq",
                     "value": "cars.toystore.com"
-                }],
-                "actions": [
+                }]
+            },
+            "actions": [
+            {
+                "extension": "authorino",
+                "scope": "authconfig-A"
+            },
+            {
+                "extension": "limitador",
+                "scope": "rlp-ns-A/rlp-name-A",
+                "data": [
                 {
-                    "extension": "authorino",
-                    "scope": "authconfig-A"
+                    "static": {
+                        "key": "rlp-ns-A/rlp-name-A",
+                        "value": "1"
+                    }
                 },
                 {
-                    "extension": "limitador",
-                    "scope": "rlp-ns-A/rlp-name-A",
-                    "data": [
-                    {
-                        "static": {
-                            "key": "rlp-ns-A/rlp-name-A",
-                            "value": "1"
-                        }
-                    },
-                    {
-                        "selector": {
-                            "selector": "auth.metadata.username"
-                        }
-                    }]
+                    "selector": {
+                        "selector": "auth.metadata.username"
+                    }
                 }]
-            }
+            }]
         }]
     }"#;
 
@@ -710,11 +710,10 @@ mod test {
             panic!()
         }
 
-        let route_rule_conditions = &filter_config.action_sets[0].route_rule_conditions;
-        let matches = &route_rule_conditions.matches;
+        let matches = &filter_config.action_sets[0].route_rule_conditions.matches;
         assert_eq!(matches.len(), 3);
 
-        let actions = &route_rule_conditions.actions;
+        let actions = &filter_config.action_sets[0].actions;
         assert_eq!(actions.len(), 2);
 
         let auth_action = &actions[0];
@@ -788,21 +787,21 @@ mod test {
             {
                 "name": "rlp-ns-A/rlp-name-A",
                 "routeRuleConditions": {
-                    "hostnames": ["*.toystore.com", "example.com"],
-                    "actions": [
+                    "hostnames": ["*.toystore.com", "example.com"]
+                },
+                "actions": [
+                {
+                    "extension": "limitador",
+                    "scope": "rlp-ns-A/rlp-name-A",
+                    "data": [
                     {
-                        "extension": "limitador",
-                        "scope": "rlp-ns-A/rlp-name-A",
-                        "data": [
-                        {
-                            "selector": {
-                                "selector": "my.selector.path",
-                                "key": "mykey",
-                                "default": "my_selector_default_value"
-                            }
-                        }]
+                        "selector": {
+                            "selector": "my.selector.path",
+                            "key": "mykey",
+                            "default": "my_selector_default_value"
+                        }
                     }]
-                }
+                }]
             }]
         }"#;
         let res = serde_json::from_str::<PluginConfiguration>(config);
@@ -814,8 +813,7 @@ mod test {
         let filter_config = res.unwrap();
         assert_eq!(filter_config.action_sets.len(), 1);
 
-        let route_rule_conditions = &filter_config.action_sets[0].route_rule_conditions;
-        let actions = &route_rule_conditions.actions;
+        let actions = &filter_config.action_sets[0].actions;
         assert_eq!(actions.len(), 1);
 
         let data_items = &actions[0].data;
@@ -873,14 +871,14 @@ mod test {
                         "selector": "request.host",
                         "operator": "matches",
                         "value": "*.com"
-                    }],
-                    "actions": [
-                    {
-                        "extension": "limitador",
-                        "scope": "rlp-ns-A/rlp-name-A",
-                        "data": [ { "selector": { "selector": "my.selector.path" } }]
                     }]
-                }
+                },
+                "actions": [
+                {
+                    "extension": "limitador",
+                    "scope": "rlp-ns-A/rlp-name-A",
+                    "data": [ { "selector": { "selector": "my.selector.path" } }]
+                }]
             }]
         }"#;
         let res = serde_json::from_str::<PluginConfiguration>(config);
@@ -892,8 +890,7 @@ mod test {
         let filter_config = res.unwrap();
         assert_eq!(filter_config.action_sets.len(), 1);
 
-        let route_rule_conditions = &filter_config.action_sets[0].route_rule_conditions;
-        let matches = &route_rule_conditions.matches;
+        let matches = &filter_config.action_sets[0].route_rule_conditions.matches;
         assert_eq!(matches.len(), 5);
 
         let expected_conditions = [
@@ -926,25 +923,25 @@ mod test {
             {
                 "name": "rlp-ns-A/rlp-name-A",
                 "routeRuleConditions": {
-                    "hostnames": ["*.toystore.com", "example.com"],
-                    "actions": [
+                    "hostnames": ["*.toystore.com", "example.com"]
+                },
+                "actions": [
+                {
+                    "extension": "limitador",
+                    "scope": "rlp-ns-A/rlp-name-A",
+                    "data": [
                     {
-                        "extension": "limitador",
-                        "scope": "rlp-ns-A/rlp-name-A",
-                        "data": [
-                        {
-                            "static": {
-                                "key": "rlp-ns-A/rlp-name-A",
-                                "value": "1"
-                            }
-                        },
-                        {
-                            "selector": {
-                                "selector": "auth.metadata.username"
-                            }
-                        }]
+                        "static": {
+                            "key": "rlp-ns-A/rlp-name-A",
+                            "value": "1"
+                        }
+                    },
+                    {
+                        "selector": {
+                            "selector": "auth.metadata.username"
+                        }
                     }]
-                }
+                }]
             }]
         }"#;
         let res = serde_json::from_str::<PluginConfiguration>(config);
@@ -962,8 +959,7 @@ mod test {
             Timeout(Duration::from_millis(20))
         );
 
-        let route_rule_conditions = &filter_config.action_sets[0].route_rule_conditions;
-        let matches = &route_rule_conditions.matches;
+        let matches = &filter_config.action_sets[0].route_rule_conditions.matches;
         assert_eq!(matches.len(), 0);
     }
 
@@ -982,23 +978,23 @@ mod test {
         {
             "name": "rlp-ns-A/rlp-name-A",
             "routeRuleConditions": {
-                "hostnames": ["*.toystore.com", "example.com"],
-                "actions": [
+                "hostnames": ["*.toystore.com", "example.com"]
+            },
+            "actions": [
+            {
+                "extension": "limitador",
+                "scope": "rlp-ns-A/rlp-name-A",
+                "data": [
                 {
-                    "extension": "limitador",
-                    "scope": "rlp-ns-A/rlp-name-A",
-                    "data": [
-                    {
-                        "static": {
-                            "key": "rlp-ns-A/rlp-name-A",
-                            "value": "1"
-                        },
-                        "selector": {
-                            "selector": "auth.metadata.username"
-                        }
-                    }]
+                    "static": {
+                        "key": "rlp-ns-A/rlp-name-A",
+                        "value": "1"
+                    },
+                    "selector": {
+                        "selector": "auth.metadata.username"
+                    }
                 }]
-            }
+            }]
         }]
         }"#;
         let res = serde_json::from_str::<PluginConfiguration>(bad_config);
@@ -1017,20 +1013,20 @@ mod test {
         {
             "name": "rlp-ns-A/rlp-name-A",
             "routeRuleConditions": {
-                "hostnames": ["*.toystore.com", "example.com"],
-                "actions": [
+                "hostnames": ["*.toystore.com", "example.com"]
+            },
+            "actions": [
+            {
+                "extension": "limitador",
+                "scope": "rlp-ns-A/rlp-name-A",
+                "data": [
                 {
-                    "extension": "limitador",
-                    "scope": "rlp-ns-A/rlp-name-A",
-                    "data": [
-                    {
-                        "unknown": {
-                            "key": "rlp-ns-A/rlp-name-A",
-                            "value": "1"
-                        }
-                    }]
+                    "unknown": {
+                        "key": "rlp-ns-A/rlp-name-A",
+                        "value": "1"
+                    }
                 }]
-            }
+            }]
         }]
         }"#;
         let res = serde_json::from_str::<PluginConfiguration>(bad_config);
@@ -1055,14 +1051,14 @@ mod test {
                         "selector": "request.path",
                         "operator": "unknown",
                         "value": "/admin/toy"
-                    }],
-                    "actions": [
-                    {
-                        "extension": "limitador",
-                        "scope": "rlp-ns-A/rlp-name-A",
-                        "data": [ { "selector": { "selector": "my.selector.path" } }]
                     }]
-                }
+                },
+                "actions": [
+                {
+                    "extension": "limitador",
+                    "scope": "rlp-ns-A/rlp-name-A",
+                    "data": [ { "selector": { "selector": "my.selector.path" } }]
+                }]
             }]
         }"#;
         let res = serde_json::from_str::<PluginConfiguration>(bad_config);

--- a/src/configuration.rs
+++ b/src/configuration.rs
@@ -7,19 +7,17 @@ use std::sync::Arc;
 use crate::attribute::Attribute;
 use crate::configuration::action_set::ActionSet;
 use crate::configuration::action_set_index::ActionSetIndex;
-use crate::envoy::{RateLimitDescriptor, RateLimitDescriptor_Entry};
 use crate::property_path::Path;
 use crate::service::GrpcService;
 use cel_interpreter::functions::duration;
 use cel_interpreter::objects::ValueType;
 use cel_interpreter::{Context, Expression, Value};
 use cel_parser::{Atom, RelationOp};
-use log::debug;
-use protobuf::RepeatedField;
 use serde::de::{Error, Visitor};
 use serde::{Deserialize, Deserializer};
 use std::time::Duration;
 
+pub mod action;
 pub mod action_set;
 mod action_set_index;
 
@@ -529,87 +527,6 @@ impl<'de> Visitor<'de> for TimeoutVisitor {
             Err(e) => Err(E::custom(e)),
             _ => Err(E::custom("Unsupported Duration Value")),
         }
-    }
-}
-
-#[derive(Deserialize, Debug, Clone)]
-#[serde(rename_all = "camelCase")]
-pub struct Action {
-    pub extension: String,
-    pub scope: String,
-    #[serde(default)]
-    pub data: Vec<DataItem>,
-}
-
-impl Action {
-    pub fn build_descriptors(&self) -> RepeatedField<RateLimitDescriptor> {
-        let mut entries = RepeatedField::new();
-        if let Some(desc) = self.build_single_descriptor() {
-            entries.push(desc);
-        }
-        entries
-    }
-
-    fn build_single_descriptor(&self) -> Option<RateLimitDescriptor> {
-        let mut entries = RepeatedField::default();
-
-        // iterate over data items to allow any data item to skip the entire descriptor
-        for data in self.data.iter() {
-            match &data.item {
-                DataType::Static(static_item) => {
-                    let mut descriptor_entry = RateLimitDescriptor_Entry::new();
-                    descriptor_entry.set_key(static_item.key.to_owned());
-                    descriptor_entry.set_value(static_item.value.to_owned());
-                    entries.push(descriptor_entry);
-                }
-                DataType::Selector(selector_item) => {
-                    let descriptor_key = match &selector_item.key {
-                        None => selector_item.path().to_string(),
-                        Some(key) => key.to_owned(),
-                    };
-
-                    let attribute_path = selector_item.path();
-
-                    let value = match crate::property::get_property(attribute_path.tokens())
-                        .unwrap()
-                    {
-                        //TODO(didierofrivia): Replace hostcalls by DI
-                        None => {
-                            debug!(
-                                "build_single_descriptor: selector not found: {}",
-                                attribute_path
-                            );
-                            match &selector_item.default {
-                                None => return None, // skipping the entire descriptor
-                                Some(default_value) => default_value.clone(),
-                            }
-                        }
-                        // TODO(eastizle): not all fields are strings
-                        // https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/advanced/attributes
-                        Some(attribute_bytes) => match Attribute::parse(attribute_bytes) {
-                            Ok(attr_str) => attr_str,
-                            Err(e) => {
-                                debug!("build_single_descriptor: failed to parse selector value: {}, error: {}",
-                                    attribute_path, e);
-                                return None;
-                            }
-                        },
-                        // Alternative implementation (for rust >= 1.76)
-                        // Attribute::parse(attribute_bytes)
-                        //   .inspect_err(|e| debug!("#{} build_single_descriptor: failed to parse selector value: {}, error: {}",
-                        //           filter.context_id, attribute_path, e))
-                        //   .ok()?,
-                    };
-                    let mut descriptor_entry = RateLimitDescriptor_Entry::new();
-                    descriptor_entry.set_key(descriptor_key);
-                    descriptor_entry.set_value(value);
-                    entries.push(descriptor_entry);
-                }
-            }
-        }
-        let mut res = RateLimitDescriptor::new();
-        res.set_entries(entries);
-        Some(res)
     }
 }
 

--- a/src/configuration.rs
+++ b/src/configuration.rs
@@ -434,7 +434,7 @@ impl TryFrom<PluginConfiguration> for FilterConfig {
                 }
             }
 
-            for hostname in action_set.hostnames.iter() {
+            for hostname in action_set.route_rule_conditions.hostnames.iter() {
                 index.insert(hostname, Rc::new(action_set.clone()));
             }
         }
@@ -635,8 +635,8 @@ mod test {
         "actionSets": [
         {
             "name": "rlp-ns-A/rlp-name-A",
-            "hostnames": ["*.toystore.com", "example.com"],
             "routeRuleConditions": {
+                "hostnames": ["*.toystore.com", "example.com"],
                 "matches": [
                 {
                     "selector": "request.path",
@@ -787,8 +787,8 @@ mod test {
             "actionSets": [
             {
                 "name": "rlp-ns-A/rlp-name-A",
-                "hostnames": ["*.toystore.com", "example.com"],
                 "routeRuleConditions": {
+                    "hostnames": ["*.toystore.com", "example.com"],
                     "actions": [
                     {
                         "extension": "limitador",
@@ -846,8 +846,8 @@ mod test {
             "actionSets": [
             {
                 "name": "rlp-ns-A/rlp-name-A",
-                "hostnames": ["*.toystore.com", "example.com"],
                 "routeRuleConditions": {
+                    "hostnames": ["*.toystore.com", "example.com"],
                     "matches": [
                     {
                         "selector": "request.path",
@@ -925,8 +925,8 @@ mod test {
             "actionSets": [
             {
                 "name": "rlp-ns-A/rlp-name-A",
-                "hostnames": ["*.toystore.com", "example.com"],
                 "routeRuleConditions": {
+                    "hostnames": ["*.toystore.com", "example.com"],
                     "actions": [
                     {
                         "extension": "limitador",
@@ -981,8 +981,8 @@ mod test {
         "actionSets": [
         {
             "name": "rlp-ns-A/rlp-name-A",
-            "hostnames": ["*.toystore.com", "example.com"],
             "routeRuleConditions": {
+                "hostnames": ["*.toystore.com", "example.com"],
                 "actions": [
                 {
                     "extension": "limitador",
@@ -1016,10 +1016,8 @@ mod test {
         "actionSets": [
         {
             "name": "rlp-ns-A/rlp-name-A",
-            "service": "limitador-cluster",
-            "hostnames": ["*.toystore.com", "example.com"],
-            "routeRuleConditions": [
-            {
+            "routeRuleConditions": {
+                "hostnames": ["*.toystore.com", "example.com"],
                 "actions": [
                 {
                     "extension": "limitador",
@@ -1032,7 +1030,7 @@ mod test {
                         }
                     }]
                 }]
-            }]
+            }
         }]
         }"#;
         let res = serde_json::from_str::<PluginConfiguration>(bad_config);
@@ -1050,8 +1048,8 @@ mod test {
             "actionSets": [
             {
                 "name": "rlp-ns-A/rlp-name-A",
-                "hostnames": ["*.toystore.com", "example.com"],
                 "routeRuleConditions": {
+                    "hostnames": ["*.toystore.com", "example.com"],
                     "matches": [
                     {
                         "selector": "request.path",

--- a/src/configuration/action.rs
+++ b/src/configuration/action.rs
@@ -1,5 +1,5 @@
 use crate::attribute::Attribute;
-use crate::configuration::{DataItem, DataType};
+use crate::configuration::{DataItem, DataType, PatternExpression};
 use crate::envoy::{RateLimitDescriptor, RateLimitDescriptor_Entry};
 use log::debug;
 use protobuf::RepeatedField;
@@ -11,10 +11,16 @@ pub struct Action {
     pub service: String,
     pub scope: String,
     #[serde(default)]
+    pub conditions: Vec<PatternExpression>,
+    #[serde(default)]
     pub data: Vec<DataItem>,
 }
 
 impl Action {
+    pub fn conditions_apply(&self) -> bool {
+        self.conditions.is_empty() || self.conditions.iter().all(|m| m.applies())
+    }
+
     pub fn build_descriptors(&self) -> RepeatedField<RateLimitDescriptor> {
         let mut entries = RepeatedField::new();
         if let Some(desc) = self.build_single_descriptor() {

--- a/src/configuration/action.rs
+++ b/src/configuration/action.rs
@@ -8,7 +8,7 @@ use serde::Deserialize;
 #[derive(Deserialize, Debug, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct Action {
-    pub extension: String,
+    pub service: String,
     pub scope: String,
     #[serde(default)]
     pub data: Vec<DataItem>,

--- a/src/configuration/action.rs
+++ b/src/configuration/action.rs
@@ -1,0 +1,86 @@
+use crate::attribute::Attribute;
+use crate::configuration::{DataItem, DataType};
+use crate::envoy::{RateLimitDescriptor, RateLimitDescriptor_Entry};
+use log::debug;
+use protobuf::RepeatedField;
+use serde::Deserialize;
+
+#[derive(Deserialize, Debug, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct Action {
+    pub extension: String,
+    pub scope: String,
+    #[serde(default)]
+    pub data: Vec<DataItem>,
+}
+
+impl Action {
+    pub fn build_descriptors(&self) -> RepeatedField<RateLimitDescriptor> {
+        let mut entries = RepeatedField::new();
+        if let Some(desc) = self.build_single_descriptor() {
+            entries.push(desc);
+        }
+        entries
+    }
+
+    fn build_single_descriptor(&self) -> Option<RateLimitDescriptor> {
+        let mut entries = RepeatedField::default();
+
+        // iterate over data items to allow any data item to skip the entire descriptor
+        for data in self.data.iter() {
+            match &data.item {
+                DataType::Static(static_item) => {
+                    let mut descriptor_entry = RateLimitDescriptor_Entry::new();
+                    descriptor_entry.set_key(static_item.key.to_owned());
+                    descriptor_entry.set_value(static_item.value.to_owned());
+                    entries.push(descriptor_entry);
+                }
+                DataType::Selector(selector_item) => {
+                    let descriptor_key = match &selector_item.key {
+                        None => selector_item.path().to_string(),
+                        Some(key) => key.to_owned(),
+                    };
+
+                    let attribute_path = selector_item.path();
+                    let value = match crate::property::get_property(attribute_path.tokens())
+                        .unwrap()
+                    {
+                        //TODO(didierofrivia): Replace hostcalls by DI
+                        None => {
+                            debug!(
+                                "build_single_descriptor: selector not found: {}",
+                                attribute_path
+                            );
+                            match &selector_item.default {
+                                None => return None, // skipping the entire descriptor
+                                Some(default_value) => default_value.clone(),
+                            }
+                        }
+                        // TODO(eastizle): not all fields are strings
+                        // https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/advanced/attributes
+                        Some(attribute_bytes) => match Attribute::parse(attribute_bytes) {
+                            Ok(attr_str) => attr_str,
+                            Err(e) => {
+                                debug!("build_single_descriptor: failed to parse selector value: {}, error: {}",
+                                    attribute_path, e);
+                                return None;
+                            }
+                        },
+                        // Alternative implementation (for rust >= 1.76)
+                        // Attribute::parse(attribute_bytes)
+                        //   .inspect_err(|e| debug!("#{} build_single_descriptor: failed to parse selector value: {}, error: {}",
+                        //           filter.context_id, attribute_path, e))
+                        //   .ok()?,
+                    };
+                    let mut descriptor_entry = RateLimitDescriptor_Entry::new();
+                    descriptor_entry.set_key(descriptor_key);
+                    descriptor_entry.set_value(value);
+                    entries.push(descriptor_entry);
+                }
+            }
+        }
+        let mut res = RateLimitDescriptor::new();
+        res.set_entries(entries);
+        Some(res)
+    }
+}

--- a/src/configuration/action_set.rs
+++ b/src/configuration/action_set.rs
@@ -7,7 +7,6 @@ pub struct RouteRuleConditions {
     pub hostnames: Vec<String>,
     #[serde(default)]
     pub matches: Vec<PatternExpression>,
-    pub actions: Vec<Action>,
 }
 
 #[derive(Default, Deserialize, Debug, Clone)]
@@ -15,29 +14,30 @@ pub struct RouteRuleConditions {
 pub struct ActionSet {
     pub name: String,
     pub route_rule_conditions: RouteRuleConditions,
+    pub actions: Vec<Action>,
 }
 
 impl ActionSet {
     #[cfg(test)]
-    pub fn new(name: String, rules: RouteRuleConditions) -> Self {
+    pub fn new(
+        name: String,
+        route_rule_conditions: RouteRuleConditions,
+        actions: Vec<Action>,
+    ) -> Self {
         ActionSet {
             name,
-            route_rule_conditions: rules,
+            route_rule_conditions,
+            actions,
         }
     }
 
-    pub fn find_rule_that_applies(&self) -> Option<&RouteRuleConditions> {
-        if self.route_rule_conditions.matches.is_empty()
+    pub fn conditions_apply(&self) -> bool {
+        self.route_rule_conditions.matches.is_empty()
             || self
                 .route_rule_conditions
                 .matches
                 .iter()
                 .all(|m| self.pattern_expression_applies(m))
-        {
-            Some(&self.route_rule_conditions)
-        } else {
-            None
-        }
     }
 
     fn pattern_expression_applies(&self, p_e: &PatternExpression) -> bool {

--- a/src/configuration/action_set.rs
+++ b/src/configuration/action_set.rs
@@ -17,16 +17,16 @@ pub struct Rule {
 
 #[derive(Default, Deserialize, Debug, Clone)]
 #[serde(rename_all = "camelCase")]
-pub struct Policy {
+pub struct ActionSet {
     pub name: String,
     pub hostnames: Vec<String>,
     pub rules: Vec<Rule>,
 }
 
-impl Policy {
+impl ActionSet {
     #[cfg(test)]
     pub fn new(name: String, hostnames: Vec<String>, rules: Vec<Rule>) -> Self {
-        Policy {
+        ActionSet {
             name,
             hostnames,
             rules,

--- a/src/configuration/action_set.rs
+++ b/src/configuration/action_set.rs
@@ -1,4 +1,5 @@
-use crate::configuration::{Action, PatternExpression};
+use crate::configuration::action::Action;
+use crate::configuration::PatternExpression;
 use log::debug;
 use serde::Deserialize;
 

--- a/src/configuration/action_set.rs
+++ b/src/configuration/action_set.rs
@@ -1,6 +1,5 @@
 use crate::configuration::action::Action;
 use crate::configuration::PatternExpression;
-use log::debug;
 use serde::Deserialize;
 
 #[derive(Deserialize, Debug, Clone, Default)]
@@ -38,26 +37,6 @@ impl ActionSet {
                 .route_rule_conditions
                 .matches
                 .iter()
-                .all(|m| self.pattern_expression_applies(m))
-    }
-
-    fn pattern_expression_applies(&self, p_e: &PatternExpression) -> bool {
-        let attribute_path = p_e.path();
-
-        let attribute_value = match crate::property::get_property(attribute_path).unwrap() {
-            //TODO(didierofrivia): Replace hostcalls by DI
-            None => {
-                debug!(
-                    "pattern_expression_applies:  selector not found: {}, defaulting to ``",
-                    p_e.selector
-                );
-                b"".to_vec()
-            }
-            Some(attribute_bytes) => attribute_bytes,
-        };
-        p_e.eval(attribute_value).unwrap_or_else(|e| {
-            debug!("pattern_expression_applies failed: {}", e);
-            false
-        })
+                .all(|m| m.applies())
     }
 }

--- a/src/configuration/action_set.rs
+++ b/src/configuration/action_set.rs
@@ -4,6 +4,7 @@ use serde::Deserialize;
 
 #[derive(Deserialize, Debug, Clone, Default)]
 pub struct RouteRuleConditions {
+    pub hostnames: Vec<String>,
     #[serde(default)]
     pub matches: Vec<PatternExpression>,
     pub actions: Vec<Action>,
@@ -13,16 +14,14 @@ pub struct RouteRuleConditions {
 #[serde(rename_all = "camelCase")]
 pub struct ActionSet {
     pub name: String,
-    pub hostnames: Vec<String>,
     pub route_rule_conditions: RouteRuleConditions,
 }
 
 impl ActionSet {
     #[cfg(test)]
-    pub fn new(name: String, hostnames: Vec<String>, rules: RouteRuleConditions) -> Self {
+    pub fn new(name: String, rules: RouteRuleConditions) -> Self {
         ActionSet {
             name,
-            hostnames,
             route_rule_conditions: rules,
         }
     }

--- a/src/configuration/action_set.rs
+++ b/src/configuration/action_set.rs
@@ -2,16 +2,10 @@ use crate::configuration::{Action, PatternExpression};
 use log::debug;
 use serde::Deserialize;
 
-#[derive(Deserialize, Debug, Clone)]
-#[serde(rename_all = "camelCase")]
-pub struct Condition {
-    pub all_of: Vec<PatternExpression>,
-}
-
-#[derive(Deserialize, Debug, Clone)]
-pub struct Rule {
+#[derive(Deserialize, Debug, Clone, Default)]
+pub struct RouteRuleConditions {
     #[serde(default)]
-    pub conditions: Vec<Condition>,
+    pub matches: Vec<PatternExpression>,
     pub actions: Vec<Action>,
 }
 
@@ -20,41 +14,31 @@ pub struct Rule {
 pub struct ActionSet {
     pub name: String,
     pub hostnames: Vec<String>,
-    pub rules: Vec<Rule>,
+    pub route_rule_conditions: RouteRuleConditions,
 }
 
 impl ActionSet {
     #[cfg(test)]
-    pub fn new(name: String, hostnames: Vec<String>, rules: Vec<Rule>) -> Self {
+    pub fn new(name: String, hostnames: Vec<String>, rules: RouteRuleConditions) -> Self {
         ActionSet {
             name,
             hostnames,
-            rules,
+            route_rule_conditions: rules,
         }
     }
 
-    pub fn find_rule_that_applies(&self) -> Option<&Rule> {
-        self.rules
-            .iter()
-            .find(|rule: &&Rule| self.filter_rule_by_conditions(&rule.conditions))
-    }
-
-    fn filter_rule_by_conditions(&self, conditions: &[Condition]) -> bool {
-        if conditions.is_empty() {
-            // no conditions is equivalent to matching all the requests.
-            return true;
+    pub fn find_rule_that_applies(&self) -> Option<&RouteRuleConditions> {
+        if self.route_rule_conditions.matches.is_empty()
+            || self
+                .route_rule_conditions
+                .matches
+                .iter()
+                .all(|m| self.pattern_expression_applies(m))
+        {
+            Some(&self.route_rule_conditions)
+        } else {
+            None
         }
-
-        conditions
-            .iter()
-            .any(|condition| self.condition_applies(condition))
-    }
-
-    fn condition_applies(&self, condition: &Condition) -> bool {
-        condition
-            .all_of
-            .iter()
-            .all(|pattern_expression| self.pattern_expression_applies(pattern_expression))
     }
 
     fn pattern_expression_applies(&self, p_e: &PatternExpression) -> bool {

--- a/src/configuration/action_set_index.rs
+++ b/src/configuration/action_set_index.rs
@@ -48,7 +48,7 @@ mod tests {
     use std::rc::Rc;
 
     fn build_ratelimit_action_set(name: &str) -> ActionSet {
-        ActionSet::new(name.to_owned(), Default::default())
+        ActionSet::new(name.to_owned(), Default::default(), Vec::new())
     }
 
     #[test]

--- a/src/configuration/action_set_index.rs
+++ b/src/configuration/action_set_index.rs
@@ -48,7 +48,7 @@ mod tests {
     use std::rc::Rc;
 
     fn build_ratelimit_action_set(name: &str) -> ActionSet {
-        ActionSet::new(name.to_owned(), Vec::new(), Vec::new())
+        ActionSet::new(name.to_owned(), Vec::new(), Default::default())
     }
 
     #[test]

--- a/src/configuration/action_set_index.rs
+++ b/src/configuration/action_set_index.rs
@@ -48,7 +48,7 @@ mod tests {
     use std::rc::Rc;
 
     fn build_ratelimit_action_set(name: &str) -> ActionSet {
-        ActionSet::new(name.to_owned(), Vec::new(), Default::default())
+        ActionSet::new(name.to_owned(), Default::default())
     }
 
     #[test]

--- a/src/filter/http_context.rs
+++ b/src/filter/http_context.rs
@@ -31,20 +31,22 @@ impl Filter {
 
     #[allow(clippy::manual_inspect)]
     fn process_action_sets(&self, action_sets: &[Rc<ActionSet>]) -> Action {
-        if let Some(rule) = action_sets.iter().find_map(|action_set| {
-            action_set.find_rule_that_applies().map(|rule| {
-                debug!(
-                    "#{} action_set selected {}",
-                    self.context_id, action_set.name
-                );
-                rule
-            })
-        }) {
+        if let Some(action_set) = action_sets
+            .iter()
+            .find(|action_set| action_set.conditions_apply())
+        {
+            debug!(
+                "#{} action_set selected {}",
+                self.context_id, action_set.name
+            );
             self.operation_dispatcher
                 .borrow_mut()
-                .build_operations(rule);
+                .build_operations(&action_set.actions);
         } else {
-            debug!("#{} process_action_sets: no rule applied", self.context_id);
+            debug!(
+                "#{} process_action_sets: no action_set with conditions applies",
+                self.context_id
+            );
             return Action::Continue;
         }
 

--- a/src/filter/root_context.rs
+++ b/src/filter/root_context.rs
@@ -40,11 +40,11 @@ impl RootContext for FilterRoot {
         self.config
             .services
             .iter()
-            .for_each(|(extension, service)| {
+            .for_each(|(service_name, grpc_service)| {
                 service_handlers
-                    .entry(extension.clone())
+                    .entry(service_name.clone())
                     .or_insert(Rc::from(GrpcServiceHandler::new(
-                        Rc::clone(service),
+                        Rc::clone(grpc_service),
                         Rc::clone(&header_resolver),
                     )));
             });

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,8 +5,6 @@ mod envoy;
 mod filter;
 mod glob;
 mod operation_dispatcher;
-mod policy;
-mod policy_index;
 mod property;
 mod property_path;
 mod service;

--- a/src/operation_dispatcher.rs
+++ b/src/operation_dispatcher.rs
@@ -1,5 +1,5 @@
 use crate::configuration::action::Action;
-use crate::configuration::{Extension, ExtensionType, FailureMode};
+use crate::configuration::{FailureMode, Service, ServiceType};
 use crate::service::grpc_message::GrpcMessageRequest;
 use crate::service::{GetMapValuesBytesFn, GrpcCallFn, GrpcMessageBuildFn, GrpcServiceHandler};
 use log::error;
@@ -35,22 +35,26 @@ impl State {
 pub(crate) struct Operation {
     state: RefCell<State>,
     result: RefCell<Result<u32, Status>>,
-    extension: Rc<Extension>,
+    service: Rc<Service>,
     action: Action,
-    service: Rc<GrpcServiceHandler>,
+    service_handler: Rc<GrpcServiceHandler>,
     grpc_call_fn: GrpcCallFn,
     get_map_values_bytes_fn: GetMapValuesBytesFn,
     grpc_message_build_fn: GrpcMessageBuildFn,
 }
 
 impl Operation {
-    pub fn new(extension: Rc<Extension>, action: Action, service: Rc<GrpcServiceHandler>) -> Self {
+    pub fn new(
+        service: Rc<Service>,
+        action: Action,
+        service_handler: Rc<GrpcServiceHandler>,
+    ) -> Self {
         Self {
             state: RefCell::new(State::Pending),
             result: RefCell::new(Ok(0)), // Heuristics: zero represents that it's not been triggered, following `hostcalls` example
-            extension,
-            action,
             service,
+            action,
+            service_handler,
             grpc_call_fn,
             get_map_values_bytes_fn,
             grpc_message_build_fn,
@@ -58,13 +62,12 @@ impl Operation {
     }
 
     fn trigger(&self) -> Result<u32, Status> {
-        if let Some(message) = (self.grpc_message_build_fn)(self.get_extension_type(), &self.action)
-        {
-            let res = self.service.send(
+        if let Some(message) = (self.grpc_message_build_fn)(self.get_service_type(), &self.action) {
+            let res = self.service_handler.send(
                 self.get_map_values_bytes_fn,
                 self.grpc_call_fn,
                 message,
-                self.extension.timeout.0,
+                self.service.timeout.0,
             );
             self.set_result(res);
             self.next_state();
@@ -95,12 +98,12 @@ impl Operation {
         *self.result.borrow_mut() = result;
     }
 
-    pub fn get_extension_type(&self) -> &ExtensionType {
-        &self.extension.extension_type
+    pub fn get_service_type(&self) -> &ServiceType {
+        &self.service.service_type
     }
 
     pub fn get_failure_mode(&self) -> &FailureMode {
-        &self.extension.failure_mode
+        &self.service.failure_mode
     }
 }
 
@@ -127,9 +130,9 @@ impl OperationDispatcher {
         let mut operations: Vec<Rc<Operation>> = vec![];
         for action in actions.iter() {
             // TODO(didierofrivia): Error handling
-            if let Some(service) = self.service_handlers.get(&action.extension) {
+            if let Some(service) = self.service_handlers.get(&action.service) {
                 operations.push(Rc::new(Operation::new(
-                    service.get_extension(),
+                    service.get_service(),
                     action.clone(),
                     Rc::clone(service),
                 )))
@@ -223,7 +226,7 @@ fn get_map_values_bytes_fn(map_type: MapType, key: &str) -> Result<Option<Bytes>
 }
 
 fn grpc_message_build_fn(
-    extension_type: &ExtensionType,
+    extension_type: &ServiceType,
     action: &Action,
 ) -> Option<GrpcMessageRequest> {
     GrpcMessageRequest::new(extension_type, action)
@@ -256,7 +259,7 @@ mod tests {
     }
 
     fn grpc_message_build_fn_stub(
-        _extension_type: &ExtensionType,
+        _extension_type: &ServiceType,
         _action: &Action,
     ) -> Option<GrpcMessageRequest> {
         Some(GrpcMessageRequest::RateLimit(build_message()))
@@ -278,23 +281,23 @@ mod tests {
 
     fn build_operation(
         grpc_call_fn_stub: GrpcCallFn,
-        extension_type: ExtensionType,
+        extension_type: ServiceType,
     ) -> Rc<Operation> {
         Rc::new(Operation {
             state: RefCell::from(State::Pending),
             result: RefCell::new(Ok(0)),
-            extension: Rc::new(Extension {
-                extension_type,
+            service: Rc::new(Service {
+                service_type: extension_type,
                 endpoint: "local".to_string(),
                 failure_mode: FailureMode::Deny,
                 timeout: Timeout(Duration::from_millis(42)),
             }),
             action: Action {
-                extension: "local".to_string(),
+                service: "local".to_string(),
                 scope: "".to_string(),
                 data: vec![],
             },
-            service: Rc::new(build_grpc_service_handler()),
+            service_handler: Rc::new(build_grpc_service_handler()),
             grpc_call_fn: grpc_call_fn_stub,
             get_map_values_bytes_fn: get_map_values_bytes_fn_stub,
             grpc_message_build_fn: grpc_message_build_fn_stub,
@@ -303,17 +306,17 @@ mod tests {
 
     #[test]
     fn operation_getters() {
-        let operation = build_operation(default_grpc_call_fn_stub, ExtensionType::RateLimit);
+        let operation = build_operation(default_grpc_call_fn_stub, ServiceType::RateLimit);
 
         assert_eq!(operation.get_state(), State::Pending);
-        assert_eq!(*operation.get_extension_type(), ExtensionType::RateLimit);
+        assert_eq!(*operation.get_service_type(), ServiceType::RateLimit);
         assert_eq!(*operation.get_failure_mode(), FailureMode::Deny);
         assert_eq!(operation.get_result(), Ok(0));
     }
 
     #[test]
     fn operation_transition() {
-        let operation = build_operation(default_grpc_call_fn_stub, ExtensionType::RateLimit);
+        let operation = build_operation(default_grpc_call_fn_stub, ServiceType::RateLimit);
         assert_eq!(operation.get_result(), Ok(0));
         assert_eq!(operation.get_state(), State::Pending);
         let mut res = operation.trigger();
@@ -332,7 +335,7 @@ mod tests {
         assert_eq!(operation_dispatcher.operations.len(), 0);
         operation_dispatcher.push_operations(vec![build_operation(
             default_grpc_call_fn_stub,
-            ExtensionType::RateLimit,
+            ServiceType::RateLimit,
         )]);
 
         assert_eq!(operation_dispatcher.operations.len(), 1);
@@ -343,7 +346,7 @@ mod tests {
         let mut operation_dispatcher = OperationDispatcher::default();
         operation_dispatcher.push_operations(vec![build_operation(
             default_grpc_call_fn_stub,
-            ExtensionType::RateLimit,
+            ServiceType::RateLimit,
         )]);
         assert_eq!(
             operation_dispatcher.get_current_operation_state(),
@@ -378,8 +381,8 @@ mod tests {
         }
 
         operation_dispatcher.push_operations(vec![
-            build_operation(grpc_call_fn_stub_66, ExtensionType::RateLimit),
-            build_operation(grpc_call_fn_stub_77, ExtensionType::Auth),
+            build_operation(grpc_call_fn_stub_66, ServiceType::RateLimit),
+            build_operation(grpc_call_fn_stub_77, ServiceType::Auth),
         ]);
 
         assert_eq!(
@@ -391,8 +394,8 @@ mod tests {
         let mut op = operation_dispatcher.next();
         assert_eq!(op.clone().unwrap().get_result(), Ok(66));
         assert_eq!(
-            *op.clone().unwrap().get_extension_type(),
-            ExtensionType::RateLimit
+            *op.clone().unwrap().get_service_type(),
+            ServiceType::RateLimit
         );
         assert_eq!(op.unwrap().get_state(), State::Waiting);
         assert_eq!(operation_dispatcher.waiting_operations.len(), 1);
@@ -403,10 +406,7 @@ mod tests {
 
         op = operation_dispatcher.next();
         assert_eq!(op.clone().unwrap().get_result(), Ok(77));
-        assert_eq!(
-            *op.clone().unwrap().get_extension_type(),
-            ExtensionType::Auth
-        );
+        assert_eq!(*op.clone().unwrap().get_service_type(), ServiceType::Auth);
         assert_eq!(op.unwrap().get_state(), State::Waiting);
         assert_eq!(operation_dispatcher.waiting_operations.len(), 1);
 

--- a/src/operation_dispatcher.rs
+++ b/src/operation_dispatcher.rs
@@ -1,4 +1,3 @@
-use crate::configuration::action_set::RouteRuleConditions;
 use crate::configuration::{Action, Extension, ExtensionType, FailureMode};
 use crate::service::grpc_message::GrpcMessageRequest;
 use crate::service::{GetMapValuesBytesFn, GrpcCallFn, GrpcMessageBuildFn, GrpcServiceHandler};
@@ -123,9 +122,9 @@ impl OperationDispatcher {
         self.waiting_operations.get(&token_id).cloned()
     }
 
-    pub fn build_operations(&mut self, rule: &RouteRuleConditions) {
+    pub fn build_operations(&mut self, actions: &Vec<Action>) {
         let mut operations: Vec<Rc<Operation>> = vec![];
-        for action in rule.actions.iter() {
+        for action in actions.iter() {
             // TODO(didierofrivia): Error handling
             if let Some(service) = self.service_handlers.get(&action.extension) {
                 operations.push(Rc::new(Operation::new(

--- a/src/operation_dispatcher.rs
+++ b/src/operation_dispatcher.rs
@@ -1,5 +1,5 @@
+use crate::configuration::action_set::Rule;
 use crate::configuration::{Action, Extension, ExtensionType, FailureMode};
-use crate::policy::Rule;
 use crate::service::grpc_message::GrpcMessageRequest;
 use crate::service::{GetMapValuesBytesFn, GrpcCallFn, GrpcMessageBuildFn, GrpcServiceHandler};
 use log::error;

--- a/src/operation_dispatcher.rs
+++ b/src/operation_dispatcher.rs
@@ -1,4 +1,4 @@
-use crate::configuration::action_set::Rule;
+use crate::configuration::action_set::RouteRuleConditions;
 use crate::configuration::{Action, Extension, ExtensionType, FailureMode};
 use crate::service::grpc_message::GrpcMessageRequest;
 use crate::service::{GetMapValuesBytesFn, GrpcCallFn, GrpcMessageBuildFn, GrpcServiceHandler};
@@ -123,7 +123,7 @@ impl OperationDispatcher {
         self.waiting_operations.get(&token_id).cloned()
     }
 
-    pub fn build_operations(&mut self, rule: &Rule) {
+    pub fn build_operations(&mut self, rule: &RouteRuleConditions) {
         let mut operations: Vec<Rc<Operation>> = vec![];
         for action in rule.actions.iter() {
             // TODO(didierofrivia): Error handling

--- a/src/operation_dispatcher.rs
+++ b/src/operation_dispatcher.rs
@@ -1,4 +1,5 @@
-use crate::configuration::{Action, Extension, ExtensionType, FailureMode};
+use crate::configuration::action::Action;
+use crate::configuration::{Extension, ExtensionType, FailureMode};
 use crate::service::grpc_message::GrpcMessageRequest;
 use crate::service::{GetMapValuesBytesFn, GrpcCallFn, GrpcMessageBuildFn, GrpcServiceHandler};
 use log::error;

--- a/src/service.rs
+++ b/src/service.rs
@@ -2,7 +2,8 @@ pub(crate) mod auth;
 pub(crate) mod grpc_message;
 pub(crate) mod rate_limit;
 
-use crate::configuration::{Action, Extension, ExtensionType, FailureMode};
+use crate::configuration::action::Action;
+use crate::configuration::{Extension, ExtensionType, FailureMode};
 use crate::envoy::StatusCode;
 use crate::operation_dispatcher::Operation;
 use crate::service::auth::{AuthService, AUTH_METHOD_NAME, AUTH_SERVICE_NAME};

--- a/src/service/grpc_message.rs
+++ b/src/service/grpc_message.rs
@@ -1,5 +1,5 @@
 use crate::configuration::action::Action;
-use crate::configuration::ExtensionType;
+use crate::configuration::ServiceType;
 use crate::envoy::{CheckRequest, CheckResponse, RateLimitRequest, RateLimitResponse};
 use crate::service::auth::AuthService;
 use crate::service::rate_limit::RateLimitService;
@@ -124,9 +124,9 @@ impl Message for GrpcMessageRequest {
 
 impl GrpcMessageRequest {
     // Using domain as ce_host for the time being, we might pass a DataType in the future.
-    pub fn new(extension_type: &ExtensionType, action: &Action) -> Option<Self> {
-        match extension_type {
-            ExtensionType::RateLimit => {
+    pub fn new(service_type: &ServiceType, action: &Action) -> Option<Self> {
+        match service_type {
+            ServiceType::RateLimit => {
                 let descriptors = action.build_descriptors();
                 if descriptors.is_empty() {
                     debug!("grpc_message_request: empty descriptors");
@@ -137,7 +137,7 @@ impl GrpcMessageRequest {
                     ))
                 }
             }
-            ExtensionType::Auth => Some(GrpcMessageRequest::Auth(AuthService::request_message(
+            ServiceType::Auth => Some(GrpcMessageRequest::Auth(AuthService::request_message(
                 action.scope.clone(),
             ))),
         }
@@ -253,12 +253,12 @@ impl Message for GrpcMessageResponse {
 
 impl GrpcMessageResponse {
     pub fn new(
-        extension_type: &ExtensionType,
+        service_type: &ServiceType,
         res_body_bytes: &Bytes,
     ) -> GrpcMessageResult<GrpcMessageResponse> {
-        match extension_type {
-            ExtensionType::RateLimit => RateLimitService::response_message(res_body_bytes),
-            ExtensionType::Auth => AuthService::response_message(res_body_bytes),
+        match service_type {
+            ServiceType::RateLimit => RateLimitService::response_message(res_body_bytes),
+            ServiceType::Auth => AuthService::response_message(res_body_bytes),
         }
     }
 }

--- a/src/service/grpc_message.rs
+++ b/src/service/grpc_message.rs
@@ -1,4 +1,5 @@
-use crate::configuration::{Action, ExtensionType};
+use crate::configuration::action::Action;
+use crate::configuration::ExtensionType;
 use crate::envoy::{CheckRequest, CheckResponse, RateLimitRequest, RateLimitResponse};
 use crate::service::auth::AuthService;
 use crate::service::rate_limit::RateLimitService;

--- a/tests/auth.rs
+++ b/tests/auth.rs
@@ -13,7 +13,7 @@ const CONFIG: &str = r#"{
                 "timeout": "5s"
             }
         },
-        "policies": [
+        "actionSets": [
         {
             "name": "some-name",
             "hostnames": ["*.toystore.com", "example.com"],
@@ -110,7 +110,10 @@ fn it_auths() {
         )
         .expect_get_property(Some(vec!["request", "method"]))
         .returning(Some("POST".as_bytes()))
-        .expect_log(Some(LogLevel::Debug), Some("#2 policy selected some-name"))
+        .expect_log(
+            Some(LogLevel::Debug),
+            Some("#2 action_set selected some-name"),
+        )
         // retrieving properties for CheckRequest
         .expect_get_header_map_pairs(Some(MapType::HttpRequestHeaders))
         .returning(None)
@@ -302,7 +305,10 @@ fn it_denies() {
         )
         .expect_get_property(Some(vec!["request", "method"]))
         .returning(Some("POST".as_bytes()))
-        .expect_log(Some(LogLevel::Debug), Some("#2 policy selected some-name"))
+        .expect_log(
+            Some(LogLevel::Debug),
+            Some("#2 action_set selected some-name"),
+        )
         // retrieving properties for CheckRequest
         .expect_get_header_map_pairs(Some(MapType::HttpRequestHeaders))
         .returning(None)

--- a/tests/auth.rs
+++ b/tests/auth.rs
@@ -33,13 +33,13 @@ const CONFIG: &str = r#"{
                     "selector": "request.method",
                     "operator": "eq",
                     "value": "POST"
-                }],
-                "actions": [
-                {
-                    "extension": "authorino",
-                    "scope": "authconfig-A"
                 }]
-            }
+            },
+            "actions": [
+            {
+                "extension": "authorino",
+                "scope": "authconfig-A"
+            }]
         }]
     }"#;
 

--- a/tests/auth.rs
+++ b/tests/auth.rs
@@ -5,7 +5,7 @@ use serial_test::serial;
 pub(crate) mod util;
 
 const CONFIG: &str = r#"{
-        "extensions": {
+        "services": {
             "authorino": {
                 "type": "auth",
                 "endpoint": "authorino-cluster",
@@ -37,7 +37,7 @@ const CONFIG: &str = r#"{
             },
             "actions": [
             {
-                "extension": "authorino",
+                "service": "authorino",
                 "scope": "authconfig-A"
             }]
         }]

--- a/tests/auth.rs
+++ b/tests/auth.rs
@@ -5,43 +5,43 @@ use serial_test::serial;
 pub(crate) mod util;
 
 const CONFIG: &str = r#"{
-        "services": {
-            "authorino": {
-                "type": "auth",
-                "endpoint": "authorino-cluster",
-                "failureMode": "deny",
-                "timeout": "5s"
-            }
-        },
-        "actionSets": [
-        {
-            "name": "some-name",
-            "routeRuleConditions": {
-                "hostnames": ["*.toystore.com", "example.com"],
-                "matches": [
-                {
-                    "selector": "request.url_path",
-                    "operator": "startswith",
-                    "value": "/admin/toy"
-                },
-                {
-                    "selector": "request.host",
-                    "operator": "eq",
-                    "value": "cars.toystore.com"
-                },
-                {
-                    "selector": "request.method",
-                    "operator": "eq",
-                    "value": "POST"
-                }]
-            },
-            "actions": [
+    "services": {
+        "authorino": {
+            "type": "auth",
+            "endpoint": "authorino-cluster",
+            "failureMode": "deny",
+            "timeout": "5s"
+        }
+    },
+    "actionSets": [
+    {
+        "name": "some-name",
+        "routeRuleConditions": {
+            "hostnames": ["*.toystore.com", "example.com"],
+            "matches": [
             {
-                "service": "authorino",
-                "scope": "authconfig-A"
+                "selector": "request.url_path",
+                "operator": "startswith",
+                "value": "/admin/toy"
+            },
+            {
+                "selector": "request.host",
+                "operator": "eq",
+                "value": "cars.toystore.com"
+            },
+            {
+                "selector": "request.method",
+                "operator": "eq",
+                "value": "POST"
             }]
+        },
+        "actions": [
+        {
+            "service": "authorino",
+            "scope": "authconfig-A"
         }]
-    }"#;
+    }]
+}"#;
 
 #[test]
 #[serial]

--- a/tests/auth.rs
+++ b/tests/auth.rs
@@ -16,8 +16,8 @@ const CONFIG: &str = r#"{
         "actionSets": [
         {
             "name": "some-name",
-            "hostnames": ["*.toystore.com", "example.com"],
             "routeRuleConditions": {
+                "hostnames": ["*.toystore.com", "example.com"],
                 "matches": [
                 {
                     "selector": "request.url_path",

--- a/tests/auth.rs
+++ b/tests/auth.rs
@@ -17,33 +17,29 @@ const CONFIG: &str = r#"{
         {
             "name": "some-name",
             "hostnames": ["*.toystore.com", "example.com"],
-            "rules": [
-            {
-                "conditions": [
+            "routeRuleConditions": {
+                "matches": [
                 {
-                    "allOf": [
-                    {
-                        "selector": "request.url_path",
-                        "operator": "startswith",
-                        "value": "/admin/toy"
-                    },
-                    {
-                        "selector": "request.host",
-                        "operator": "eq",
-                        "value": "cars.toystore.com"
-                    },
-                    {
-                        "selector": "request.method",
-                        "operator": "eq",
-                        "value": "POST"
-                    }]
+                    "selector": "request.url_path",
+                    "operator": "startswith",
+                    "value": "/admin/toy"
+                },
+                {
+                    "selector": "request.host",
+                    "operator": "eq",
+                    "value": "cars.toystore.com"
+                },
+                {
+                    "selector": "request.method",
+                    "operator": "eq",
+                    "value": "POST"
                 }],
                 "actions": [
                 {
                     "extension": "authorino",
                     "scope": "authconfig-A"
                 }]
-            }]
+            }
         }]
     }"#;
 

--- a/tests/multi.rs
+++ b/tests/multi.rs
@@ -6,7 +6,7 @@ use serial_test::serial;
 pub(crate) mod util;
 
 const CONFIG: &str = r#"{
-        "extensions": {
+        "services": {
             "authorino": {
                 "type": "auth",
                 "endpoint": "authorino-cluster",
@@ -44,11 +44,11 @@ const CONFIG: &str = r#"{
             },
             "actions": [
             {
-                "extension": "authorino",
+                "service": "authorino",
                 "scope": "authconfig-A"
             },
             {
-                "extension": "limitador",
+                "service": "limitador",
                 "scope": "RLS-domain",
                 "data": [
                 {

--- a/tests/multi.rs
+++ b/tests/multi.rs
@@ -23,8 +23,8 @@ const CONFIG: &str = r#"{
         "actionSets": [
         {
             "name": "some-name",
-            "hostnames": ["*.toystore.com", "example.com"],
             "routeRuleConditions": {
+                "hostnames": ["*.toystore.com", "example.com"],
                 "matches": [
                 {
                     "selector": "request.url_path",

--- a/tests/multi.rs
+++ b/tests/multi.rs
@@ -20,7 +20,7 @@ const CONFIG: &str = r#"{
                 "timeout": "5s"
             }
         },
-        "policies": [
+        "actionSets": [
         {
             "name": "some-name",
             "hostnames": ["*.toystore.com", "example.com"],
@@ -128,7 +128,10 @@ fn it_performs_authenticated_rate_limiting() {
         )
         .expect_get_property(Some(vec!["request", "method"]))
         .returning(Some("POST".as_bytes()))
-        .expect_log(Some(LogLevel::Debug), Some("#2 policy selected some-name"))
+        .expect_log(
+            Some(LogLevel::Debug),
+            Some("#2 action_set selected some-name"),
+        )
         // retrieving properties for CheckRequest
         .expect_get_header_map_pairs(Some(MapType::HttpRequestHeaders))
         .returning(None)
@@ -338,7 +341,10 @@ fn unauthenticated_does_not_ratelimit() {
         )
         .expect_get_property(Some(vec!["request", "method"]))
         .returning(Some("POST".as_bytes()))
-        .expect_log(Some(LogLevel::Debug), Some("#2 policy selected some-name"))
+        .expect_log(
+            Some(LogLevel::Debug),
+            Some("#2 action_set selected some-name"),
+        )
         // retrieving properties for CheckRequest
         .expect_get_header_map_pairs(Some(MapType::HttpRequestHeaders))
         .returning(None)

--- a/tests/multi.rs
+++ b/tests/multi.rs
@@ -24,26 +24,22 @@ const CONFIG: &str = r#"{
         {
             "name": "some-name",
             "hostnames": ["*.toystore.com", "example.com"],
-            "rules": [
-            {
-                "conditions": [
+            "routeRuleConditions": {
+                "matches": [
                 {
-                    "allOf": [
-                    {
-                        "selector": "request.url_path",
-                        "operator": "startswith",
-                        "value": "/admin/toy"
-                    },
-                    {
-                        "selector": "request.host",
-                        "operator": "eq",
-                        "value": "cars.toystore.com"
-                    },
-                    {
-                        "selector": "request.method",
-                        "operator": "eq",
-                        "value": "POST"
-                    }]
+                    "selector": "request.url_path",
+                    "operator": "startswith",
+                    "value": "/admin/toy"
+                },
+                {
+                    "selector": "request.host",
+                    "operator": "eq",
+                    "value": "cars.toystore.com"
+                },
+                {
+                    "selector": "request.method",
+                    "operator": "eq",
+                    "value": "POST"
                 }],
                 "actions": [
                 {
@@ -61,7 +57,7 @@ const CONFIG: &str = r#"{
                         }
                     }]
                 }]
-            }]
+            }
         }]
     }"#;
 

--- a/tests/multi.rs
+++ b/tests/multi.rs
@@ -6,60 +6,60 @@ use serial_test::serial;
 pub(crate) mod util;
 
 const CONFIG: &str = r#"{
-        "services": {
-            "authorino": {
-                "type": "auth",
-                "endpoint": "authorino-cluster",
-                "failureMode": "deny",
-                "timeout": "5s"
-            },
-            "limitador": {
-                "type": "ratelimit",
-                "endpoint": "limitador-cluster",
-                "failureMode": "deny",
-                "timeout": "5s"
-            }
+    "services": {
+        "authorino": {
+            "type": "auth",
+            "endpoint": "authorino-cluster",
+            "failureMode": "deny",
+            "timeout": "5s"
         },
-        "actionSets": [
+        "limitador": {
+            "type": "ratelimit",
+            "endpoint": "limitador-cluster",
+            "failureMode": "deny",
+            "timeout": "5s"
+        }
+    },
+    "actionSets": [
+    {
+        "name": "some-name",
+        "routeRuleConditions": {
+            "hostnames": ["*.toystore.com", "example.com"],
+            "matches": [
+            {
+                "selector": "request.url_path",
+                "operator": "startswith",
+                "value": "/admin/toy"
+            },
+            {
+                "selector": "request.host",
+                "operator": "eq",
+                "value": "cars.toystore.com"
+            },
+            {
+                "selector": "request.method",
+                "operator": "eq",
+                "value": "POST"
+            }]
+        },
+        "actions": [
         {
-            "name": "some-name",
-            "routeRuleConditions": {
-                "hostnames": ["*.toystore.com", "example.com"],
-                "matches": [
-                {
-                    "selector": "request.url_path",
-                    "operator": "startswith",
-                    "value": "/admin/toy"
-                },
-                {
-                    "selector": "request.host",
-                    "operator": "eq",
-                    "value": "cars.toystore.com"
-                },
-                {
-                    "selector": "request.method",
-                    "operator": "eq",
-                    "value": "POST"
-                }]
-            },
-            "actions": [
+            "service": "authorino",
+            "scope": "authconfig-A"
+        },
+        {
+            "service": "limitador",
+            "scope": "RLS-domain",
+            "data": [
             {
-                "service": "authorino",
-                "scope": "authconfig-A"
-            },
-            {
-                "service": "limitador",
-                "scope": "RLS-domain",
-                "data": [
-                {
-                    "static": {
-                        "key": "admin",
-                        "value": "1"
-                    }
-                }]
+                "static": {
+                    "key": "admin",
+                    "value": "1"
+                }
             }]
         }]
-    }"#;
+    }]
+}"#;
 
 #[test]
 #[serial]
@@ -469,6 +469,321 @@ fn unauthenticated_does_not_ratelimit() {
             ]),
             None,
         )
+        .execute_and_expect(ReturnType::None)
+        .unwrap();
+
+    module
+        .call_proxy_on_response_headers(http_context, 0, false)
+        .expect_log(Some(LogLevel::Debug), Some("#2 on_http_response_headers"))
+        .execute_and_expect(ReturnType::Action(Action::Continue))
+        .unwrap();
+}
+
+#[test]
+#[serial]
+fn authenticated_one_ratelimit_action_matches() {
+    let args = tester::MockSettings {
+        wasm_path: wasm_module(),
+        quiet: false,
+        allow_unexpected: false,
+    };
+    let mut module = tester::mock(args).unwrap();
+
+    module
+        .call_start()
+        .execute_and_expect(ReturnType::None)
+        .unwrap();
+
+    let cfg = r#"{
+        "services": {
+            "authorino": {
+                "type": "auth",
+                "endpoint": "authorino-cluster",
+                "failureMode": "deny",
+                "timeout": "5s"
+            },
+            "limitador": {
+                "type": "ratelimit",
+                "endpoint": "limitador-cluster",
+                "failureMode": "deny",
+                "timeout": "5s"
+            }
+        },
+        "actionSets": [
+        {
+            "name": "some-name",
+            "routeRuleConditions": {
+                "hostnames": ["*.toystore.com", "example.com"],
+                "matches": [
+                {
+                    "selector": "request.url_path",
+                    "operator": "startswith",
+                    "value": "/admin/toy"
+                },
+                {
+                    "selector": "request.host",
+                    "operator": "eq",
+                    "value": "cars.toystore.com"
+                },
+                {
+                    "selector": "request.method",
+                    "operator": "eq",
+                    "value": "POST"
+                }]
+            },
+            "actions": [
+            {
+                "service": "authorino",
+                "scope": "authconfig-A"
+            },
+            {
+                "service": "limitador",
+                "scope": "RLS-domain",
+                "conditions": [
+                {
+                    "selector": "source.address",
+                    "operator": "eq",
+                    "value": "127.0.0.1:80"
+                }],
+                "data": [
+                {
+                    "static": {
+                        "key": "me",
+                        "value": "1"
+                    }
+                }]
+            },
+            {
+                "service": "limitador",
+                "scope": "RLS-domain",
+                "conditions": [
+                {
+                    "selector": "source.address",
+                    "operator": "neq",
+                    "value": "127.0.0.1:80"
+                }],
+                "data": [
+                {
+                    "static": {
+                        "key": "other",
+                        "value": "1"
+                    }
+                }]
+            }
+            ]
+        }]
+    }"#;
+
+    module
+        .call_start()
+        .execute_and_expect(ReturnType::None)
+        .unwrap();
+
+    let root_context = 1;
+
+    module
+        .call_proxy_on_context_create(root_context, 0)
+        .expect_log(Some(LogLevel::Info), Some("#1 set_root_context"))
+        .execute_and_expect(ReturnType::None)
+        .unwrap();
+
+    module
+        .call_proxy_on_configure(root_context, 0)
+        .expect_log(Some(LogLevel::Info), Some("#1 on_configure"))
+        .expect_get_buffer_bytes(Some(BufferType::PluginConfiguration))
+        .returning(Some(cfg.as_bytes()))
+        .expect_log(Some(LogLevel::Info), None)
+        .execute_and_expect(ReturnType::Bool(true))
+        .unwrap();
+
+    let http_context = 2;
+    module
+        .call_proxy_on_context_create(http_context, root_context)
+        .expect_log(Some(LogLevel::Debug), Some("#2 create_http_context"))
+        .execute_and_expect(ReturnType::None)
+        .unwrap();
+
+    module
+        .call_proxy_on_request_headers(http_context, 0, false)
+        .expect_log(Some(LogLevel::Debug), Some("#2 on_http_request_headers"))
+        .expect_get_header_map_value(Some(MapType::HttpRequestHeaders), Some(":authority"))
+        .returning(Some("cars.toystore.com"))
+        // retrieving properties for conditions
+        .expect_log(
+            Some(LogLevel::Debug),
+            Some("get_property: path: [\"request\", \"url_path\"]"),
+        )
+        .expect_get_property(Some(vec!["request", "url_path"]))
+        .returning(Some("/admin/toy".as_bytes()))
+        .expect_log(
+            Some(LogLevel::Debug),
+            Some("get_property: path: [\"request\", \"host\"]"),
+        )
+        .expect_get_property(Some(vec!["request", "host"]))
+        .returning(Some("cars.toystore.com".as_bytes()))
+        .expect_log(
+            Some(LogLevel::Debug),
+            Some("get_property: path: [\"request\", \"method\"]"),
+        )
+        .expect_get_property(Some(vec!["request", "method"]))
+        .returning(Some("POST".as_bytes()))
+        .expect_log(
+            Some(LogLevel::Debug),
+            Some("#2 action_set selected some-name"),
+        )
+        // retrieving properties for CheckRequest
+        .expect_get_header_map_pairs(Some(MapType::HttpRequestHeaders))
+        .returning(None)
+        .expect_log(
+            Some(LogLevel::Debug),
+            Some("get_property: path: [\"request\", \"host\"]"),
+        )
+        .expect_get_property(Some(vec!["request", "host"]))
+        .returning(Some("cars.toystore.com".as_bytes()))
+        .expect_log(
+            Some(LogLevel::Debug),
+            Some("get_property: path: [\"request\", \"method\"]"),
+        )
+        .expect_get_property(Some(vec!["request", "method"]))
+        .returning(Some("GET".as_bytes()))
+        .expect_log(
+            Some(LogLevel::Debug),
+            Some("get_property: path: [\"request\", \"scheme\"]"),
+        )
+        .expect_get_property(Some(vec!["request", "scheme"]))
+        .returning(Some("http".as_bytes()))
+        .expect_log(
+            Some(LogLevel::Debug),
+            Some("get_property: path: [\"request\", \"path\"]"),
+        )
+        .expect_get_property(Some(vec!["request", "path"]))
+        .returning(Some("/admin/toy".as_bytes()))
+        .expect_log(
+            Some(LogLevel::Debug),
+            Some("get_property: path: [\"request\", \"protocol\"]"),
+        )
+        .expect_get_property(Some(vec!["request", "protocol"]))
+        .returning(Some("HTTP".as_bytes()))
+        .expect_log(
+            Some(LogLevel::Debug),
+            Some("get_property: path: [\"request\", \"time\"]"),
+        )
+        .expect_get_property(Some(vec!["request", "time"]))
+        .returning(None)
+        .expect_log(
+            Some(LogLevel::Debug),
+            Some("get_property: path: [\"destination\", \"address\"]"),
+        )
+        .expect_get_property(Some(vec!["destination", "address"]))
+        .returning(Some("127.0.0.1:8000".as_bytes()))
+        .expect_log(
+            Some(LogLevel::Debug),
+            Some("get_property: path: [\"destination\", \"port\"]"),
+        )
+        .expect_get_property(Some(vec!["destination", "port"]))
+        .returning(Some("8000".as_bytes()))
+        .expect_log(
+            Some(LogLevel::Debug),
+            Some("get_property: path: [\"source\", \"address\"]"),
+        )
+        .expect_get_property(Some(vec!["source", "address"]))
+        .returning(Some("1.2.3.4:80".as_bytes()))
+        .expect_log(
+            Some(LogLevel::Debug),
+            Some("get_property: path: [\"source\", \"port\"]"),
+        )
+        .expect_get_property(Some(vec!["source", "port"]))
+        .returning(Some("45000".as_bytes()))
+        // retrieving tracing headers
+        .expect_get_header_map_value(Some(MapType::HttpRequestHeaders), Some("traceparent"))
+        .returning(None)
+        .expect_get_header_map_value(Some(MapType::HttpRequestHeaders), Some("tracestate"))
+        .returning(None)
+        .expect_get_header_map_value(Some(MapType::HttpRequestHeaders), Some("baggage"))
+        .returning(None)
+        .expect_grpc_call(
+            Some("authorino-cluster"),
+            Some("envoy.service.auth.v3.Authorization"),
+            Some("Check"),
+            Some(&[0, 0, 0, 0]),
+            Some(&[
+                10, 212, 1, 10, 18, 10, 16, 10, 14, 18, 10, 49, 46, 50, 46, 51, 46, 52, 58, 56, 48,
+                24, 0, 18, 22, 10, 20, 10, 18, 18, 14, 49, 50, 55, 46, 48, 46, 48, 46, 49, 58, 56,
+                48, 48, 48, 24, 0, 34, 141, 1, 10, 0, 18, 136, 1, 18, 3, 71, 69, 84, 26, 30, 10,
+                10, 58, 97, 117, 116, 104, 111, 114, 105, 116, 121, 18, 16, 97, 98, 105, 95, 116,
+                101, 115, 116, 95, 104, 97, 114, 110, 101, 115, 115, 26, 14, 10, 7, 58, 109, 101,
+                116, 104, 111, 100, 18, 3, 71, 69, 84, 26, 38, 10, 5, 58, 112, 97, 116, 104, 18,
+                29, 47, 100, 101, 102, 97, 117, 108, 116, 47, 114, 101, 113, 117, 101, 115, 116,
+                47, 104, 101, 97, 100, 101, 114, 115, 47, 112, 97, 116, 104, 34, 10, 47, 97, 100,
+                109, 105, 110, 47, 116, 111, 121, 42, 17, 99, 97, 114, 115, 46, 116, 111, 121, 115,
+                116, 111, 114, 101, 46, 99, 111, 109, 50, 4, 104, 116, 116, 112, 82, 4, 72, 84, 84,
+                80, 82, 20, 10, 4, 104, 111, 115, 116, 18, 12, 97, 117, 116, 104, 99, 111, 110,
+                102, 105, 103, 45, 65, 90, 0,
+            ]),
+            Some(5000),
+        )
+        .returning(Some(42))
+        .expect_log(
+            Some(LogLevel::Debug),
+            Some("#2 initiated gRPC call (id# 42)"),
+        )
+        .execute_and_expect(ReturnType::Action(Action::Pause))
+        .unwrap();
+
+    let grpc_response: [u8; 6] = [10, 0, 34, 0, 26, 0];
+    module
+        .call_proxy_on_grpc_receive(http_context, 42, grpc_response.len() as i32)
+        .expect_log(
+            Some(LogLevel::Debug),
+            Some("#2 on_grpc_call_response: received gRPC call response: token: 42, status: 0"),
+        )
+        .expect_get_buffer_bytes(Some(BufferType::GrpcReceiveBuffer))
+        .returning(Some(&grpc_response))
+        .expect_log(
+            Some(LogLevel::Debug),
+            Some("process_auth_grpc_response: received OkHttpResponse"),
+        )
+        // conditions checks
+        .expect_log(
+            Some(LogLevel::Debug),
+            Some("get_property: path: [\"source\", \"address\"]"),
+        )
+        .expect_get_property(Some(vec!["source", "address"]))
+        .returning(Some("1.2.3.4:80".as_bytes()))
+        .expect_log(
+            Some(LogLevel::Debug),
+            Some("actions conditions do not apply, skipping"),
+        )
+        .expect_log(
+            Some(LogLevel::Debug),
+            Some("get_property: path: [\"source\", \"address\"]"),
+        )
+        .expect_get_property(Some(vec!["source", "address"]))
+        .returning(Some("1.2.3.4:80".as_bytes()))
+        .expect_grpc_call(
+            Some("limitador-cluster"),
+            Some("envoy.service.ratelimit.v3.RateLimitService"),
+            Some("ShouldRateLimit"),
+            Some(&[0, 0, 0, 0]),
+            Some(&[
+                10, 10, 82, 76, 83, 45, 100, 111, 109, 97, 105, 110, 18, 12, 10, 10, 10, 5, 111,
+                116, 104, 101, 114, 18, 1, 49, 24, 1,
+            ]),
+            Some(5000),
+        )
+        .returning(Some(43))
+        .execute_and_expect(ReturnType::None)
+        .unwrap();
+
+    let grpc_response: [u8; 2] = [8, 1];
+    module
+        .call_proxy_on_grpc_receive(http_context, 43, grpc_response.len() as i32)
+        .expect_log(
+            Some(LogLevel::Debug),
+            Some("#2 on_grpc_call_response: received gRPC call response: token: 43, status: 0"),
+        )
+        .expect_get_buffer_bytes(Some(BufferType::GrpcReceiveBuffer))
+        .returning(Some(&grpc_response))
         .execute_and_expect(ReturnType::None)
         .unwrap();
 

--- a/tests/multi.rs
+++ b/tests/multi.rs
@@ -40,24 +40,24 @@ const CONFIG: &str = r#"{
                     "selector": "request.method",
                     "operator": "eq",
                     "value": "POST"
-                }],
-                "actions": [
-                {
-                    "extension": "authorino",
-                    "scope": "authconfig-A"
-                },
-                {
-                    "extension": "limitador",
-                    "scope": "RLS-domain",
-                    "data": [
-                    {
-                        "static": {
-                            "key": "admin",
-                            "value": "1"
-                        }
-                    }]
                 }]
-            }
+            },
+            "actions": [
+            {
+                "extension": "authorino",
+                "scope": "authconfig-A"
+            },
+            {
+                "extension": "limitador",
+                "scope": "RLS-domain",
+                "data": [
+                {
+                    "static": {
+                        "key": "admin",
+                        "value": "1"
+                    }
+                }]
+            }]
         }]
     }"#;
 

--- a/tests/rate_limited.rs
+++ b/tests/rate_limited.rs
@@ -22,7 +22,7 @@ fn it_loads() {
 
     let root_context = 1;
     let cfg = r#"{
-        "extensions": {},
+        "services": {},
         "actionSets": []
     }"#;
 
@@ -83,7 +83,7 @@ fn it_limits() {
 
     let root_context = 1;
     let cfg = r#"{
-        "extensions": {
+        "services": {
             "limitador": {
                 "type": "ratelimit",
                 "endpoint": "limitador-cluster",
@@ -115,7 +115,7 @@ fn it_limits() {
             },
             "actions": [
             {
-                "extension": "limitador",
+                "service": "limitador",
                 "scope": "RLS-domain",
                 "data": [
                     {
@@ -240,7 +240,7 @@ fn it_passes_additional_headers() {
 
     let root_context = 1;
     let cfg = r#"{
-        "extensions": {
+        "services": {
             "limitador": {
                 "type": "ratelimit",
                 "endpoint": "limitador-cluster",
@@ -272,7 +272,7 @@ fn it_passes_additional_headers() {
             },
             "actions": [
             {
-                "extension": "limitador",
+                "service": "limitador",
                 "scope": "RLS-domain",
                 "data": [
                     {
@@ -411,7 +411,7 @@ fn it_rate_limits_with_empty_conditions() {
 
     let root_context = 1;
     let cfg = r#"{
-        "extensions": {
+        "services": {
             "limitador": {
                 "type": "ratelimit",
                 "endpoint": "limitador-cluster",
@@ -427,7 +427,7 @@ fn it_rate_limits_with_empty_conditions() {
             },
             "actions": [
             {
-                "extension": "limitador",
+                "service": "limitador",
                 "scope": "RLS-domain",
                 "data": [
                     {
@@ -533,7 +533,7 @@ fn it_does_not_rate_limits_when_selector_does_not_exist_and_misses_default_value
 
     let root_context = 1;
     let cfg = r#"{
-        "extensions": {
+        "services": {
             "limitador": {
                 "type": "ratelimit",
                 "endpoint": "limitador-cluster",
@@ -549,7 +549,7 @@ fn it_does_not_rate_limits_when_selector_does_not_exist_and_misses_default_value
             },
             "actions": [
             {
-                "extension": "limitador",
+                "service": "limitador",
                 "scope": "RLS-domain",
                 "data": [
                     {

--- a/tests/rate_limited.rs
+++ b/tests/rate_limited.rs
@@ -111,21 +111,21 @@ fn it_limits() {
                     "selector": "request.method",
                     "operator": "eq",
                     "value": "POST"
-                }],
-                "actions": [
-                {
-                    "extension": "limitador",
-                    "scope": "RLS-domain",
-                    "data": [
-                        {
-                            "static": {
-                                "key": "admin",
-                                "value": "1"
-                            }
-                        }
-                    ]
                 }]
-            }
+            },
+            "actions": [
+            {
+                "extension": "limitador",
+                "scope": "RLS-domain",
+                "data": [
+                    {
+                        "static": {
+                            "key": "admin",
+                            "value": "1"
+                        }
+                    }
+                ]
+            }]
         }]
     }"#;
 
@@ -268,21 +268,21 @@ fn it_passes_additional_headers() {
                     "selector": "request.method",
                     "operator": "eq",
                     "value": "POST"
-                }],
-                "actions": [
-                {
-                    "extension": "limitador",
-                    "scope": "RLS-domain",
-                    "data": [
-                        {
-                            "static": {
-                                "key": "admin",
-                                "value": "1"
-                            }
-                        }
-                    ]
                 }]
-            }
+            },
+            "actions": [
+            {
+                "extension": "limitador",
+                "scope": "RLS-domain",
+                "data": [
+                    {
+                        "static": {
+                            "key": "admin",
+                            "value": "1"
+                        }
+                    }
+                ]
+            }]
         }]
     }"#;
 
@@ -423,21 +423,21 @@ fn it_rate_limits_with_empty_conditions() {
         {
             "name": "some-name",
             "routeRuleConditions": {
-                "hostnames": ["*.com"],
-                "actions": [
-                {
-                    "extension": "limitador",
-                    "scope": "RLS-domain",
-                    "data": [
-                        {
-                            "static": {
-                                "key": "admin",
-                                "value": "1"
-                            }
+                "hostnames": ["*.com"]
+            },
+            "actions": [
+            {
+                "extension": "limitador",
+                "scope": "RLS-domain",
+                "data": [
+                    {
+                        "static": {
+                            "key": "admin",
+                            "value": "1"
                         }
-                    ]
-                }]
-            }
+                    }
+                ]
+            }]
         }]
     }"#;
 
@@ -545,20 +545,20 @@ fn it_does_not_rate_limits_when_selector_does_not_exist_and_misses_default_value
         {
             "name": "some-name",
             "routeRuleConditions": {
-                "hostnames": ["*.com"],
-                "actions": [
-                {
-                    "extension": "limitador",
-                    "scope": "RLS-domain",
-                    "data": [
-                        {
-                            "selector": {
-                                "selector": "unknown.path"
-                            }
+                "hostnames": ["*.com"]
+            },
+            "actions": [
+            {
+                "extension": "limitador",
+                "scope": "RLS-domain",
+                "data": [
+                    {
+                        "selector": {
+                            "selector": "unknown.path"
                         }
-                    ]
-                }]
-            }
+                    }
+                ]
+            }]
         }]
     }"#;
 

--- a/tests/rate_limited.rs
+++ b/tests/rate_limited.rs
@@ -23,7 +23,7 @@ fn it_loads() {
     let root_context = 1;
     let cfg = r#"{
         "extensions": {},
-        "policies": []
+        "actionSets": []
     }"#;
 
     module
@@ -91,7 +91,7 @@ fn it_limits() {
                 "timeout": "5s"
             }
         },
-        "policies": [
+        "actionSets": [
         {
             "name": "some-name",
             "hostnames": ["*.toystore.com", "example.com"],
@@ -178,7 +178,10 @@ fn it_limits() {
         )
         .expect_get_property(Some(vec!["request", "method"]))
         .returning(Some("POST".as_bytes()))
-        .expect_log(Some(LogLevel::Debug), Some("#2 policy selected some-name"))
+        .expect_log(
+            Some(LogLevel::Debug),
+            Some("#2 action_set selected some-name"),
+        )
         // retrieving tracing headers
         .expect_get_header_map_value(Some(MapType::HttpRequestHeaders), Some("traceparent"))
         .returning(None)
@@ -249,7 +252,7 @@ fn it_passes_additional_headers() {
                 "timeout": "5s"
             }
         },
-        "policies": [
+        "actionSets": [
         {
             "name": "some-name",
             "hostnames": ["*.toystore.com", "example.com"],
@@ -336,7 +339,10 @@ fn it_passes_additional_headers() {
         )
         .expect_get_property(Some(vec!["request", "method"]))
         .returning(Some("POST".as_bytes()))
-        .expect_log(Some(LogLevel::Debug), Some("#2 policy selected some-name"))
+        .expect_log(
+            Some(LogLevel::Debug),
+            Some("#2 action_set selected some-name"),
+        )
         // retrieving tracing headers
         .expect_get_header_map_value(Some(MapType::HttpRequestHeaders), Some("traceparent"))
         .returning(None)
@@ -421,7 +427,7 @@ fn it_rate_limits_with_empty_conditions() {
                 "timeout": "5s"
             }
         },
-        "policies": [
+        "actionSets": [
         {
             "name": "some-name",
             "hostnames": ["*.com"],
@@ -470,7 +476,10 @@ fn it_rate_limits_with_empty_conditions() {
         .expect_log(Some(LogLevel::Debug), Some("#2 on_http_request_headers"))
         .expect_get_header_map_value(Some(MapType::HttpRequestHeaders), Some(":authority"))
         .returning(Some("a.com"))
-        .expect_log(Some(LogLevel::Debug), Some("#2 policy selected some-name"))
+        .expect_log(
+            Some(LogLevel::Debug),
+            Some("#2 action_set selected some-name"),
+        )
         // retrieving tracing headers
         .expect_get_header_map_value(Some(MapType::HttpRequestHeaders), Some("traceparent"))
         .returning(None)
@@ -541,7 +550,7 @@ fn it_does_not_rate_limits_when_selector_does_not_exist_and_misses_default_value
                 "timeout": "5s"
             }
         },
-        "policies": [
+        "actionSets": [
         {
             "name": "some-name",
             "hostnames": ["*.com"],
@@ -589,7 +598,10 @@ fn it_does_not_rate_limits_when_selector_does_not_exist_and_misses_default_value
         .expect_log(Some(LogLevel::Debug), Some("#2 on_http_request_headers"))
         .expect_get_header_map_value(Some(MapType::HttpRequestHeaders), Some(":authority"))
         .returning(Some("a.com"))
-        .expect_log(Some(LogLevel::Debug), Some("#2 policy selected some-name"))
+        .expect_log(
+            Some(LogLevel::Debug),
+            Some("#2 action_set selected some-name"),
+        )
         // retrieving properties for RateLimitRequest
         .expect_log(
             Some(LogLevel::Debug),

--- a/tests/rate_limited.rs
+++ b/tests/rate_limited.rs
@@ -95,26 +95,22 @@ fn it_limits() {
         {
             "name": "some-name",
             "hostnames": ["*.toystore.com", "example.com"],
-            "rules": [
-            {
-                "conditions": [
+            "routeRuleConditions": {
+                "matches": [
                 {
-                    "allOf": [
-                    {
-                        "selector": "request.url_path",
-                        "operator": "startswith",
-                        "value": "/admin/toy"
-                    },
-                    {
-                        "selector": "request.host",
-                        "operator": "eq",
-                        "value": "cars.toystore.com"
-                    },
-                    {
-                        "selector": "request.method",
-                        "operator": "eq",
-                        "value": "POST"
-                    }]
+                    "selector": "request.url_path",
+                    "operator": "startswith",
+                    "value": "/admin/toy"
+                },
+                {
+                    "selector": "request.host",
+                    "operator": "eq",
+                    "value": "cars.toystore.com"
+                },
+                {
+                    "selector": "request.method",
+                    "operator": "eq",
+                    "value": "POST"
                 }],
                 "actions": [
                 {
@@ -129,7 +125,7 @@ fn it_limits() {
                         }
                     ]
                 }]
-            }]
+            }
         }]
     }"#;
 
@@ -256,26 +252,22 @@ fn it_passes_additional_headers() {
         {
             "name": "some-name",
             "hostnames": ["*.toystore.com", "example.com"],
-            "rules": [
-            {
-                "conditions": [
+            "routeRuleConditions": {
+                "matches": [
                 {
-                   "allOf": [
-                    {
-                        "selector": "request.url_path",
-                        "operator": "startswith",
-                        "value": "/admin/toy"
-                    },
-                    {
-                        "selector": "request.host",
-                        "operator": "eq",
-                        "value": "cars.toystore.com"
-                    },
-                    {
-                        "selector": "request.method",
-                        "operator": "eq",
-                        "value": "POST"
-                    }]
+                    "selector": "request.url_path",
+                    "operator": "startswith",
+                    "value": "/admin/toy"
+                },
+                {
+                    "selector": "request.host",
+                    "operator": "eq",
+                    "value": "cars.toystore.com"
+                },
+                {
+                    "selector": "request.method",
+                    "operator": "eq",
+                    "value": "POST"
                 }],
                 "actions": [
                 {
@@ -290,7 +282,7 @@ fn it_passes_additional_headers() {
                         }
                     ]
                 }]
-            }]
+            }
         }]
     }"#;
 
@@ -431,8 +423,7 @@ fn it_rate_limits_with_empty_conditions() {
         {
             "name": "some-name",
             "hostnames": ["*.com"],
-            "rules": [
-            {
+            "routeRuleConditions": {
                 "actions": [
                 {
                     "extension": "limitador",
@@ -446,7 +437,7 @@ fn it_rate_limits_with_empty_conditions() {
                         }
                     ]
                 }]
-            }]
+            }
         }]
     }"#;
 
@@ -554,8 +545,7 @@ fn it_does_not_rate_limits_when_selector_does_not_exist_and_misses_default_value
         {
             "name": "some-name",
             "hostnames": ["*.com"],
-            "rules": [
-            {
+            "routeRuleConditions": {
                 "actions": [
                 {
                     "extension": "limitador",
@@ -568,7 +558,7 @@ fn it_does_not_rate_limits_when_selector_does_not_exist_and_misses_default_value
                         }
                     ]
                 }]
-            }]
+            }
         }]
     }"#;
 

--- a/tests/rate_limited.rs
+++ b/tests/rate_limited.rs
@@ -94,8 +94,8 @@ fn it_limits() {
         "actionSets": [
         {
             "name": "some-name",
-            "hostnames": ["*.toystore.com", "example.com"],
             "routeRuleConditions": {
+                "hostnames": ["*.toystore.com", "example.com"],
                 "matches": [
                 {
                     "selector": "request.url_path",
@@ -251,8 +251,8 @@ fn it_passes_additional_headers() {
         "actionSets": [
         {
             "name": "some-name",
-            "hostnames": ["*.toystore.com", "example.com"],
             "routeRuleConditions": {
+                "hostnames": ["*.toystore.com", "example.com"],
                 "matches": [
                 {
                     "selector": "request.url_path",
@@ -422,8 +422,8 @@ fn it_rate_limits_with_empty_conditions() {
         "actionSets": [
         {
             "name": "some-name",
-            "hostnames": ["*.com"],
             "routeRuleConditions": {
+                "hostnames": ["*.com"],
                 "actions": [
                 {
                     "extension": "limitador",
@@ -544,8 +544,8 @@ fn it_does_not_rate_limits_when_selector_does_not_exist_and_misses_default_value
         "actionSets": [
         {
             "name": "some-name",
-            "hostnames": ["*.com"],
             "routeRuleConditions": {
+                "hostnames": ["*.com"],
                 "actions": [
                 {
                     "extension": "limitador",

--- a/tests/remote_address.rs
+++ b/tests/remote_address.rs
@@ -33,8 +33,8 @@ fn it_limits_based_on_source_address() {
         "actionSets": [
             {
                 "name": "some-name",
-                "hostnames": ["*.example.com"],
                 "routeRuleConditions": {
+                    "hostnames": ["*.example.com"],
                     "matches": [
                         {
                             "selector": "source.remote_address",

--- a/tests/remote_address.rs
+++ b/tests/remote_address.rs
@@ -41,22 +41,22 @@ fn it_limits_based_on_source_address() {
                             "operator": "neq",
                             "value": "50.0.0.1"
                         }
-                    ],
-                    "actions": [
-                        {
-                            "extension": "limitador",
-                            "scope": "RLS-domain",
-                            "data": [
-                                {
-                                    "selector": {
-                                        "selector": "source.remote_address",
-                                        "value": "1"
-                                    }
-                                }
-                            ]
-                        }
                     ]
-                }
+                },
+                "actions": [
+                    {
+                        "extension": "limitador",
+                        "scope": "RLS-domain",
+                        "data": [
+                            {
+                                "selector": {
+                                    "selector": "source.remote_address",
+                                    "value": "1"
+                                }
+                            }
+                        ]
+                    }
+                ]
             }
         ]
     }"#;

--- a/tests/remote_address.rs
+++ b/tests/remote_address.rs
@@ -22,7 +22,7 @@ fn it_limits_based_on_source_address() {
 
     let root_context = 1;
     let cfg = r#"{
-        "extensions": {
+        "services": {
             "limitador": {
                 "type": "ratelimit",
                 "endpoint": "limitador-cluster",
@@ -45,7 +45,7 @@ fn it_limits_based_on_source_address() {
                 },
                 "actions": [
                     {
-                        "extension": "limitador",
+                        "service": "limitador",
                         "scope": "RLS-domain",
                         "data": [
                             {

--- a/tests/remote_address.rs
+++ b/tests/remote_address.rs
@@ -34,35 +34,29 @@ fn it_limits_based_on_source_address() {
             {
                 "name": "some-name",
                 "hostnames": ["*.example.com"],
-                "rules": [
-                    {
-                        "conditions": [
-                            {
-                                "allOf": [
-                                    {
+                "routeRuleConditions": {
+                    "matches": [
+                        {
+                            "selector": "source.remote_address",
+                            "operator": "neq",
+                            "value": "50.0.0.1"
+                        }
+                    ],
+                    "actions": [
+                        {
+                            "extension": "limitador",
+                            "scope": "RLS-domain",
+                            "data": [
+                                {
+                                    "selector": {
                                         "selector": "source.remote_address",
-                                        "operator": "neq",
-                                        "value": "50.0.0.1"
+                                        "value": "1"
                                     }
-                                ]
-                            }
-                        ],
-                        "actions": [
-                            {
-                                "extension": "limitador",
-                                "scope": "RLS-domain",
-                                "data": [
-                                    {
-                                        "selector": {
-                                            "selector": "source.remote_address",
-                                            "value": "1"
-                                        }
-                                    }
-                                ]
-                            }
-                        ]
-                    }
-                ]
+                                }
+                            ]
+                        }
+                    ]
+                }
             }
         ]
     }"#;

--- a/tests/remote_address.rs
+++ b/tests/remote_address.rs
@@ -30,7 +30,7 @@ fn it_limits_based_on_source_address() {
                 "timeout": "5s"
             }
         },
-        "policies": [
+        "actionSets": [
             {
                 "name": "some-name",
                 "hostnames": ["*.example.com"],
@@ -100,7 +100,10 @@ fn it_limits_based_on_source_address() {
         )
         .expect_get_property(Some(vec!["source", "address"]))
         .returning(Some("40.0.0.1:0".as_bytes()))
-        .expect_log(Some(LogLevel::Debug), Some("#2 policy selected some-name"))
+        .expect_log(
+            Some(LogLevel::Debug),
+            Some("#2 action_set selected some-name"),
+        )
         // retrieving properties for data
         .expect_log(
             Some(LogLevel::Debug),

--- a/utils/deploy/envoy-notls.yaml
+++ b/utils/deploy/envoy-notls.yaml
@@ -342,6 +342,46 @@ data:
                                           ]
                                         }
                                       ]
+                                    },
+                                    {
+                                      "name": "multi-ns-B/multi-name-B",
+                                      "routeRuleConditions": {
+                                        "hostnames": [
+                                          "*.b.multi.com"
+                                        ],
+                                        "matches": [
+                                          {
+                                            "selector": "request.path",
+                                            "operator": "eq",
+                                            "value": "/get"
+                                          }
+                                        ]
+                                      },
+                                      "actions": [
+                                        {
+                                          "service": "authorino",
+                                          "scope": "effective-route-1"
+                                        },
+                                        {
+                                          "service": "limitador",
+                                          "scope": "multi-ns-B/multi-name-B",
+                                          "conditions": [
+                                            {
+                                              "selector": "filter_state.wasm\\.kuadrant\\.identity\\.userid",
+                                              "operator": "eq",
+                                              "value": "alice"
+                                            }
+                                          ],
+                                          "data": [
+                                            {
+                                              "static": {
+                                                "key": "user_id",
+                                                "value": "alice"
+                                              }
+                                            }
+                                          ]
+                                        }
+                                      ]
                                     }
                                   ]
                                 }

--- a/utils/deploy/envoy-notls.yaml
+++ b/utils/deploy/envoy-notls.yaml
@@ -152,10 +152,10 @@ data:
                                   "actionSets": [
                                     {
                                       "name": "auth-ns-A/auth-name-A",
-                                      "hostnames": [
-                                        "*.a.auth.com"
-                                      ],
                                       "routeRuleConditions": {
+                                        "hostnames": [
+                                          "*.a.auth.com"
+                                        ],
                                         "matches": [
                                           {
                                             "selector": "request.path",
@@ -173,10 +173,10 @@ data:
                                     },
                                     {
                                       "name": "rlp-ns-A/rlp-name-A",
-                                      "hostnames": [
-                                        "*.a.rlp.com"
-                                      ],
                                       "routeRuleConditions": {
+                                        "hostnames": [
+                                          "*.a.rlp.com"
+                                        ],
                                         "actions": [
                                           {
                                             "extension": "limitador",
@@ -194,10 +194,10 @@ data:
                                     },
                                     {
                                       "name": "rlp-ns-B/rlp-name-B",
-                                      "hostnames": [
-                                        "*.b.rlp.com"
-                                      ],
                                       "routeRuleConditions": {
+                                        "hostnames": [
+                                          "*.b.rlp.com"
+                                        ],
                                         "matches": [
                                           {
                                             "selector": "request.url_path",
@@ -223,10 +223,10 @@ data:
                                     },
                                     {
                                       "name": "rlp-ns-C/rlp-name-C",
-                                      "hostnames": [
-                                        "*.c.rlp.com"
-                                      ],
                                       "routeRuleConditions": {
+                                        "hostnames": [
+                                          "*.c.rlp.com"
+                                        ],
                                         "matches": [
                                           {
                                             "selector": "request.url_path",
@@ -312,10 +312,10 @@ data:
                                     },
                                     {
                                       "name": "multi-ns-A/multi-name-A",
-                                      "hostnames": [
-                                        "*.a.multi.com"
-                                      ],
                                       "routeRuleConditions": {
+                                        "hostnames": [
+                                          "*.a.multi.com"
+                                        ],
                                         "matches": [
                                           {
                                             "selector": "request.path",

--- a/utils/deploy/envoy-notls.yaml
+++ b/utils/deploy/envoy-notls.yaml
@@ -162,35 +162,35 @@ data:
                                             "operator": "eq",
                                             "value": "/get"
                                           }
-                                        ],
-                                        "actions": [
-                                          {
-                                            "extension": "authorino",
-                                            "scope": "effective-route-1"
-                                          }
                                         ]
-                                      }
+                                      },
+                                      "actions": [
+                                        {
+                                          "extension": "authorino",
+                                          "scope": "effective-route-1"
+                                        }
+                                      ]
                                     },
                                     {
                                       "name": "rlp-ns-A/rlp-name-A",
                                       "routeRuleConditions": {
                                         "hostnames": [
                                           "*.a.rlp.com"
-                                        ],
-                                        "actions": [
-                                          {
-                                            "extension": "limitador",
-                                            "scope": "rlp-ns-A/rlp-name-A",
-                                            "data": [
-                                              {
-                                                "selector": {
-                                                  "selector": "unknown.path"
-                                                }
-                                              }
-                                            ]
-                                          }
                                         ]
-                                      }
+                                      },
+                                      "actions": [
+                                        {
+                                          "extension": "limitador",
+                                          "scope": "rlp-ns-A/rlp-name-A",
+                                          "data": [
+                                            {
+                                              "selector": {
+                                                "selector": "unknown.path"
+                                              }
+                                            }
+                                          ]
+                                        }
+                                      ]
                                     },
                                     {
                                       "name": "rlp-ns-B/rlp-name-B",
@@ -204,22 +204,22 @@ data:
                                             "operator": "startswith",
                                             "value": "/unknown-path"
                                           }
-                                        ],
-                                        "actions": [
-                                          {
-                                            "extension": "limitador",
-                                            "scope": "rlp-ns-B/rlp-name-B",
-                                            "data": [
-                                              {
-                                                "static": {
-                                                  "key": "rlp-ns-B/rlp-name-B/limit-not-to-be-activated",
-                                                  "value": "1"
-                                                }
-                                              }
-                                            ]
-                                          }
                                         ]
-                                      }
+                                      },
+                                      "actions": [
+                                        {
+                                          "extension": "limitador",
+                                          "scope": "rlp-ns-B/rlp-name-B",
+                                          "data": [
+                                            {
+                                              "static": {
+                                                "key": "rlp-ns-B/rlp-name-B/limit-not-to-be-activated",
+                                                "value": "1"
+                                              }
+                                            }
+                                          ]
+                                        }
+                                      ]
                                     },
                                     {
                                       "name": "rlp-ns-C/rlp-name-C",
@@ -243,38 +243,38 @@ data:
                                             "operator": "eq",
                                             "value": "GET"
                                           }
-                                        ],
-                                        "actions": [
-                                          {
-                                            "extension": "limitador",
-                                            "scope": "rlp-ns-C/rlp-name-C",
-                                            "data": [
-                                              {
-                                                "static": {
-                                                  "key": "limit_to_be_activated",
-                                                  "value": "1"
-                                                }
-                                              },
-                                              {
-                                                "selector": {
-                                                  "selector": "source.address"
-                                                }
-                                              },
-                                              {
-                                                "selector": {
-                                                  "selector": "request.headers.My-Custom-Header-01"
-                                                }
-                                              },
-                                              {
-                                                "selector": {
-                                                  "selector": "metadata.filter_metadata.envoy\\.filters\\.http\\.header_to_metadata.user_id",
-                                                  "key": "user_id"
-                                                }
-                                              }
-                                            ]
-                                          }
                                         ]
-                                      }
+                                      },
+                                      "actions": [
+                                        {
+                                          "extension": "limitador",
+                                          "scope": "rlp-ns-C/rlp-name-C",
+                                          "data": [
+                                            {
+                                              "static": {
+                                                "key": "limit_to_be_activated",
+                                                "value": "1"
+                                              }
+                                            },
+                                            {
+                                              "selector": {
+                                                "selector": "source.address"
+                                              }
+                                            },
+                                            {
+                                              "selector": {
+                                                "selector": "request.headers.My-Custom-Header-01"
+                                              }
+                                            },
+                                            {
+                                              "selector": {
+                                                "selector": "metadata.filter_metadata.envoy\\.filters\\.http\\.header_to_metadata.user_id",
+                                                "key": "user_id"
+                                              }
+                                            }
+                                          ]
+                                        }
+                                      ]
                                     },
                                     {
                                       "name": "rlp-ns-D/rlp-name-D",
@@ -322,26 +322,26 @@ data:
                                             "operator": "eq",
                                             "value": "/get"
                                           }
-                                        ],
-                                        "actions": [
-                                          {
-                                            "extension": "authorino",
-                                            "scope": "effective-route-1"
-                                          },
-                                          {
-                                            "extension": "limitador",
-                                            "scope": "multi-ns-A/multi-name-A",
-                                            "data": [
-                                              {
-                                                "selector": {
-                                                  "selector": "filter_state.wasm\\.kuadrant\\.identity\\.userid",
-                                                  "key": "user_id"
-                                                }
-                                              }
-                                            ]
-                                          }
                                         ]
-                                      }
+                                      },
+                                      "actions": [
+                                        {
+                                          "extension": "authorino",
+                                          "scope": "effective-route-1"
+                                        },
+                                        {
+                                          "extension": "limitador",
+                                          "scope": "multi-ns-A/multi-name-A",
+                                          "data": [
+                                            {
+                                              "selector": {
+                                                "selector": "filter_state.wasm\\.kuadrant\\.identity\\.userid",
+                                                "key": "user_id"
+                                              }
+                                            }
+                                          ]
+                                        }
+                                      ]
                                     }
                                   ]
                                 }

--- a/utils/deploy/envoy-notls.yaml
+++ b/utils/deploy/envoy-notls.yaml
@@ -155,146 +155,126 @@ data:
                                       "hostnames": [
                                         "*.a.auth.com"
                                       ],
-                                      "rules": [
-                                        {
-                                          "conditions": [
-                                            {
-                                              "allOf": [
-                                                {
-                                                  "selector": "request.path",
-                                                  "operator": "eq",
-                                                  "value": "/get"
-                                                }
-                                              ]
-                                            }
-                                          ],
-                                          "actions": [
-                                            {
-                                              "extension": "authorino",
-                                              "scope": "effective-route-1"
-                                            }
-                                          ]
-                                        }
-                                      ]
+                                      "routeRuleConditions": {
+                                        "matches": [
+                                          {
+                                            "selector": "request.path",
+                                            "operator": "eq",
+                                            "value": "/get"
+                                          }
+                                        ],
+                                        "actions": [
+                                          {
+                                            "extension": "authorino",
+                                            "scope": "effective-route-1"
+                                          }
+                                        ]
+                                      }
                                     },
                                     {
                                       "name": "rlp-ns-A/rlp-name-A",
                                       "hostnames": [
                                         "*.a.rlp.com"
                                       ],
-                                      "rules": [
-                                        {
-                                          "actions": [
-                                            {
-                                              "extension": "limitador",
-                                              "scope": "rlp-ns-A/rlp-name-A",
-                                              "data": [
-                                                {
-                                                  "selector": {
-                                                    "selector": "unknown.path"
-                                                  }
+                                      "routeRuleConditions": {
+                                        "actions": [
+                                          {
+                                            "extension": "limitador",
+                                            "scope": "rlp-ns-A/rlp-name-A",
+                                            "data": [
+                                              {
+                                                "selector": {
+                                                  "selector": "unknown.path"
                                                 }
-                                              ]
-                                            }
-                                          ]
-                                        }
-                                      ]
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      }
                                     },
                                     {
                                       "name": "rlp-ns-B/rlp-name-B",
                                       "hostnames": [
                                         "*.b.rlp.com"
                                       ],
-                                      "rules": [
-                                        {
-                                          "conditions": [
-                                            {
-                                              "allOf": [
-                                                {
-                                                  "selector": "request.url_path",
-                                                  "operator": "startswith",
-                                                  "value": "/unknown-path"
+                                      "routeRuleConditions": {
+                                        "matches": [
+                                          {
+                                            "selector": "request.url_path",
+                                            "operator": "startswith",
+                                            "value": "/unknown-path"
+                                          }
+                                        ],
+                                        "actions": [
+                                          {
+                                            "extension": "limitador",
+                                            "scope": "rlp-ns-B/rlp-name-B",
+                                            "data": [
+                                              {
+                                                "static": {
+                                                  "key": "rlp-ns-B/rlp-name-B/limit-not-to-be-activated",
+                                                  "value": "1"
                                                 }
-                                              ]
-                                            }
-                                          ],
-                                          "actions": [
-                                            {
-                                              "extension": "limitador",
-                                              "scope": "rlp-ns-B/rlp-name-B",
-                                              "data": [
-                                                {
-                                                  "static": {
-                                                    "key": "rlp-ns-B/rlp-name-B/limit-not-to-be-activated",
-                                                    "value": "1"
-                                                  }
-                                                }
-                                              ]
-                                            }
-                                          ]
-                                        }
-                                      ]
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      }
                                     },
                                     {
                                       "name": "rlp-ns-C/rlp-name-C",
                                       "hostnames": [
                                         "*.c.rlp.com"
                                       ],
-                                      "rules": [
-                                        {
-                                          "conditions": [
-                                            {
-                                              "allOf": [
-                                                {
-                                                  "selector": "request.url_path",
-                                                  "operator": "startswith",
-                                                  "value": "/get"
-                                                },
-                                                {
-                                                  "selector": "request.host",
-                                                  "operator": "eq",
-                                                  "value": "test.c.rlp.com"
-                                                },
-                                                {
-                                                  "selector": "request.method",
-                                                  "operator": "eq",
-                                                  "value": "GET"
+                                      "routeRuleConditions": {
+                                        "matches": [
+                                          {
+                                            "selector": "request.url_path",
+                                            "operator": "startswith",
+                                            "value": "/get"
+                                          },
+                                          {
+                                            "selector": "request.host",
+                                            "operator": "eq",
+                                            "value": "test.c.rlp.com"
+                                          },
+                                          {
+                                            "selector": "request.method",
+                                            "operator": "eq",
+                                            "value": "GET"
+                                          }
+                                        ],
+                                        "actions": [
+                                          {
+                                            "extension": "limitador",
+                                            "scope": "rlp-ns-C/rlp-name-C",
+                                            "data": [
+                                              {
+                                                "static": {
+                                                  "key": "limit_to_be_activated",
+                                                  "value": "1"
                                                 }
-                                              ]
-                                            }
-                                          ],
-                                          "actions": [
-                                            {
-                                              "extension": "limitador",
-                                              "scope": "rlp-ns-C/rlp-name-C",
-                                              "data": [
-                                                {
-                                                  "static": {
-                                                    "key": "limit_to_be_activated",
-                                                    "value": "1"
-                                                  }
-                                                },
-                                                {
-                                                  "selector": {
-                                                    "selector": "source.address"
-                                                  }
-                                                },
-                                                {
-                                                  "selector": {
-                                                    "selector": "request.headers.My-Custom-Header-01"
-                                                  }
-                                                },
-                                                {
-                                                  "selector": {
-                                                    "selector": "metadata.filter_metadata.envoy\\.filters\\.http\\.header_to_metadata.user_id",
-                                                    "key": "user_id"
-                                                  }
+                                              },
+                                              {
+                                                "selector": {
+                                                  "selector": "source.address"
                                                 }
-                                              ]
-                                            }
-                                          ]
-                                        }
-                                      ]
+                                              },
+                                              {
+                                                "selector": {
+                                                  "selector": "request.headers.My-Custom-Header-01"
+                                                }
+                                              },
+                                              {
+                                                "selector": {
+                                                  "selector": "metadata.filter_metadata.envoy\\.filters\\.http\\.header_to_metadata.user_id",
+                                                  "key": "user_id"
+                                                }
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      }
                                     },
                                     {
                                       "name": "rlp-ns-D/rlp-name-D",
@@ -335,39 +315,33 @@ data:
                                       "hostnames": [
                                         "*.a.multi.com"
                                       ],
-                                      "rules": [
-                                        {
-                                          "conditions": [
-                                            {
-                                              "allOf": [
-                                                {
-                                                  "selector": "request.path",
-                                                  "operator": "eq",
-                                                  "value": "/get"
+                                      "routeRuleConditions": {
+                                        "matches": [
+                                          {
+                                            "selector": "request.path",
+                                            "operator": "eq",
+                                            "value": "/get"
+                                          }
+                                        ],
+                                        "actions": [
+                                          {
+                                            "extension": "authorino",
+                                            "scope": "effective-route-1"
+                                          },
+                                          {
+                                            "extension": "limitador",
+                                            "scope": "multi-ns-A/multi-name-A",
+                                            "data": [
+                                              {
+                                                "selector": {
+                                                  "selector": "filter_state.wasm\\.kuadrant\\.identity\\.userid",
+                                                  "key": "user_id"
                                                 }
-                                              ]
-                                            }
-                                          ],
-                                          "actions": [
-                                            {
-                                              "extension": "authorino",
-                                              "scope": "effective-route-1"
-                                            },
-                                            {
-                                              "extension": "limitador",
-                                              "scope": "multi-ns-A/multi-name-A",
-                                              "data": [
-                                                {
-                                                  "selector": {
-                                                    "selector": "filter_state.wasm\\.kuadrant\\.identity\\.userid",
-                                                    "key": "user_id"
-                                                  }
-                                                }
-                                              ]
-                                            }
-                                          ]
-                                        }
-                                      ]
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      }
                                     }
                                   ]
                                 }

--- a/utils/deploy/envoy-notls.yaml
+++ b/utils/deploy/envoy-notls.yaml
@@ -137,7 +137,7 @@ data:
                               "@type": "type.googleapis.com/google.protobuf.StringValue"
                               value: >
                                 {
-                                  "extensions": {
+                                  "services": {
                                     "authorino": {
                                       "type": "auth",
                                       "endpoint": "authorino_wasm",
@@ -166,7 +166,7 @@ data:
                                       },
                                       "actions": [
                                         {
-                                          "extension": "authorino",
+                                          "service": "authorino",
                                           "scope": "effective-route-1"
                                         }
                                       ]
@@ -180,7 +180,7 @@ data:
                                       },
                                       "actions": [
                                         {
-                                          "extension": "limitador",
+                                          "service": "limitador",
                                           "scope": "rlp-ns-A/rlp-name-A",
                                           "data": [
                                             {
@@ -208,7 +208,7 @@ data:
                                       },
                                       "actions": [
                                         {
-                                          "extension": "limitador",
+                                          "service": "limitador",
                                           "scope": "rlp-ns-B/rlp-name-B",
                                           "data": [
                                             {
@@ -247,7 +247,7 @@ data:
                                       },
                                       "actions": [
                                         {
-                                          "extension": "limitador",
+                                          "service": "limitador",
                                           "scope": "rlp-ns-C/rlp-name-C",
                                           "data": [
                                             {
@@ -326,11 +326,11 @@ data:
                                       },
                                       "actions": [
                                         {
-                                          "extension": "authorino",
+                                          "service": "authorino",
                                           "scope": "effective-route-1"
                                         },
                                         {
-                                          "extension": "limitador",
+                                          "service": "limitador",
                                           "scope": "multi-ns-A/multi-name-A",
                                           "data": [
                                             {

--- a/utils/deploy/envoy-notls.yaml
+++ b/utils/deploy/envoy-notls.yaml
@@ -149,7 +149,7 @@ data:
                                       "failureMode": "deny"
                                     }
                                   },
-                                  "policies": [
+                                  "actionSets": [
                                     {
                                       "name": "auth-ns-A/auth-name-A",
                                       "hostnames": [

--- a/utils/deploy/envoy-tls.yaml
+++ b/utils/deploy/envoy-tls.yaml
@@ -145,7 +145,7 @@ data:
                               "@type": "type.googleapis.com/google.protobuf.StringValue"
                               value: >
                                 {
-                                  "extensions": {
+                                  "services": {
                                     "authorino": {
                                       "type": "auth",
                                       "endpoint": "authorino_wasm",
@@ -174,7 +174,7 @@ data:
                                       },
                                       "actions": [
                                         {
-                                          "extension": "authorino",
+                                          "service": "authorino",
                                           "scope": "effective-route-1"
                                         }
                                       ]
@@ -188,7 +188,7 @@ data:
                                       },
                                       "actions": [
                                         {
-                                          "extension": "limitador",
+                                          "service": "limitador",
                                           "scope": "rlp-ns-A/rlp-name-A",
                                           "data": [
                                             {
@@ -216,7 +216,7 @@ data:
                                       },
                                       "actions": [
                                         {
-                                          "extension": "limitador",
+                                          "service": "limitador",
                                           "scope": "rlp-ns-B/rlp-name-B",
                                           "data": [
                                             {
@@ -255,7 +255,7 @@ data:
                                       },
                                       "actions": [
                                         {
-                                          "extension": "limitador",
+                                          "service": "limitador",
                                           "scope": "rlp-ns-C/rlp-name-C",
                                           "data": [
                                             {
@@ -334,11 +334,11 @@ data:
                                       },
                                       "actions": [
                                         {
-                                          "extension": "authorino",
+                                          "service": "authorino",
                                           "scope": "effective-route-1"
                                         },
                                         {
-                                          "extension": "limitador",
+                                          "service": "limitador",
                                           "scope": "multi-ns-A/multi-name-A",
                                           "data": [
                                             {

--- a/utils/deploy/envoy-tls.yaml
+++ b/utils/deploy/envoy-tls.yaml
@@ -160,10 +160,10 @@ data:
                                   "actionSets": [
                                     {
                                       "name": "auth-ns-A/auth-name-A",
-                                      "hostnames": [
-                                        "*.a.auth.com"
-                                      ],
                                       "routeRuleConditions": {
+                                        "hostnames": [
+                                          "*.a.auth.com"
+                                        ],
                                         "matches": [
                                           {
                                             "selector": "request.path",
@@ -181,10 +181,10 @@ data:
                                     },
                                     {
                                       "name": "rlp-ns-A/rlp-name-A",
-                                      "hostnames": [
-                                        "*.a.rlp.com"
-                                      ],
                                       "routeRuleConditions": {
+                                        "hostnames": [
+                                          "*.a.rlp.com"
+                                        ],
                                         "actions": [
                                           {
                                             "extension": "limitador",
@@ -202,10 +202,10 @@ data:
                                     },
                                     {
                                       "name": "rlp-ns-B/rlp-name-B",
-                                      "hostnames": [
-                                        "*.b.rlp.com"
-                                      ],
                                       "routeRuleConditions": {
+                                        "hostnames": [
+                                          "*.b.rlp.com"
+                                        ],
                                         "matches": [
                                           {
                                             "selector": "request.url_path",
@@ -231,10 +231,10 @@ data:
                                     },
                                     {
                                       "name": "rlp-ns-C/rlp-name-C",
-                                      "hostnames": [
-                                        "*.c.rlp.com"
-                                      ],
                                       "routeRuleConditions": {
+                                        "hostnames": [
+                                          "*.c.rlp.com"
+                                        ],
                                         "matches": [
                                           {
                                             "selector": "request.url_path",
@@ -320,10 +320,10 @@ data:
                                     },
                                     {
                                       "name": "multi-ns-A/multi-name-A",
-                                      "hostnames": [
-                                        "*.a.multi.com"
-                                      ],
                                       "routeRuleConditions": {
+                                        "hostnames": [
+                                          "*.a.multi.com"
+                                        ],
                                         "matches": [
                                           {
                                             "selector": "request.path",

--- a/utils/deploy/envoy-tls.yaml
+++ b/utils/deploy/envoy-tls.yaml
@@ -157,7 +157,7 @@ data:
                                       "failureMode": "deny"
                                     }
                                   },
-                                  "policies": [
+                                  "actionSets": [
                                     {
                                       "name": "auth-ns-A/auth-name-A",
                                       "hostnames": [

--- a/utils/deploy/envoy-tls.yaml
+++ b/utils/deploy/envoy-tls.yaml
@@ -350,6 +350,46 @@ data:
                                           ]
                                         }
                                       ]
+                                    },
+                                    {
+                                      "name": "multi-ns-B/multi-name-B",
+                                      "routeRuleConditions": {
+                                        "hostnames": [
+                                          "*.b.multi.com"
+                                        ],
+                                        "matches": [
+                                          {
+                                            "selector": "request.path",
+                                            "operator": "eq",
+                                            "value": "/get"
+                                          }
+                                        ]
+                                      },
+                                      "actions": [
+                                        {
+                                          "service": "authorino",
+                                          "scope": "effective-route-1"
+                                        },
+                                        {
+                                          "service": "limitador",
+                                          "scope": "multi-ns-B/multi-name-B",
+                                          "conditions": [
+                                            {
+                                              "selector": "filter_state.wasm\\.kuadrant\\.identity\\.userid",
+                                              "operator": "eq",
+                                              "value": "alice"
+                                            }
+                                          ],
+                                          "data": [
+                                            {
+                                              "static": {
+                                                "key": "user_id",
+                                                "value": "alice"
+                                              }
+                                            }
+                                          ]
+                                        }
+                                      ]
                                     }
                                   ]
                                 }

--- a/utils/deploy/envoy-tls.yaml
+++ b/utils/deploy/envoy-tls.yaml
@@ -170,35 +170,35 @@ data:
                                             "operator": "eq",
                                             "value": "/get"
                                           }
-                                        ],
-                                        "actions": [
-                                          {
-                                            "extension": "authorino",
-                                            "scope": "effective-route-1"
-                                          }
                                         ]
-                                      }
+                                      },
+                                      "actions": [
+                                        {
+                                          "extension": "authorino",
+                                          "scope": "effective-route-1"
+                                        }
+                                      ]
                                     },
                                     {
                                       "name": "rlp-ns-A/rlp-name-A",
                                       "routeRuleConditions": {
                                         "hostnames": [
                                           "*.a.rlp.com"
-                                        ],
-                                        "actions": [
-                                          {
-                                            "extension": "limitador",
-                                            "scope": "rlp-ns-A/rlp-name-A",
-                                            "data": [
-                                              {
-                                                "selector": {
-                                                  "selector": "unknown.path"
-                                                }
-                                              }
-                                            ]
-                                          }
                                         ]
-                                      }
+                                      },
+                                      "actions": [
+                                        {
+                                          "extension": "limitador",
+                                          "scope": "rlp-ns-A/rlp-name-A",
+                                          "data": [
+                                            {
+                                              "selector": {
+                                                "selector": "unknown.path"
+                                              }
+                                            }
+                                          ]
+                                        }
+                                      ]
                                     },
                                     {
                                       "name": "rlp-ns-B/rlp-name-B",
@@ -212,22 +212,22 @@ data:
                                             "operator": "startswith",
                                             "value": "/unknown-path"
                                           }
-                                        ],
-                                        "actions": [
-                                          {
-                                            "extension": "limitador",
-                                            "scope": "rlp-ns-B/rlp-name-B",
-                                            "data": [
-                                              {
-                                                "static": {
-                                                  "key": "rlp-ns-B/rlp-name-B/limit-not-to-be-activated",
-                                                  "value": "1"
-                                                }
-                                              }
-                                            ]
-                                          }
                                         ]
-                                      }
+                                      },
+                                      "actions": [
+                                        {
+                                          "extension": "limitador",
+                                          "scope": "rlp-ns-B/rlp-name-B",
+                                          "data": [
+                                            {
+                                              "static": {
+                                                "key": "rlp-ns-B/rlp-name-B/limit-not-to-be-activated",
+                                                "value": "1"
+                                              }
+                                            }
+                                          ]
+                                        }
+                                      ]
                                     },
                                     {
                                       "name": "rlp-ns-C/rlp-name-C",
@@ -251,38 +251,38 @@ data:
                                             "operator": "eq",
                                             "value": "GET"
                                           }
-                                        ],
-                                        "actions": [
-                                          {
-                                            "extension": "limitador",
-                                            "scope": "rlp-ns-C/rlp-name-C",
-                                            "data": [
-                                              {
-                                                "static": {
-                                                  "key": "limit_to_be_activated",
-                                                  "value": "1"
-                                                }
-                                              },
-                                              {
-                                                "selector": {
-                                                  "selector": "source.address"
-                                                }
-                                              },
-                                              {
-                                                "selector": {
-                                                  "selector": "request.headers.My-Custom-Header-01"
-                                                }
-                                              },
-                                              {
-                                                "selector": {
-                                                  "selector": "metadata.filter_metadata.envoy\\.filters\\.http\\.header_to_metadata.user_id",
-                                                  "key": "user_id"
-                                                }
-                                              }
-                                            ]
-                                          }
                                         ]
-                                      }
+                                      },
+                                      "actions": [
+                                        {
+                                          "extension": "limitador",
+                                          "scope": "rlp-ns-C/rlp-name-C",
+                                          "data": [
+                                            {
+                                              "static": {
+                                                "key": "limit_to_be_activated",
+                                                "value": "1"
+                                              }
+                                            },
+                                            {
+                                              "selector": {
+                                                "selector": "source.address"
+                                              }
+                                            },
+                                            {
+                                              "selector": {
+                                                "selector": "request.headers.My-Custom-Header-01"
+                                              }
+                                            },
+                                            {
+                                              "selector": {
+                                                "selector": "metadata.filter_metadata.envoy\\.filters\\.http\\.header_to_metadata.user_id",
+                                                "key": "user_id"
+                                              }
+                                            }
+                                          ]
+                                        }
+                                      ]
                                     },
                                     {
                                       "name": "rlp-ns-D/rlp-name-D",
@@ -330,26 +330,26 @@ data:
                                             "operator": "eq",
                                             "value": "/get"
                                           }
-                                        ],
-                                        "actions": [
-                                          {
-                                            "extension": "authorino",
-                                            "scope": "effective-route-1"
-                                          },
-                                          {
-                                            "extension": "limitador",
-                                            "scope": "multi-ns-A/multi-name-A",
-                                            "data": [
-                                              {
-                                                "selector": {
-                                                  "selector": "filter_state.wasm\\.kuadrant\\.identity\\.userid",
-                                                  "key": "user_id"
-                                                }
-                                              }
-                                            ]
-                                          }
                                         ]
-                                      }
+                                      },
+                                      "actions": [
+                                        {
+                                          "extension": "authorino",
+                                          "scope": "effective-route-1"
+                                        },
+                                        {
+                                          "extension": "limitador",
+                                          "scope": "multi-ns-A/multi-name-A",
+                                          "data": [
+                                            {
+                                              "selector": {
+                                                "selector": "filter_state.wasm\\.kuadrant\\.identity\\.userid",
+                                                "key": "user_id"
+                                              }
+                                            }
+                                          ]
+                                        }
+                                      ]
                                     }
                                   ]
                                 }

--- a/utils/deploy/envoy-tls.yaml
+++ b/utils/deploy/envoy-tls.yaml
@@ -163,146 +163,126 @@ data:
                                       "hostnames": [
                                         "*.a.auth.com"
                                       ],
-                                      "rules": [
-                                        {
-                                          "conditions": [
-                                            {
-                                              "allOf": [
-                                                {
-                                                  "selector": "request.path",
-                                                  "operator": "eq",
-                                                  "value": "/get"
-                                                }
-                                              ]
-                                            }
-                                          ],
-                                          "actions": [
-                                            {
-                                              "extension": "authorino",
-                                              "scope": "effective-route-1"
-                                            }
-                                          ]
-                                        }
-                                      ]
+                                      "routeRuleConditions": {
+                                        "matches": [
+                                          {
+                                            "selector": "request.path",
+                                            "operator": "eq",
+                                            "value": "/get"
+                                          }
+                                        ],
+                                        "actions": [
+                                          {
+                                            "extension": "authorino",
+                                            "scope": "effective-route-1"
+                                          }
+                                        ]
+                                      }
                                     },
                                     {
                                       "name": "rlp-ns-A/rlp-name-A",
                                       "hostnames": [
                                         "*.a.rlp.com"
                                       ],
-                                      "rules": [
-                                        {
-                                          "actions": [
-                                            {
-                                              "extension": "limitador",
-                                              "scope": "rlp-ns-A/rlp-name-A",
-                                              "data": [
-                                                {
-                                                  "selector": {
-                                                    "selector": "unknown.path"
-                                                  }
+                                      "routeRuleConditions": {
+                                        "actions": [
+                                          {
+                                            "extension": "limitador",
+                                            "scope": "rlp-ns-A/rlp-name-A",
+                                            "data": [
+                                              {
+                                                "selector": {
+                                                  "selector": "unknown.path"
                                                 }
-                                              ]
-                                            }
-                                          ]
-                                        }
-                                      ]
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      }
                                     },
                                     {
                                       "name": "rlp-ns-B/rlp-name-B",
                                       "hostnames": [
                                         "*.b.rlp.com"
                                       ],
-                                      "rules": [
-                                        {
-                                          "conditions": [
-                                            {
-                                              "allOf": [
-                                                {
-                                                  "selector": "request.url_path",
-                                                  "operator": "startswith",
-                                                  "value": "/unknown-path"
+                                      "routeRuleConditions": {
+                                        "matches": [
+                                          {
+                                            "selector": "request.url_path",
+                                            "operator": "startswith",
+                                            "value": "/unknown-path"
+                                          }
+                                        ],
+                                        "actions": [
+                                          {
+                                            "extension": "limitador",
+                                            "scope": "rlp-ns-B/rlp-name-B",
+                                            "data": [
+                                              {
+                                                "static": {
+                                                  "key": "rlp-ns-B/rlp-name-B/limit-not-to-be-activated",
+                                                  "value": "1"
                                                 }
-                                              ]
-                                            }
-                                          ],
-                                          "actions": [
-                                            {
-                                              "extension": "limitador",
-                                              "scope": "rlp-ns-B/rlp-name-B",
-                                              "data": [
-                                                {
-                                                  "static": {
-                                                    "key": "rlp-ns-B/rlp-name-B/limit-not-to-be-activated",
-                                                    "value": "1"
-                                                  }
-                                                }
-                                              ]
-                                            }
-                                          ]
-                                        }
-                                      ]
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      }
                                     },
                                     {
                                       "name": "rlp-ns-C/rlp-name-C",
                                       "hostnames": [
                                         "*.c.rlp.com"
                                       ],
-                                      "rules": [
-                                        {
-                                          "conditions": [
-                                            {
-                                              "allOf": [
-                                                {
-                                                  "selector": "request.url_path",
-                                                  "operator": "startswith",
-                                                  "value": "/get"
-                                                },
-                                                {
-                                                  "selector": "request.host",
-                                                  "operator": "eq",
-                                                  "value": "test.c.rlp.com"
-                                                },
-                                                {
-                                                  "selector": "request.method",
-                                                  "operator": "eq",
-                                                  "value": "GET"
+                                      "routeRuleConditions": {
+                                        "matches": [
+                                          {
+                                            "selector": "request.url_path",
+                                            "operator": "startswith",
+                                            "value": "/get"
+                                          },
+                                          {
+                                            "selector": "request.host",
+                                            "operator": "eq",
+                                            "value": "test.c.rlp.com"
+                                          },
+                                          {
+                                            "selector": "request.method",
+                                            "operator": "eq",
+                                            "value": "GET"
+                                          }
+                                        ],
+                                        "actions": [
+                                          {
+                                            "extension": "limitador",
+                                            "scope": "rlp-ns-C/rlp-name-C",
+                                            "data": [
+                                              {
+                                                "static": {
+                                                  "key": "limit_to_be_activated",
+                                                  "value": "1"
                                                 }
-                                              ]
-                                            }
-                                          ],
-                                          "actions": [
-                                            {
-                                              "extension": "limitador",
-                                              "scope": "rlp-ns-C/rlp-name-C",
-                                              "data": [
-                                                {
-                                                  "static": {
-                                                    "key": "limit_to_be_activated",
-                                                    "value": "1"
-                                                  }
-                                                },
-                                                {
-                                                  "selector": {
-                                                    "selector": "source.address"
-                                                  }
-                                                },
-                                                {
-                                                  "selector": {
-                                                    "selector": "request.headers.My-Custom-Header-01"
-                                                  }
-                                                },
-                                                {
-                                                  "selector": {
-                                                    "selector": "metadata.filter_metadata.envoy\\.filters\\.http\\.header_to_metadata.user_id",
-                                                    "key": "user_id"
-                                                  }
+                                              },
+                                              {
+                                                "selector": {
+                                                  "selector": "source.address"
                                                 }
-                                              ]
-                                            }
-                                          ]
-                                        }
-                                      ]
+                                              },
+                                              {
+                                                "selector": {
+                                                  "selector": "request.headers.My-Custom-Header-01"
+                                                }
+                                              },
+                                              {
+                                                "selector": {
+                                                  "selector": "metadata.filter_metadata.envoy\\.filters\\.http\\.header_to_metadata.user_id",
+                                                  "key": "user_id"
+                                                }
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      }
                                     },
                                     {
                                       "name": "rlp-ns-D/rlp-name-D",
@@ -343,39 +323,33 @@ data:
                                       "hostnames": [
                                         "*.a.multi.com"
                                       ],
-                                      "rules": [
-                                        {
-                                          "conditions": [
-                                            {
-                                              "allOf": [
-                                                {
-                                                  "selector": "request.path",
-                                                  "operator": "eq",
-                                                  "value": "/get"
+                                      "routeRuleConditions": {
+                                        "matches": [
+                                          {
+                                            "selector": "request.path",
+                                            "operator": "eq",
+                                            "value": "/get"
+                                          }
+                                        ],
+                                        "actions": [
+                                          {
+                                            "extension": "authorino",
+                                            "scope": "effective-route-1"
+                                          },
+                                          {
+                                            "extension": "limitador",
+                                            "scope": "multi-ns-A/multi-name-A",
+                                            "data": [
+                                              {
+                                                "selector": {
+                                                  "selector": "filter_state.wasm\\.kuadrant\\.identity\\.userid",
+                                                  "key": "user_id"
                                                 }
-                                              ]
-                                            }
-                                          ],
-                                          "actions": [
-                                            {
-                                              "extension": "authorino",
-                                              "scope": "effective-route-1"
-                                            },
-                                            {
-                                              "extension": "limitador",
-                                              "scope": "multi-ns-A/multi-name-A",
-                                              "data": [
-                                                {
-                                                  "selector": {
-                                                    "selector": "filter_state.wasm\\.kuadrant\\.identity\\.userid",
-                                                    "key": "user_id"
-                                                  }
-                                                }
-                                              ]
-                                            }
-                                          ]
-                                        }
-                                      ]
+                                              }
+                                            ]
+                                          }
+                                        ]
+                                      }
                                     }
                                   ]
                                 }

--- a/utils/deploy/limits.yaml
+++ b/utils/deploy/limits.yaml
@@ -6,6 +6,12 @@
     - "limit_to_be_activated == '1'"
     - "user_id == 'bob'"
   variables: []
+- namespace: rlp-ns-D/rlp-name-D
+  max_value: 2
+  seconds: 10
+  conditions: []
+  variables:
+  - source.remote_address
 - namespace: multi-ns-A/multi-name-A
   max_value: 5
   seconds: 10
@@ -18,9 +24,9 @@
   conditions:
     - "user_id == 'bob'"
   variables: []
-- namespace: rlp-ns-D/rlp-name-D
-  max_value: 2
+- namespace: multi-ns-B/multi-name-B
+  max_value: 5
   seconds: 10
-  conditions: []
-  variables:
-    - source.remote_address
+  conditions:
+  - "user_id == 'alice'"
+  variables: []


### PR DESCRIPTION
### Changes

This is moving towards a configuration based on the suggestion in #108.

Currently this is looking as follows:

```yaml
services:
  auth-service:
    type: auth
    endpoint: auth-cluster
    failureMode: deny
    timeout: 10ms
  ratelimit-service:
    type: ratelimit
    endpoint: ratelimit-cluster
    failureMode: deny
actionSets:
  - name: rlp-ns-A/rlp-name-A
    routeRuleConditions:
      hostnames: [ "*.toystore.com" ]
      matches:
      - selector: request.url_path
        operator: startswith
        value: /get
      - selector: request.host
        operator: eq
        value: test.toystore.com
      - selector: request.method
        operator: eq
        value: GET
    actions:
    - service: ratelimit-service
      scope: rlp-ns-A/rlp-name-A
      conditions: []
      data:
      - selector:
          selector: request.headers.My-Custom-Header
      - static:
          key: admin
          value: "1"
```

I've separated all of the changes by commit to try make it easier to read the changes.

The primary change to non-config types is that we now have `actions.conditions` so we can conditionally perform an action - example provided in the envoy configuration that only calls the rate limiting service when `user_id == 'alice'`:

```
make build && make local-setup
```

Port-forward envoy and watch the logs for all services:
```
kubectl port-forward --namespace default deployment/envoy 8000:8000
kubectl logs -f deployment/envoy
kubectl logs -f deployment/authorino
kubectl logs -f deployment/limitador
```

Test unauthenticated does not get rate limited:
```
curl -H "Host: test.b.multi.com" http://127.0.0.1:8000/get -i
# HTTP/1.1 401 Unauthorized
```

Bob is not rate limited (note no calls to limitador in logs):
```
while :; do curl --write-out '%{http_code}\n' --silent --output /dev/null -H "Authorization: APIKEY IAMBOB" -H "Host: test.b.multi.com" http://127.0.0.1:8000/get | grep -E --color "\b(429)\b|$"; sleep 1; done
```

Alice has 5 requests per 10 seconds:
```
while :; do curl --write-out '%{http_code}\n' --silent --output /dev/null -H "Authorization: APIKEY IAMALICE" -H "Host: test.b.multi.com" http://127.0.0.1:8000/get | grep -E --color "\b(429)\b|$"; sleep 1; done
```

### Outstanding

- [x] Tests for conditional actions
- [x] Retrieve the `scope` from `action.data` (won't do)

For a future PR:
- Convert `routeRuleConditions.matches` and `action.conditions` from `PatternExpression` to CEL
- "Merge" subsequent actions of the same type to only make a single call for ratelimit 