### PR TITLE
source.remote_address well known attribute

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -1,0 +1,35 @@
+---
+name: e2e tests
+
+on:
+  push:
+    branches:
+      - 'main'
+  pull_request:
+    branches:
+      - '*'
+jobs:
+  remote_address:
+    name: Remote address integration test
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - uses: actions-rs/toolchain@v1
+      with:
+        profile: minimal
+        toolchain: stable
+        override: true
+        target: wasm32-unknown-unknown
+    - uses: arduino/setup-protoc@v1
+      with:
+        version: '3.x'
+    - uses: actions-rs/cargo@v1
+      with:
+        command: build
+        args: --target wasm32-unknown-unknown
+    - name: Run docker compose
+      run: |
+        docker compose -f ./e2e/remote-address/docker-compose.yaml run start_services
+    - name: Execute tests in the running services
+      run: |
+        make -f ./e2e/remote-address/Makefile test

--- a/README.md
+++ b/README.md
@@ -76,9 +76,7 @@ The only characters taken into account are:
 #### Selectors
 
 Selector of an attribute from the contextual properties provided by kuadrant.
-Currently, only some of the
-[Envoy Attributes](https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/advanced/attributes)
-can be used.
+See [#Well-Known-Attributes] for more info about available attributes.
 
 The struct is
 
@@ -110,6 +108,13 @@ Input: this.is.a.exam\.ple -> Retuns: ["this", "is", "a", "exam.ple"].
 Some path segments include dot `.` char in them. For instance envoy filter
 names: `envoy.filters.http.header_to_metadata`.
 In that particular cases, the dot chat (separator), needs to be escaped.
+
+### Well Known Attributes
+
+| Attribute | Description |
+| ---  | --- |
+| [Envoy Attributes](https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/advanced/attributes) |  Contextual properties provided by Envoy during request and connection processing |
+| `source.remote_address` | This attribute evaluates to the `trusted client address` (IP address without port) as it is being defined by [Envoy Doc](https://www.envoyproxy.io/docs/envoy/latest/configuration/http/http_conn_man/headers#x-forwarded-for)  |
 
 ## Building
 

--- a/README.md
+++ b/README.md
@@ -172,7 +172,7 @@ curl -H "Host: test.a.auth.com" -H "Authorization: APIKEY IAMALICE" http://127.0
 # HTTP/1.1 200 OK
 ```
 
-And three rate limit policies defined for e2e testing:
+And some rate limit policies defined for e2e testing:
 
 * `rlp-a`: Only one data item. Data selector should not generate return any value. Thus, descriptor should be empty and
   rate limiting service should **not** be called.
@@ -197,10 +197,6 @@ The expected descriptor entries:
 
 ```
 Entry { key: "limit_to_be_activated", value: "1" }
-```
-
-```
-Entry { key: "source.remote_address", value: "50.0.0.1" }
 ```
 
 ```
@@ -231,7 +227,6 @@ Bob has 2 requests per 10 seconds:
 ```sh
 while :; do curl --write-out '%{http_code}\n' --silent --output /dev/null -H "Authorization: APIKEY IAMBOB" -H "Host: test.a.multi.com" http://127.0.0.1:8000/get | grep -E --color "\b(429)\b|$"; sleep 1; done
 ```
-
 
 To rebuild and deploy to the cluster:
 

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ The only characters taken into account are:
 #### Selectors
 
 Selector of an attribute from the contextual properties provided by kuadrant.
-See [#Well-Known-Attributes] for more info about available attributes.
+See [Well Known Attributes](#Well-Known-Attributes) for more info about available attributes.
 
 The struct is
 

--- a/README.md
+++ b/README.md
@@ -187,10 +187,32 @@ curl -H "Host: test.a.rlp.com" http://127.0.0.1:8000/get -i
 curl -H "Host: test.b.rlp.com" http://127.0.0.1:8000/get -i
 ```
 
-* `rlp-c`: Four descriptors from multiple rules should be generated. Hence, rate limiting service should be called.
+* `rlp-c`: Descriptor entries from multiple data items should be generated. Hence, rate limiting service should be called.
 
 ```sh
-curl -H "Host: test.c.rlp.com" -H "x-forwarded-for: 127.0.0.1" -H "My-Custom-Header-01: my-custom-header-value-01" -H "x-dyn-user-id: bob" http://127.0.0.1:8000/get -i
+curl -H "Host: test.c.rlp.com" -H "x-forwarded-for: 50.0.0.1" -H "My-Custom-Header-01: my-custom-header-value-01" -H "x-dyn-user-id: bob" http://127.0.0.1:8000/get -i
+```
+
+The expected descriptor entries:
+
+```
+Entry { key: "limit_to_be_activated", value: "1" }
+```
+
+```
+Entry { key: "source.remote_address", value: "50.0.0.1" }
+```
+
+```
+Entry { key: "source.address", value: "50.0.0.1:0" }
+```
+
+```
+Entry { key: "request.headers.My-Custom-Header-01", value: "my-custom-header-value-01" }
+```
+
+```
+Entry { key: "user_id", value: "bob" }
 ```
 
 * `multi-a` which defines two actions for authenticated ratelimiting.
@@ -210,23 +232,6 @@ Bob has 2 requests per 10 seconds:
 while :; do curl --write-out '%{http_code}\n' --silent --output /dev/null -H "Authorization: APIKEY IAMBOB" -H "Host: test.a.multi.com" http://127.0.0.1:8000/get | grep -E --color "\b(429)\b|$"; sleep 1; done
 ```
 
-The expected descriptors:
-
-```
-RateLimitDescriptor { entries: [Entry { key: "limit_to_be_activated", value: "1" }], limit: None }
-```
-
-```
-RateLimitDescriptor { entries: [Entry { key: "source.address", value: "127.0.0.1:0" }], limit: None }
-```
-
-```
-RateLimitDescriptor { entries: [Entry { key: "request.headers.My-Custom-Header-01", value: "my-custom-header-value-01" }], limit: None }
-```
-
-```
-RateLimitDescriptor { entries: [Entry { key: "user_id", value: "bob" }], limit: None }
-```
 
 To rebuild and deploy to the cluster:
 

--- a/e2e/remote-address/Makefile
+++ b/e2e/remote-address/Makefile
@@ -1,0 +1,23 @@
+SHELL = /usr/bin/env bash -o pipefail
+.SHELLFLAGS = -ec
+.DEFAULT_GOAL := gateway
+MKFILE_PATH := $(abspath $(lastword $(MAKEFILE_LIST)))
+WORKDIR := $(patsubst %/,%,$(dir $(MKFILE_PATH)))
+DOCKER ?= $(shell which docker 2> /dev/null || echo "docker")
+
+run:
+	$(DOCKER) compose -f docker-compose.yaml run start_services
+
+test:
+	curl --silent --output /dev/null --fail --resolve test.example.com:18000:127.0.0.1 -H "X-Forwarded-For: 40.0.0.1" "http://test.example.com:18000"
+	curl --silent --output /dev/null --fail --resolve test.example.com:18000:127.0.0.1 -H "X-Forwarded-For: 50.0.0.1" "http://test.example.com:18000"
+	$(eval TMP := $(shell mktemp -d))
+	curl --silent --output $(TMP)/counters.json --fail "http://127.0.0.1:18080/counters/ratelimit-source"
+	# only one counter
+	NUM_COUNTERS=$$(jq --exit-status 'length' $(TMP)/counters.json) && test $${NUM_COUNTERS} -eq 1
+	# that counter must belong to 40.0.0.1
+	VARIABLE_COUNTER=$$(jq -r --exit-status '.[].set_variables."source.remote_address"' $(TMP)/counters.json) && [ "$${VARIABLE_COUNTER}" == "40.0.0.1" ]
+
+clean:
+	$(DOCKER) compose down --volumes --remove-orphans
+	$(DOCKER) compose -f docker-compose.yaml down --volumes --remove-orphans

--- a/e2e/remote-address/README.md
+++ b/e2e/remote-address/README.md
@@ -1,0 +1,88 @@
+## Remote address integration test
+
+This is a integration test to validate integration between Envoy and Kuadrant's Wasm module.
+
+The Wasm module defines `source.remote_address` that should generate `trusted client address`
+based on envoy configuration. If Envoy changes the contract, this test should fail.
+
+This test is being added to the CI test suite
+
+### Description
+
+The Wasm configuration defines a set of rules for `*.example.com`.
+
+```yaml
+{
+    "name": "ratelimit-source",
+    "hostnames": [
+        "*.example.com"
+    ],
+    "rules": [
+        {
+            "conditions": [
+                {
+                    "allOf": [
+                    {
+                        "selector": "source.remote_address",
+                        "operator": "neq",
+                        "value": "50.0.0.1"
+                    }
+                    ]
+                }
+            ],
+            "actions": [
+                {
+                    "extension": "limitador",
+                    "scope": "ratelimit-source",
+                    "data": [
+                        {
+                            "selector": {
+                                "selector": "source.remote_address"
+                            }
+                        }
+                    ]
+                }
+            ]
+        }
+    ]
+}
+```
+
+And a new limit configuration
+
+```yaml
+- namespace: ratelimit-source
+  max_value: 2
+  seconds: 30
+  conditions: []
+  variables:
+    - source.remote_address
+```
+
+That configuration enables source based rate limiting on `*.example.com` subdomains,
+with only one "privileged" exception: the IP "50.0.0.1" will not be rate limited.
+
+The test will run two requests:
+* IP "40.0.0.1" -> the test will verify it is being rate limited inspecting limitador for counters
+* IP "50.0.0.1" -> the test will verify it is not being rate limited inspecting limitador for counters
+
+### Run Manually
+
+It requires Wasm module being built at `target/wasm32-unknown-unknown/debug/wasm_shim.wasm`.
+Check *Makefile* at the root of the project to build the module.
+
+```
+make run
+```
+
+Run the test 
+
+```
+make test
+```
+
+### Clean up
+
+```
+make clean
+```

--- a/e2e/remote-address/docker-compose.yaml
+++ b/e2e/remote-address/docker-compose.yaml
@@ -1,0 +1,56 @@
+---
+services:
+  envoy:
+    image: envoyproxy/envoy:v1.31-latest
+    depends_on:
+    - limitador
+    - upstream
+    command:
+    - /usr/local/bin/envoy
+    - --config-path
+    - /etc/envoy.yaml
+    - --log-level
+    - info
+    - --component-log-level
+    - wasm:debug,http:debug,router:debug
+    - --service-cluster
+    - proxy
+    expose:
+    - "80"
+    - "8001"
+    ports:
+    - "18000:80"
+    - "18001:8001"
+    volumes:
+    - ./envoy.yaml:/etc/envoy.yaml
+    - ../../target/wasm32-unknown-unknown/debug/wasm_shim.wasm:/opt/kuadrant/wasm/wasm_shim.wasm
+  limitador:
+    image: quay.io/kuadrant/limitador:latest
+    command: ["limitador-server", "-vvv", "/opt/kuadrant/limits/limits.yaml"]
+    ports:
+    - "18080:8080"
+    - "18081:8081"
+    expose:
+    - "8080"
+    - "8081"
+    volumes:
+    - ./limits.yaml:/opt/kuadrant/limits/limits.yaml
+  upstream:
+    image: quay.io/kuadrant/authorino-examples:talker-api
+    environment:
+      PORT: 3000
+    expose:
+    - "3000"
+  start_services:
+    image: alpine
+    depends_on:
+    - envoy
+    command: >
+      /bin/sh -c "
+      while ! nc -z envoy 80;
+      do
+      echo sleeping;
+      sleep 1;
+      done;
+      echo Connected!
+      "

--- a/e2e/remote-address/envoy.yaml
+++ b/e2e/remote-address/envoy.yaml
@@ -1,0 +1,129 @@
+---
+static_resources:
+  listeners:
+  - name: main
+    address:
+      socket_address:
+        address: 0.0.0.0
+        port_value: 80
+    filter_chains:
+      - filters:
+        - name: envoy.filters.network.http_connection_manager
+          typed_config:
+            "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+            stat_prefix: ingress_http
+            use_remote_address: true
+            xff_num_trusted_hops: 1
+            route_config:
+              name: local_route
+              virtual_hosts:
+                - name: local_service
+                  domains:
+                    - "*"
+                  routes:
+                    - match:
+                        prefix: "/"
+                      route:
+                        cluster: upstream
+            http_filters:
+              - name: envoy.filters.http.wasm
+                typed_config:
+                  "@type": type.googleapis.com/envoy.extensions.filters.http.wasm.v3.Wasm
+                  config:
+                    name: kuadrant_wasm
+                    root_id: kuadrant_wasm
+                    vm_config:
+                      vm_id: vm.sentinel.kuadrant_wasm
+                      runtime: envoy.wasm.runtime.v8
+                      code:
+                        local:
+                          filename: /opt/kuadrant/wasm/wasm_shim.wasm
+                      allow_precompiled: true
+                    configuration:
+                      "@type": "type.googleapis.com/google.protobuf.StringValue"
+                      value: >
+                        {
+                          "extensions": {
+                            "limitador": {
+                              "type": "ratelimit",
+                              "endpoint": "limitador",
+                              "failureMode": "deny"
+                            }
+                          },
+                          "policies": [
+                            {
+                              "name": "ratelimit-source",
+                              "hostnames": [
+                                "*.example.com"
+                              ],
+                              "rules": [
+                                {
+                                  "conditions": [
+                                    {
+                                      "allOf": [
+                                        {
+                                          "selector": "source.remote_address",
+                                          "operator": "neq",
+                                          "value": "50.0.0.1"
+                                        }
+                                      ]
+                                    }
+                                  ],
+                                  "actions": [
+                                    {
+                                      "extension": "limitador",
+                                      "scope": "ratelimit-source",
+                                      "data": [
+                                        {
+                                          "selector": {
+                                            "selector": "source.remote_address"
+                                          }
+                                        }
+                                      ]
+                                    }
+                                  ]
+                                }
+                              ]
+                            }
+                          ]
+                        }
+              - name: envoy.filters.http.router
+                typed_config:
+                  "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
+  clusters:
+    - name: upstream
+      connect_timeout: 0.25s
+      type: STRICT_DNS
+      lb_policy: round_robin
+      load_assignment:
+        cluster_name: upstream
+        endpoints:
+        - lb_endpoints:
+          - endpoint:
+              address:
+                socket_address:
+                  address: upstream
+                  port_value: 3000
+    - name: limitador
+      connect_timeout: 0.25s
+      type: STRICT_DNS
+      lb_policy: round_robin
+      typed_extension_protocol_options:
+        envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
+          "@type": type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
+          explicit_http_config:
+            http2_protocol_options: {}
+      load_assignment:
+        cluster_name: limitador
+        endpoints:
+        - lb_endpoints:
+          - endpoint:
+              address:
+                socket_address:
+                  address: limitador
+                  port_value: 8081
+admin:
+  address:
+    socket_address:
+      address: 0.0.0.0
+      port_value: 8001

--- a/e2e/remote-address/limits.yaml
+++ b/e2e/remote-address/limits.yaml
@@ -1,0 +1,7 @@
+---
+- namespace: ratelimit-source
+  max_value: 30
+  seconds: 60
+  conditions: []
+  variables:
+    - source.remote_address

--- a/src/attribute.rs
+++ b/src/attribute.rs
@@ -111,7 +111,7 @@ pub fn get_attribute<T>(attr: &str) -> Result<T, String>
 where
     T: Attribute,
 {
-    match crate::property::get_property(attr) {
+    match crate::property::get_property(Path::from(attr).tokens()) {
         Ok(Some(attribute_bytes)) => T::parse(attribute_bytes),
         Ok(None) => Err(format!("get_attribute: not found or null: {attr}")),
         Err(e) => Err(format!("get_attribute: error: {e:?}")),

--- a/src/attribute.rs
+++ b/src/attribute.rs
@@ -1,4 +1,3 @@
-use crate::configuration::Path;
 use chrono::{DateTime, FixedOffset};
 use log::{debug, error};
 use protobuf::well_known_types::Struct;
@@ -111,7 +110,7 @@ pub fn get_attribute<T>(attr: &str) -> Result<T, String>
 where
     T: Attribute,
 {
-    match hostcalls::get_property(Path::from(attr).tokens()) {
+    match crate::property::get_property(attr) {
         Ok(Some(attribute_bytes)) => T::parse(attribute_bytes),
         Ok(None) => Err(format!("get_attribute: not found or null: {attr}")),
         Err(e) => Err(format!("get_attribute: error: {e:?}")),
@@ -119,7 +118,7 @@ where
 }
 
 pub fn set_attribute(attr: &str, value: &[u8]) {
-    match hostcalls::set_property(Path::from(attr).tokens(), Some(value)) {
+    match hostcalls::set_property(crate::property::Path::from(attr).tokens(), Some(value)) {
         Ok(_) => (),
         Err(_) => error!("set_attribute: failed to set property {attr}"),
     };

--- a/src/attribute.rs
+++ b/src/attribute.rs
@@ -1,3 +1,4 @@
+use crate::property_path::Path;
 use chrono::{DateTime, FixedOffset};
 use log::{debug, error};
 use protobuf::well_known_types::Struct;
@@ -118,7 +119,7 @@ where
 }
 
 pub fn set_attribute(attr: &str, value: &[u8]) {
-    match hostcalls::set_property(crate::property::Path::from(attr).tokens(), Some(value)) {
+    match hostcalls::set_property(Path::from(attr).tokens(), Some(value)) {
         Ok(_) => (),
         Err(_) => error!("set_attribute: failed to set property {attr}"),
     };

--- a/src/configuration.rs
+++ b/src/configuration.rs
@@ -1122,7 +1122,6 @@ mod test {
                 selector: "request.id".to_string(),
                 operator: WhenConditionOperator::Equal,
                 value: "request_id".to_string(),
-                path: Default::default(),
                 compiled: Default::default(),
             };
             p.compile().expect("Should compile fine!");
@@ -1140,7 +1139,6 @@ mod test {
                 selector: "request.id".to_string(),
                 operator: WhenConditionOperator::Equal,
                 value: "\"request_id\"".to_string(),
-                path: Default::default(),
                 compiled: Default::default(),
             };
             p.compile().expect("Should compile fine!");
@@ -1158,7 +1156,6 @@ mod test {
                 selector: "request.id".to_string(),
                 operator: WhenConditionOperator::Equal,
                 value: "123".to_string(),
-                path: Default::default(),
                 compiled: Default::default(),
             };
             p.compile().expect("Should compile fine!");
@@ -1176,7 +1173,6 @@ mod test {
                 selector: "foobar".to_string(),
                 operator: WhenConditionOperator::Equal,
                 value: "\"123\"".to_string(),
-                path: Default::default(),
                 compiled: Default::default(),
             };
             p.compile().expect("Should compile fine!");
@@ -1194,7 +1190,6 @@ mod test {
                 selector: "destination.port".to_string(),
                 operator: WhenConditionOperator::Equal,
                 value: "8080".to_string(),
-                path: Default::default(),
                 compiled: Default::default(),
             };
             p.compile().expect("Should compile fine!");
@@ -1212,7 +1207,6 @@ mod test {
                 selector: "foobar".to_string(),
                 operator: WhenConditionOperator::Equal,
                 value: "8080".to_string(),
-                path: Default::default(),
                 compiled: Default::default(),
             };
             p.compile().expect("Should compile fine!");
@@ -1230,7 +1224,6 @@ mod test {
                 selector: "foobar".to_string(),
                 operator: WhenConditionOperator::Equal,
                 value: "1.0".to_string(),
-                path: Default::default(),
                 compiled: Default::default(),
             };
             p.compile().expect("Should compile fine!");
@@ -1248,7 +1241,6 @@ mod test {
                 selector: "connection.mtls".to_string(),
                 operator: WhenConditionOperator::Equal,
                 value: "true".to_string(),
-                path: Default::default(),
                 compiled: Default::default(),
             };
             p.compile().expect("Should compile fine!");
@@ -1266,7 +1258,6 @@ mod test {
                 selector: "request.time".to_string(),
                 operator: WhenConditionOperator::Equal,
                 value: "2023-05-28T00:00:00+00:00".to_string(),
-                path: Default::default(),
                 compiled: Default::default(),
             };
             p.compile().expect("Should compile fine!");

--- a/src/configuration.rs
+++ b/src/configuration.rs
@@ -8,7 +8,7 @@ use crate::attribute::Attribute;
 use crate::envoy::{RateLimitDescriptor, RateLimitDescriptor_Entry};
 use crate::policy::Policy;
 use crate::policy_index::PolicyIndex;
-use crate::property::Path;
+use crate::property_path::Path;
 use crate::service::GrpcService;
 use cel_interpreter::functions::duration;
 use cel_interpreter::objects::ValueType;
@@ -1078,39 +1078,6 @@ mod test {
 
         let rlp_option = filter_config.index.get_longest_match_policies("unknown");
         assert!(rlp_option.is_none());
-    }
-
-    #[test]
-    fn path_tokenizes_with_escaping_basic() {
-        let path: Path = r"one\.two..three\\\\.four\\\.\five.".into();
-        assert_eq!(
-            path.tokens(),
-            vec!["one.two", "", r"three\\", r"four\.five", ""]
-        );
-    }
-
-    #[test]
-    fn path_tokenizes_with_escaping_ends_with_separator() {
-        let path: Path = r"one.".into();
-        assert_eq!(path.tokens(), vec!["one", ""]);
-    }
-
-    #[test]
-    fn path_tokenizes_with_escaping_ends_with_escape() {
-        let path: Path = r"one\".into();
-        assert_eq!(path.tokens(), vec!["one"]);
-    }
-
-    #[test]
-    fn path_tokenizes_with_escaping_starts_with_separator() {
-        let path: Path = r".one".into();
-        assert_eq!(path.tokens(), vec!["", "one"]);
-    }
-
-    #[test]
-    fn path_tokenizes_with_escaping_starts_with_escape() {
-        let path: Path = r"\one".into();
-        assert_eq!(path.tokens(), vec!["one"]);
     }
 
     mod pattern_expressions {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,6 +8,7 @@ mod operation_dispatcher;
 mod policy;
 mod policy_index;
 mod property;
+mod property_path;
 mod service;
 
 #[cfg(test)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,6 +7,7 @@ mod glob;
 mod operation_dispatcher;
 mod policy;
 mod policy_index;
+mod property;
 mod service;
 
 #[cfg(test)]

--- a/src/policy.rs
+++ b/src/policy.rs
@@ -58,7 +58,9 @@ impl Policy {
     }
 
     fn pattern_expression_applies(&self, p_e: &PatternExpression) -> bool {
-        let attribute_value = match crate::property::get_property(p_e.selector.as_str()).unwrap() {
+        let attribute_path = p_e.path();
+
+        let attribute_value = match crate::property::get_property(attribute_path).unwrap() {
             //TODO(didierofrivia): Replace hostcalls by DI
             None => {
                 debug!(

--- a/src/policy.rs
+++ b/src/policy.rs
@@ -1,6 +1,5 @@
 use crate::configuration::{Action, PatternExpression};
 use log::debug;
-use proxy_wasm::hostcalls;
 use serde::Deserialize;
 
 #[derive(Deserialize, Debug, Clone)]
@@ -59,12 +58,7 @@ impl Policy {
     }
 
     fn pattern_expression_applies(&self, p_e: &PatternExpression) -> bool {
-        let attribute_path = p_e.path();
-        debug!(
-            "get_property:  selector: {} path: {:?}",
-            p_e.selector, attribute_path
-        );
-        let attribute_value = match hostcalls::get_property(attribute_path).unwrap() {
+        let attribute_value = match crate::property::get_property(p_e.selector.as_str()).unwrap() {
             //TODO(didierofrivia): Replace hostcalls by DI
             None => {
                 debug!(

--- a/src/property.rs
+++ b/src/property.rs
@@ -1,57 +1,7 @@
+use crate::property_path::Path;
 use log::debug;
 use proxy_wasm::hostcalls;
 use proxy_wasm::types::Status;
-use std::fmt::{Debug, Display, Formatter};
-
-#[derive(Debug, Clone)]
-pub struct Path {
-    tokens: Vec<String>,
-}
-
-impl Display for Path {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        write!(
-            f,
-            "{}",
-            self.tokens
-                .iter()
-                .map(|t| t.replace('.', "\\."))
-                .collect::<Vec<String>>()
-                .join(".")
-        )
-    }
-}
-
-impl From<&str> for Path {
-    fn from(value: &str) -> Self {
-        let mut token = String::new();
-        let mut tokens: Vec<String> = Vec::new();
-        let mut chars = value.chars();
-        while let Some(ch) = chars.next() {
-            match ch {
-                '.' => {
-                    tokens.push(token);
-                    token = String::new();
-                }
-                '\\' => {
-                    if let Some(next) = chars.next() {
-                        token.push(next);
-                    }
-                }
-                _ => token.push(ch),
-            }
-        }
-        tokens.push(token);
-
-        Self { tokens }
-    }
-}
-
-impl Path {
-    pub fn tokens(&self) -> Vec<&str> {
-        self.tokens.iter().map(String::as_str).collect()
-    }
-}
 
 fn remote_address() -> Result<Option<Vec<u8>>, Status> {
     Ok(None)

--- a/src/property.rs
+++ b/src/property.rs
@@ -1,10 +1,41 @@
 use crate::property_path::Path;
 use log::debug;
+use log::warn;
 use proxy_wasm::hostcalls;
+use proxy_wasm::types::MapType;
 use proxy_wasm::types::Status;
 
 fn remote_address() -> Result<Option<Vec<u8>>, Status> {
-    Ok(None)
+    // From https://www.envoyproxy.io/docs/envoy/latest/configuration/http/http_conn_man/headers#x-forwarded-for
+    // If use_remote_address is set to true, Envoy sets the x-envoy-external-address header to the trusted client address.
+    debug!("get_map_value(MapType::HttpRequestHeaders, x-envoy-external-address");
+    match hostcalls::get_map_value(MapType::HttpRequestHeaders, "x-envoy-external-address")? {
+        None => {
+            debug!("x-envoy-external-address property not found");
+            // When the incoming request does not have XFF header,
+            // envoy does not set x-envoy-external-address regardless of the xff_num_trusted_hops
+            // value. The request is considered originated internally.
+            // For this case, the trusted client address is the source IP address
+            // of the immediate downstream node’s connection to Envoy
+            match host_get_property("source.address")? {
+                None => {
+                    warn!("source.address property not found");
+                    Err(Status::BadArgument)
+                }
+                Some(host_vec) => match String::from_utf8(host_vec) {
+                    Err(e) => {
+                        warn!("source.address property value not string: {}", e);
+                        Err(Status::BadArgument)
+                    }
+                    Ok(source_address) => {
+                        let split_address = source_address.split(':').collect::<Vec<_>>();
+                        Ok(Some(split_address[0].as_bytes().to_vec()))
+                    }
+                },
+            }
+        }
+        Some(trusted_client_address) => Ok(Some(trusted_client_address.as_bytes().to_vec())),
+    }
 }
 
 fn host_get_property(property: &str) -> Result<Option<Vec<u8>>, Status> {
@@ -19,7 +50,7 @@ fn host_get_property(property: &str) -> Result<Option<Vec<u8>>, Status> {
 
 pub fn get_property(property: &str) -> Result<Option<Vec<u8>>, Status> {
     match property {
-        "kuadrant.remote_address" => remote_address(),
+        "source.remote_address" => remote_address(),
         _ => host_get_property(property),
     }
 }

--- a/src/property.rs
+++ b/src/property.rs
@@ -59,7 +59,11 @@ fn remote_address() -> Result<Option<Vec<u8>>, Status> {
 
 fn host_get_property(property: &str) -> Result<Option<Vec<u8>>, Status> {
     let path = Path::from(property);
-    debug!("get_property:  property: {} path: {}", property, path);
+    debug!(
+        "get_property:  selector: {} path: {:?}",
+        property,
+        path.tokens()
+    );
     hostcalls::get_property(path.tokens())
 }
 

--- a/src/property.rs
+++ b/src/property.rs
@@ -2,39 +2,26 @@ use crate::property_path::Path;
 use log::debug;
 use log::warn;
 use proxy_wasm::hostcalls;
-use proxy_wasm::types::MapType;
 use proxy_wasm::types::Status;
 
 fn remote_address() -> Result<Option<Vec<u8>>, Status> {
-    // From https://www.envoyproxy.io/docs/envoy/latest/configuration/http/http_conn_man/headers#x-forwarded-for
-    // If use_remote_address is set to true, Envoy sets the x-envoy-external-address header to the trusted client address.
-    debug!("get_map_value(MapType::HttpRequestHeaders, x-envoy-external-address");
-    match hostcalls::get_map_value(MapType::HttpRequestHeaders, "x-envoy-external-address")? {
+    // Ref https://www.envoyproxy.io/docs/envoy/latest/configuration/http/http_conn_man/headers#x-forwarded-for
+    // Envoy sets source.address to the trusted client address AND port.
+    match host_get_property("source.address")? {
         None => {
-            debug!("x-envoy-external-address property not found");
-            // When the incoming request does not have XFF header,
-            // envoy does not set x-envoy-external-address regardless of the xff_num_trusted_hops
-            // value. The request is considered originated internally.
-            // For this case, the trusted client address is the source IP address
-            // of the immediate downstream node’s connection to Envoy
-            match host_get_property("source.address")? {
-                None => {
-                    warn!("source.address property not found");
-                    Err(Status::BadArgument)
-                }
-                Some(host_vec) => match String::from_utf8(host_vec) {
-                    Err(e) => {
-                        warn!("source.address property value not string: {}", e);
-                        Err(Status::BadArgument)
-                    }
-                    Ok(source_address) => {
-                        let split_address = source_address.split(':').collect::<Vec<_>>();
-                        Ok(Some(split_address[0].as_bytes().to_vec()))
-                    }
-                },
-            }
+            warn!("source.address property not found");
+            Err(Status::BadArgument)
         }
-        Some(trusted_client_address) => Ok(Some(trusted_client_address.as_bytes().to_vec())),
+        Some(host_vec) => match String::from_utf8(host_vec) {
+            Err(e) => {
+                warn!("source.address property value not string: {}", e);
+                Err(Status::BadArgument)
+            }
+            Ok(source_address) => {
+                let split_address = source_address.split(':').collect::<Vec<_>>();
+                Ok(Some(split_address[0].as_bytes().to_vec()))
+            }
+        },
     }
 }
 

--- a/src/property.rs
+++ b/src/property.rs
@@ -1,0 +1,71 @@
+use log::debug;
+use proxy_wasm::hostcalls;
+use proxy_wasm::types::Status;
+use std::fmt::{Debug, Display, Formatter};
+
+#[derive(Debug, Clone)]
+pub struct Path {
+    tokens: Vec<String>,
+}
+
+impl Display for Path {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "{}",
+            self.tokens
+                .iter()
+                .map(|t| t.replace('.', "\\."))
+                .collect::<Vec<String>>()
+                .join(".")
+        )
+    }
+}
+
+impl From<&str> for Path {
+    fn from(value: &str) -> Self {
+        let mut token = String::new();
+        let mut tokens: Vec<String> = Vec::new();
+        let mut chars = value.chars();
+        while let Some(ch) = chars.next() {
+            match ch {
+                '.' => {
+                    tokens.push(token);
+                    token = String::new();
+                }
+                '\\' => {
+                    if let Some(next) = chars.next() {
+                        token.push(next);
+                    }
+                }
+                _ => token.push(ch),
+            }
+        }
+        tokens.push(token);
+
+        Self { tokens }
+    }
+}
+
+impl Path {
+    pub fn tokens(&self) -> Vec<&str> {
+        self.tokens.iter().map(String::as_str).collect()
+    }
+}
+
+fn remote_address() -> Result<Option<Vec<u8>>, Status> {
+    Ok(None)
+}
+
+fn host_get_property(property: &str) -> Result<Option<Vec<u8>>, Status> {
+    let path = Path::from(property);
+    debug!("get_property:  property: {} path: {}", property, path);
+    hostcalls::get_property(path.tokens())
+}
+
+pub fn get_property(property: &str) -> Result<Option<Vec<u8>>, Status> {
+    match property {
+        "kuadrant.remote_address" => remote_address(),
+        _ => host_get_property(property),
+    }
+}

--- a/src/property_path.rs
+++ b/src/property_path.rs
@@ -1,0 +1,89 @@
+use std::fmt::{Debug, Display, Formatter};
+
+#[derive(Debug, Clone)]
+pub struct Path {
+    tokens: Vec<String>,
+}
+
+impl Display for Path {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "{}",
+            self.tokens
+                .iter()
+                .map(|t| t.replace('.', "\\."))
+                .collect::<Vec<String>>()
+                .join(".")
+        )
+    }
+}
+
+impl From<&str> for Path {
+    fn from(value: &str) -> Self {
+        let mut token = String::new();
+        let mut tokens: Vec<String> = Vec::new();
+        let mut chars = value.chars();
+        while let Some(ch) = chars.next() {
+            match ch {
+                '.' => {
+                    tokens.push(token);
+                    token = String::new();
+                }
+                '\\' => {
+                    if let Some(next) = chars.next() {
+                        token.push(next);
+                    }
+                }
+                _ => token.push(ch),
+            }
+        }
+        tokens.push(token);
+
+        Self { tokens }
+    }
+}
+
+impl Path {
+    pub fn tokens(&self) -> Vec<&str> {
+        self.tokens.iter().map(String::as_str).collect()
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn path_tokenizes_with_escaping_basic() {
+        let path: Path = r"one\.two..three\\\\.four\\\.\five.".into();
+        assert_eq!(
+            path.tokens(),
+            vec!["one.two", "", r"three\\", r"four\.five", ""]
+        );
+    }
+
+    #[test]
+    fn path_tokenizes_with_escaping_ends_with_separator() {
+        let path: Path = r"one.".into();
+        assert_eq!(path.tokens(), vec!["one", ""]);
+    }
+
+    #[test]
+    fn path_tokenizes_with_escaping_ends_with_escape() {
+        let path: Path = r"one\".into();
+        assert_eq!(path.tokens(), vec!["one"]);
+    }
+
+    #[test]
+    fn path_tokenizes_with_escaping_starts_with_separator() {
+        let path: Path = r".one".into();
+        assert_eq!(path.tokens(), vec!["", "one"]);
+    }
+
+    #[test]
+    fn path_tokenizes_with_escaping_starts_with_escape() {
+        let path: Path = r"\one".into();
+        assert_eq!(path.tokens(), vec!["one"]);
+    }
+}

--- a/tests/auth.rs
+++ b/tests/auth.rs
@@ -94,19 +94,19 @@ fn it_auths() {
         // retrieving properties for conditions
         .expect_log(
             Some(LogLevel::Debug),
-            Some("get_property:  selector: request.url_path path: [\"request\", \"url_path\"]"),
+            Some("get_property: path: [\"request\", \"url_path\"]"),
         )
         .expect_get_property(Some(vec!["request", "url_path"]))
         .returning(Some("/admin/toy".as_bytes()))
         .expect_log(
             Some(LogLevel::Debug),
-            Some("get_property:  selector: request.host path: [\"request\", \"host\"]"),
+            Some("get_property: path: [\"request\", \"host\"]"),
         )
         .expect_get_property(Some(vec!["request", "host"]))
         .returning(Some("cars.toystore.com".as_bytes()))
         .expect_log(
             Some(LogLevel::Debug),
-            Some("get_property:  selector: request.method path: [\"request\", \"method\"]"),
+            Some("get_property: path: [\"request\", \"method\"]"),
         )
         .expect_get_property(Some(vec!["request", "method"]))
         .returning(Some("POST".as_bytes()))
@@ -116,63 +116,61 @@ fn it_auths() {
         .returning(None)
         .expect_log(
             Some(LogLevel::Debug),
-            Some("get_property:  selector: request.host path: [\"request\", \"host\"]"),
+            Some("get_property: path: [\"request\", \"host\"]"),
         )
         .expect_get_property(Some(vec!["request", "host"]))
         .returning(Some("cars.toystore.com".as_bytes()))
         .expect_log(
             Some(LogLevel::Debug),
-            Some("get_property:  selector: request.method path: [\"request\", \"method\"]"),
+            Some("get_property: path: [\"request\", \"method\"]"),
         )
         .expect_get_property(Some(vec!["request", "method"]))
         .returning(Some("GET".as_bytes()))
         .expect_log(
             Some(LogLevel::Debug),
-            Some("get_property:  selector: request.scheme path: [\"request\", \"scheme\"]"),
+            Some("get_property: path: [\"request\", \"scheme\"]"),
         )
         .expect_get_property(Some(vec!["request", "scheme"]))
         .returning(Some("http".as_bytes()))
         .expect_log(
             Some(LogLevel::Debug),
-            Some("get_property:  selector: request.path path: [\"request\", \"path\"]"),
+            Some("get_property: path: [\"request\", \"path\"]"),
         )
         .expect_get_property(Some(vec!["request", "path"]))
         .returning(Some("/admin/toy".as_bytes()))
         .expect_log(
             Some(LogLevel::Debug),
-            Some("get_property:  selector: request.protocol path: [\"request\", \"protocol\"]"),
+            Some("get_property: path: [\"request\", \"protocol\"]"),
         )
         .expect_get_property(Some(vec!["request", "protocol"]))
         .returning(Some("HTTP".as_bytes()))
         .expect_log(
             Some(LogLevel::Debug),
-            Some("get_property:  selector: request.time path: [\"request\", \"time\"]"),
+            Some("get_property: path: [\"request\", \"time\"]"),
         )
         .expect_get_property(Some(vec!["request", "time"]))
         .returning(None)
         .expect_log(
             Some(LogLevel::Debug),
-            Some(
-                "get_property:  selector: destination.address path: [\"destination\", \"address\"]",
-            ),
+            Some("get_property: path: [\"destination\", \"address\"]"),
         )
         .expect_get_property(Some(vec!["destination", "address"]))
         .returning(Some("127.0.0.1:8000".as_bytes()))
         .expect_log(
             Some(LogLevel::Debug),
-            Some("get_property:  selector: destination.port path: [\"destination\", \"port\"]"),
+            Some("get_property: path: [\"destination\", \"port\"]"),
         )
         .expect_get_property(Some(vec!["destination", "port"]))
         .returning(Some("8000".as_bytes()))
         .expect_log(
             Some(LogLevel::Debug),
-            Some("get_property:  selector: source.address path: [\"source\", \"address\"]"),
+            Some("get_property: path: [\"source\", \"address\"]"),
         )
         .expect_get_property(Some(vec!["source", "address"]))
         .returning(Some("127.0.0.1:45000".as_bytes()))
         .expect_log(
             Some(LogLevel::Debug),
-            Some("get_property:  selector: source.port path: [\"source\", \"port\"]"),
+            Some("get_property: path: [\"source\", \"port\"]"),
         )
         .expect_get_property(Some(vec!["source", "port"]))
         .returning(Some("45000".as_bytes()))
@@ -288,19 +286,19 @@ fn it_denies() {
         // retrieving properties for conditions
         .expect_log(
             Some(LogLevel::Debug),
-            Some("get_property:  selector: request.url_path path: [\"request\", \"url_path\"]"),
+            Some("get_property: path: [\"request\", \"url_path\"]"),
         )
         .expect_get_property(Some(vec!["request", "url_path"]))
         .returning(Some("/admin/toy".as_bytes()))
         .expect_log(
             Some(LogLevel::Debug),
-            Some("get_property:  selector: request.host path: [\"request\", \"host\"]"),
+            Some("get_property: path: [\"request\", \"host\"]"),
         )
         .expect_get_property(Some(vec!["request", "host"]))
         .returning(Some("cars.toystore.com".as_bytes()))
         .expect_log(
             Some(LogLevel::Debug),
-            Some("get_property:  selector: request.method path: [\"request\", \"method\"]"),
+            Some("get_property: path: [\"request\", \"method\"]"),
         )
         .expect_get_property(Some(vec!["request", "method"]))
         .returning(Some("POST".as_bytes()))
@@ -310,63 +308,61 @@ fn it_denies() {
         .returning(None)
         .expect_log(
             Some(LogLevel::Debug),
-            Some("get_property:  selector: request.host path: [\"request\", \"host\"]"),
+            Some("get_property: path: [\"request\", \"host\"]"),
         )
         .expect_get_property(Some(vec!["request", "host"]))
         .returning(Some("cars.toystore.com".as_bytes()))
         .expect_log(
             Some(LogLevel::Debug),
-            Some("get_property:  selector: request.method path: [\"request\", \"method\"]"),
+            Some("get_property: path: [\"request\", \"method\"]"),
         )
         .expect_get_property(Some(vec!["request", "method"]))
         .returning(Some("GET".as_bytes()))
         .expect_log(
             Some(LogLevel::Debug),
-            Some("get_property:  selector: request.scheme path: [\"request\", \"scheme\"]"),
+            Some("get_property: path: [\"request\", \"scheme\"]"),
         )
         .expect_get_property(Some(vec!["request", "scheme"]))
         .returning(Some("http".as_bytes()))
         .expect_log(
             Some(LogLevel::Debug),
-            Some("get_property:  selector: request.path path: [\"request\", \"path\"]"),
+            Some("get_property: path: [\"request\", \"path\"]"),
         )
         .expect_get_property(Some(vec!["request", "path"]))
         .returning(Some("/admin/toy".as_bytes()))
         .expect_log(
             Some(LogLevel::Debug),
-            Some("get_property:  selector: request.protocol path: [\"request\", \"protocol\"]"),
+            Some("get_property: path: [\"request\", \"protocol\"]"),
         )
         .expect_get_property(Some(vec!["request", "protocol"]))
         .returning(Some("HTTP".as_bytes()))
         .expect_log(
             Some(LogLevel::Debug),
-            Some("get_property:  selector: request.time path: [\"request\", \"time\"]"),
+            Some("get_property: path: [\"request\", \"time\"]"),
         )
         .expect_get_property(Some(vec!["request", "time"]))
         .returning(None)
         .expect_log(
             Some(LogLevel::Debug),
-            Some(
-                "get_property:  selector: destination.address path: [\"destination\", \"address\"]",
-            ),
+            Some("get_property: path: [\"destination\", \"address\"]"),
         )
         .expect_get_property(Some(vec!["destination", "address"]))
         .returning(Some("127.0.0.1:8000".as_bytes()))
         .expect_log(
             Some(LogLevel::Debug),
-            Some("get_property:  selector: destination.port path: [\"destination\", \"port\"]"),
+            Some("get_property: path: [\"destination\", \"port\"]"),
         )
         .expect_get_property(Some(vec!["destination", "port"]))
         .returning(Some("8000".as_bytes()))
         .expect_log(
             Some(LogLevel::Debug),
-            Some("get_property:  selector: source.address path: [\"source\", \"address\"]"),
+            Some("get_property: path: [\"source\", \"address\"]"),
         )
         .expect_get_property(Some(vec!["source", "address"]))
         .returning(Some("127.0.0.1:45000".as_bytes()))
         .expect_log(
             Some(LogLevel::Debug),
-            Some("get_property:  selector: source.port path: [\"source\", \"port\"]"),
+            Some("get_property: path: [\"source\", \"port\"]"),
         )
         .expect_get_property(Some(vec!["source", "port"]))
         .returning(Some("45000".as_bytes()))

--- a/tests/auth.rs
+++ b/tests/auth.rs
@@ -114,24 +114,66 @@ fn it_auths() {
         // retrieving properties for CheckRequest
         .expect_get_header_map_pairs(Some(MapType::HttpRequestHeaders))
         .returning(None)
+        .expect_log(
+            Some(LogLevel::Debug),
+            Some("get_property:  selector: request.host path: [\"request\", \"host\"]"),
+        )
         .expect_get_property(Some(vec!["request", "host"]))
         .returning(Some("cars.toystore.com".as_bytes()))
+        .expect_log(
+            Some(LogLevel::Debug),
+            Some("get_property:  selector: request.method path: [\"request\", \"method\"]"),
+        )
         .expect_get_property(Some(vec!["request", "method"]))
         .returning(Some("GET".as_bytes()))
+        .expect_log(
+            Some(LogLevel::Debug),
+            Some("get_property:  selector: request.scheme path: [\"request\", \"scheme\"]"),
+        )
         .expect_get_property(Some(vec!["request", "scheme"]))
         .returning(Some("http".as_bytes()))
+        .expect_log(
+            Some(LogLevel::Debug),
+            Some("get_property:  selector: request.path path: [\"request\", \"path\"]"),
+        )
         .expect_get_property(Some(vec!["request", "path"]))
         .returning(Some("/admin/toy".as_bytes()))
+        .expect_log(
+            Some(LogLevel::Debug),
+            Some("get_property:  selector: request.protocol path: [\"request\", \"protocol\"]"),
+        )
         .expect_get_property(Some(vec!["request", "protocol"]))
         .returning(Some("HTTP".as_bytes()))
+        .expect_log(
+            Some(LogLevel::Debug),
+            Some("get_property:  selector: request.time path: [\"request\", \"time\"]"),
+        )
         .expect_get_property(Some(vec!["request", "time"]))
         .returning(None)
+        .expect_log(
+            Some(LogLevel::Debug),
+            Some(
+                "get_property:  selector: destination.address path: [\"destination\", \"address\"]",
+            ),
+        )
         .expect_get_property(Some(vec!["destination", "address"]))
         .returning(Some("127.0.0.1:8000".as_bytes()))
+        .expect_log(
+            Some(LogLevel::Debug),
+            Some("get_property:  selector: destination.port path: [\"destination\", \"port\"]"),
+        )
         .expect_get_property(Some(vec!["destination", "port"]))
         .returning(Some("8000".as_bytes()))
+        .expect_log(
+            Some(LogLevel::Debug),
+            Some("get_property:  selector: source.address path: [\"source\", \"address\"]"),
+        )
         .expect_get_property(Some(vec!["source", "address"]))
         .returning(Some("127.0.0.1:45000".as_bytes()))
+        .expect_log(
+            Some(LogLevel::Debug),
+            Some("get_property:  selector: source.port path: [\"source\", \"port\"]"),
+        )
         .expect_get_property(Some(vec!["source", "port"]))
         .returning(Some("45000".as_bytes()))
         // retrieving tracing headers
@@ -266,24 +308,66 @@ fn it_denies() {
         // retrieving properties for CheckRequest
         .expect_get_header_map_pairs(Some(MapType::HttpRequestHeaders))
         .returning(None)
+        .expect_log(
+            Some(LogLevel::Debug),
+            Some("get_property:  selector: request.host path: [\"request\", \"host\"]"),
+        )
         .expect_get_property(Some(vec!["request", "host"]))
         .returning(Some("cars.toystore.com".as_bytes()))
+        .expect_log(
+            Some(LogLevel::Debug),
+            Some("get_property:  selector: request.method path: [\"request\", \"method\"]"),
+        )
         .expect_get_property(Some(vec!["request", "method"]))
         .returning(Some("GET".as_bytes()))
+        .expect_log(
+            Some(LogLevel::Debug),
+            Some("get_property:  selector: request.scheme path: [\"request\", \"scheme\"]"),
+        )
         .expect_get_property(Some(vec!["request", "scheme"]))
         .returning(Some("http".as_bytes()))
+        .expect_log(
+            Some(LogLevel::Debug),
+            Some("get_property:  selector: request.path path: [\"request\", \"path\"]"),
+        )
         .expect_get_property(Some(vec!["request", "path"]))
         .returning(Some("/admin/toy".as_bytes()))
+        .expect_log(
+            Some(LogLevel::Debug),
+            Some("get_property:  selector: request.protocol path: [\"request\", \"protocol\"]"),
+        )
         .expect_get_property(Some(vec!["request", "protocol"]))
         .returning(Some("HTTP".as_bytes()))
+        .expect_log(
+            Some(LogLevel::Debug),
+            Some("get_property:  selector: request.time path: [\"request\", \"time\"]"),
+        )
         .expect_get_property(Some(vec!["request", "time"]))
         .returning(None)
+        .expect_log(
+            Some(LogLevel::Debug),
+            Some(
+                "get_property:  selector: destination.address path: [\"destination\", \"address\"]",
+            ),
+        )
         .expect_get_property(Some(vec!["destination", "address"]))
         .returning(Some("127.0.0.1:8000".as_bytes()))
+        .expect_log(
+            Some(LogLevel::Debug),
+            Some("get_property:  selector: destination.port path: [\"destination\", \"port\"]"),
+        )
         .expect_get_property(Some(vec!["destination", "port"]))
         .returning(Some("8000".as_bytes()))
+        .expect_log(
+            Some(LogLevel::Debug),
+            Some("get_property:  selector: source.address path: [\"source\", \"address\"]"),
+        )
         .expect_get_property(Some(vec!["source", "address"]))
         .returning(Some("127.0.0.1:45000".as_bytes()))
+        .expect_log(
+            Some(LogLevel::Debug),
+            Some("get_property:  selector: source.port path: [\"source\", \"port\"]"),
+        )
         .expect_get_property(Some(vec!["source", "port"]))
         .returning(Some("45000".as_bytes()))
         // retrieving tracing headers

--- a/tests/multi.rs
+++ b/tests/multi.rs
@@ -132,24 +132,66 @@ fn it_performs_authenticated_rate_limiting() {
         // retrieving properties for CheckRequest
         .expect_get_header_map_pairs(Some(MapType::HttpRequestHeaders))
         .returning(None)
+        .expect_log(
+            Some(LogLevel::Debug),
+            Some("get_property:  selector: request.host path: [\"request\", \"host\"]"),
+        )
         .expect_get_property(Some(vec!["request", "host"]))
         .returning(Some("cars.toystore.com".as_bytes()))
+        .expect_log(
+            Some(LogLevel::Debug),
+            Some("get_property:  selector: request.method path: [\"request\", \"method\"]"),
+        )
         .expect_get_property(Some(vec!["request", "method"]))
         .returning(Some("GET".as_bytes()))
+        .expect_log(
+            Some(LogLevel::Debug),
+            Some("get_property:  selector: request.scheme path: [\"request\", \"scheme\"]"),
+        )
         .expect_get_property(Some(vec!["request", "scheme"]))
         .returning(Some("http".as_bytes()))
+        .expect_log(
+            Some(LogLevel::Debug),
+            Some("get_property:  selector: request.path path: [\"request\", \"path\"]"),
+        )
         .expect_get_property(Some(vec!["request", "path"]))
         .returning(Some("/admin/toy".as_bytes()))
+        .expect_log(
+            Some(LogLevel::Debug),
+            Some("get_property:  selector: request.protocol path: [\"request\", \"protocol\"]"),
+        )
         .expect_get_property(Some(vec!["request", "protocol"]))
         .returning(Some("HTTP".as_bytes()))
+        .expect_log(
+            Some(LogLevel::Debug),
+            Some("get_property:  selector: request.time path: [\"request\", \"time\"]"),
+        )
         .expect_get_property(Some(vec!["request", "time"]))
         .returning(None)
+        .expect_log(
+            Some(LogLevel::Debug),
+            Some(
+                "get_property:  selector: destination.address path: [\"destination\", \"address\"]",
+            ),
+        )
         .expect_get_property(Some(vec!["destination", "address"]))
         .returning(Some("127.0.0.1:8000".as_bytes()))
+        .expect_log(
+            Some(LogLevel::Debug),
+            Some("get_property:  selector: destination.port path: [\"destination\", \"port\"]"),
+        )
         .expect_get_property(Some(vec!["destination", "port"]))
         .returning(Some("8000".as_bytes()))
+        .expect_log(
+            Some(LogLevel::Debug),
+            Some("get_property:  selector: source.address path: [\"source\", \"address\"]"),
+        )
         .expect_get_property(Some(vec!["source", "address"]))
         .returning(Some("127.0.0.1:45000".as_bytes()))
+        .expect_log(
+            Some(LogLevel::Debug),
+            Some("get_property:  selector: source.port path: [\"source\", \"port\"]"),
+        )
         .expect_get_property(Some(vec!["source", "port"]))
         .returning(Some("45000".as_bytes()))
         // retrieving tracing headers
@@ -302,24 +344,66 @@ fn unauthenticated_does_not_ratelimit() {
         // retrieving properties for CheckRequest
         .expect_get_header_map_pairs(Some(MapType::HttpRequestHeaders))
         .returning(None)
+        .expect_log(
+            Some(LogLevel::Debug),
+            Some("get_property:  selector: request.host path: [\"request\", \"host\"]"),
+        )
         .expect_get_property(Some(vec!["request", "host"]))
         .returning(Some("cars.toystore.com".as_bytes()))
+        .expect_log(
+            Some(LogLevel::Debug),
+            Some("get_property:  selector: request.method path: [\"request\", \"method\"]"),
+        )
         .expect_get_property(Some(vec!["request", "method"]))
         .returning(Some("GET".as_bytes()))
+        .expect_log(
+            Some(LogLevel::Debug),
+            Some("get_property:  selector: request.scheme path: [\"request\", \"scheme\"]"),
+        )
         .expect_get_property(Some(vec!["request", "scheme"]))
         .returning(Some("http".as_bytes()))
+        .expect_log(
+            Some(LogLevel::Debug),
+            Some("get_property:  selector: request.path path: [\"request\", \"path\"]"),
+        )
         .expect_get_property(Some(vec!["request", "path"]))
         .returning(Some("/admin/toy".as_bytes()))
+        .expect_log(
+            Some(LogLevel::Debug),
+            Some("get_property:  selector: request.protocol path: [\"request\", \"protocol\"]"),
+        )
         .expect_get_property(Some(vec!["request", "protocol"]))
         .returning(Some("HTTP".as_bytes()))
+        .expect_log(
+            Some(LogLevel::Debug),
+            Some("get_property:  selector: request.time path: [\"request\", \"time\"]"),
+        )
         .expect_get_property(Some(vec!["request", "time"]))
         .returning(None)
+        .expect_log(
+            Some(LogLevel::Debug),
+            Some(
+                "get_property:  selector: destination.address path: [\"destination\", \"address\"]",
+            ),
+        )
         .expect_get_property(Some(vec!["destination", "address"]))
         .returning(Some("127.0.0.1:8000".as_bytes()))
+        .expect_log(
+            Some(LogLevel::Debug),
+            Some("get_property:  selector: destination.port path: [\"destination\", \"port\"]"),
+        )
         .expect_get_property(Some(vec!["destination", "port"]))
         .returning(Some("8000".as_bytes()))
+        .expect_log(
+            Some(LogLevel::Debug),
+            Some("get_property:  selector: source.address path: [\"source\", \"address\"]"),
+        )
         .expect_get_property(Some(vec!["source", "address"]))
         .returning(Some("127.0.0.1:45000".as_bytes()))
+        .expect_log(
+            Some(LogLevel::Debug),
+            Some("get_property:  selector: source.port path: [\"source\", \"port\"]"),
+        )
         .expect_get_property(Some(vec!["source", "port"]))
         .returning(Some("45000".as_bytes()))
         // retrieving tracing headers

--- a/tests/multi.rs
+++ b/tests/multi.rs
@@ -112,19 +112,19 @@ fn it_performs_authenticated_rate_limiting() {
         // retrieving properties for conditions
         .expect_log(
             Some(LogLevel::Debug),
-            Some("get_property:  selector: request.url_path path: [\"request\", \"url_path\"]"),
+            Some("get_property: path: [\"request\", \"url_path\"]"),
         )
         .expect_get_property(Some(vec!["request", "url_path"]))
         .returning(Some("/admin/toy".as_bytes()))
         .expect_log(
             Some(LogLevel::Debug),
-            Some("get_property:  selector: request.host path: [\"request\", \"host\"]"),
+            Some("get_property: path: [\"request\", \"host\"]"),
         )
         .expect_get_property(Some(vec!["request", "host"]))
         .returning(Some("cars.toystore.com".as_bytes()))
         .expect_log(
             Some(LogLevel::Debug),
-            Some("get_property:  selector: request.method path: [\"request\", \"method\"]"),
+            Some("get_property: path: [\"request\", \"method\"]"),
         )
         .expect_get_property(Some(vec!["request", "method"]))
         .returning(Some("POST".as_bytes()))
@@ -134,63 +134,61 @@ fn it_performs_authenticated_rate_limiting() {
         .returning(None)
         .expect_log(
             Some(LogLevel::Debug),
-            Some("get_property:  selector: request.host path: [\"request\", \"host\"]"),
+            Some("get_property: path: [\"request\", \"host\"]"),
         )
         .expect_get_property(Some(vec!["request", "host"]))
         .returning(Some("cars.toystore.com".as_bytes()))
         .expect_log(
             Some(LogLevel::Debug),
-            Some("get_property:  selector: request.method path: [\"request\", \"method\"]"),
+            Some("get_property: path: [\"request\", \"method\"]"),
         )
         .expect_get_property(Some(vec!["request", "method"]))
         .returning(Some("GET".as_bytes()))
         .expect_log(
             Some(LogLevel::Debug),
-            Some("get_property:  selector: request.scheme path: [\"request\", \"scheme\"]"),
+            Some("get_property: path: [\"request\", \"scheme\"]"),
         )
         .expect_get_property(Some(vec!["request", "scheme"]))
         .returning(Some("http".as_bytes()))
         .expect_log(
             Some(LogLevel::Debug),
-            Some("get_property:  selector: request.path path: [\"request\", \"path\"]"),
+            Some("get_property: path: [\"request\", \"path\"]"),
         )
         .expect_get_property(Some(vec!["request", "path"]))
         .returning(Some("/admin/toy".as_bytes()))
         .expect_log(
             Some(LogLevel::Debug),
-            Some("get_property:  selector: request.protocol path: [\"request\", \"protocol\"]"),
+            Some("get_property: path: [\"request\", \"protocol\"]"),
         )
         .expect_get_property(Some(vec!["request", "protocol"]))
         .returning(Some("HTTP".as_bytes()))
         .expect_log(
             Some(LogLevel::Debug),
-            Some("get_property:  selector: request.time path: [\"request\", \"time\"]"),
+            Some("get_property: path: [\"request\", \"time\"]"),
         )
         .expect_get_property(Some(vec!["request", "time"]))
         .returning(None)
         .expect_log(
             Some(LogLevel::Debug),
-            Some(
-                "get_property:  selector: destination.address path: [\"destination\", \"address\"]",
-            ),
+            Some("get_property: path: [\"destination\", \"address\"]"),
         )
         .expect_get_property(Some(vec!["destination", "address"]))
         .returning(Some("127.0.0.1:8000".as_bytes()))
         .expect_log(
             Some(LogLevel::Debug),
-            Some("get_property:  selector: destination.port path: [\"destination\", \"port\"]"),
+            Some("get_property: path: [\"destination\", \"port\"]"),
         )
         .expect_get_property(Some(vec!["destination", "port"]))
         .returning(Some("8000".as_bytes()))
         .expect_log(
             Some(LogLevel::Debug),
-            Some("get_property:  selector: source.address path: [\"source\", \"address\"]"),
+            Some("get_property: path: [\"source\", \"address\"]"),
         )
         .expect_get_property(Some(vec!["source", "address"]))
         .returning(Some("127.0.0.1:45000".as_bytes()))
         .expect_log(
             Some(LogLevel::Debug),
-            Some("get_property:  selector: source.port path: [\"source\", \"port\"]"),
+            Some("get_property: path: [\"source\", \"port\"]"),
         )
         .expect_get_property(Some(vec!["source", "port"]))
         .returning(Some("45000".as_bytes()))
@@ -324,19 +322,19 @@ fn unauthenticated_does_not_ratelimit() {
         // retrieving properties for conditions
         .expect_log(
             Some(LogLevel::Debug),
-            Some("get_property:  selector: request.url_path path: [\"request\", \"url_path\"]"),
+            Some("get_property: path: [\"request\", \"url_path\"]"),
         )
         .expect_get_property(Some(vec!["request", "url_path"]))
         .returning(Some("/admin/toy".as_bytes()))
         .expect_log(
             Some(LogLevel::Debug),
-            Some("get_property:  selector: request.host path: [\"request\", \"host\"]"),
+            Some("get_property: path: [\"request\", \"host\"]"),
         )
         .expect_get_property(Some(vec!["request", "host"]))
         .returning(Some("cars.toystore.com".as_bytes()))
         .expect_log(
             Some(LogLevel::Debug),
-            Some("get_property:  selector: request.method path: [\"request\", \"method\"]"),
+            Some("get_property: path: [\"request\", \"method\"]"),
         )
         .expect_get_property(Some(vec!["request", "method"]))
         .returning(Some("POST".as_bytes()))
@@ -346,63 +344,61 @@ fn unauthenticated_does_not_ratelimit() {
         .returning(None)
         .expect_log(
             Some(LogLevel::Debug),
-            Some("get_property:  selector: request.host path: [\"request\", \"host\"]"),
+            Some("get_property: path: [\"request\", \"host\"]"),
         )
         .expect_get_property(Some(vec!["request", "host"]))
         .returning(Some("cars.toystore.com".as_bytes()))
         .expect_log(
             Some(LogLevel::Debug),
-            Some("get_property:  selector: request.method path: [\"request\", \"method\"]"),
+            Some("get_property: path: [\"request\", \"method\"]"),
         )
         .expect_get_property(Some(vec!["request", "method"]))
         .returning(Some("GET".as_bytes()))
         .expect_log(
             Some(LogLevel::Debug),
-            Some("get_property:  selector: request.scheme path: [\"request\", \"scheme\"]"),
+            Some("get_property: path: [\"request\", \"scheme\"]"),
         )
         .expect_get_property(Some(vec!["request", "scheme"]))
         .returning(Some("http".as_bytes()))
         .expect_log(
             Some(LogLevel::Debug),
-            Some("get_property:  selector: request.path path: [\"request\", \"path\"]"),
+            Some("get_property: path: [\"request\", \"path\"]"),
         )
         .expect_get_property(Some(vec!["request", "path"]))
         .returning(Some("/admin/toy".as_bytes()))
         .expect_log(
             Some(LogLevel::Debug),
-            Some("get_property:  selector: request.protocol path: [\"request\", \"protocol\"]"),
+            Some("get_property: path: [\"request\", \"protocol\"]"),
         )
         .expect_get_property(Some(vec!["request", "protocol"]))
         .returning(Some("HTTP".as_bytes()))
         .expect_log(
             Some(LogLevel::Debug),
-            Some("get_property:  selector: request.time path: [\"request\", \"time\"]"),
+            Some("get_property: path: [\"request\", \"time\"]"),
         )
         .expect_get_property(Some(vec!["request", "time"]))
         .returning(None)
         .expect_log(
             Some(LogLevel::Debug),
-            Some(
-                "get_property:  selector: destination.address path: [\"destination\", \"address\"]",
-            ),
+            Some("get_property: path: [\"destination\", \"address\"]"),
         )
         .expect_get_property(Some(vec!["destination", "address"]))
         .returning(Some("127.0.0.1:8000".as_bytes()))
         .expect_log(
             Some(LogLevel::Debug),
-            Some("get_property:  selector: destination.port path: [\"destination\", \"port\"]"),
+            Some("get_property: path: [\"destination\", \"port\"]"),
         )
         .expect_get_property(Some(vec!["destination", "port"]))
         .returning(Some("8000".as_bytes()))
         .expect_log(
             Some(LogLevel::Debug),
-            Some("get_property:  selector: source.address path: [\"source\", \"address\"]"),
+            Some("get_property: path: [\"source\", \"address\"]"),
         )
         .expect_get_property(Some(vec!["source", "address"]))
         .returning(Some("127.0.0.1:45000".as_bytes()))
         .expect_log(
             Some(LogLevel::Debug),
-            Some("get_property:  selector: source.port path: [\"source\", \"port\"]"),
+            Some("get_property: path: [\"source\", \"port\"]"),
         )
         .expect_get_property(Some(vec!["source", "port"]))
         .returning(Some("45000".as_bytes()))

--- a/tests/rate_limited.rs
+++ b/tests/rate_limited.rs
@@ -589,14 +589,11 @@ fn it_does_not_rate_limits_when_selector_does_not_exist_and_misses_default_value
         .expect_log(Some(LogLevel::Debug), Some("#2 on_http_request_headers"))
         .expect_get_header_map_value(Some(MapType::HttpRequestHeaders), Some(":authority"))
         .returning(Some("a.com"))
-        .expect_log(
-            Some(LogLevel::Debug),
-            Some("#2 policy selected some-name"),
-        )
+        .expect_log(Some(LogLevel::Debug), Some("#2 policy selected some-name"))
         // retrieving properties for RateLimitRequest
         .expect_log(
             Some(LogLevel::Debug),
-            Some("get_property:  selector: unknown.path path: Path { tokens: [\"unknown\", \"path\"] }"),
+            Some("get_property:  selector: unknown.path path: [\"unknown\", \"path\"]"),
         )
         .expect_get_property(Some(vec!["unknown", "path"]))
         .returning(None)

--- a/tests/rate_limited.rs
+++ b/tests/rate_limited.rs
@@ -162,19 +162,19 @@ fn it_limits() {
         // retrieving properties for conditions
         .expect_log(
             Some(LogLevel::Debug),
-            Some("get_property:  selector: request.url_path path: [\"request\", \"url_path\"]"),
+            Some("get_property: path: [\"request\", \"url_path\"]"),
         )
         .expect_get_property(Some(vec!["request", "url_path"]))
         .returning(Some("/admin/toy".as_bytes()))
         .expect_log(
             Some(LogLevel::Debug),
-            Some("get_property:  selector: request.host path: [\"request\", \"host\"]"),
+            Some("get_property: path: [\"request\", \"host\"]"),
         )
         .expect_get_property(Some(vec!["request", "host"]))
         .returning(Some("cars.toystore.com".as_bytes()))
         .expect_log(
             Some(LogLevel::Debug),
-            Some("get_property:  selector: request.method path: [\"request\", \"method\"]"),
+            Some("get_property: path: [\"request\", \"method\"]"),
         )
         .expect_get_property(Some(vec!["request", "method"]))
         .returning(Some("POST".as_bytes()))
@@ -320,19 +320,19 @@ fn it_passes_additional_headers() {
         // retrieving properties for conditions
         .expect_log(
             Some(LogLevel::Debug),
-            Some("get_property:  selector: request.url_path path: [\"request\", \"url_path\"]"),
+            Some("get_property: path: [\"request\", \"url_path\"]"),
         )
         .expect_get_property(Some(vec!["request", "url_path"]))
         .returning(Some("/admin/toy".as_bytes()))
         .expect_log(
             Some(LogLevel::Debug),
-            Some("get_property:  selector: request.host path: [\"request\", \"host\"]"),
+            Some("get_property: path: [\"request\", \"host\"]"),
         )
         .expect_get_property(Some(vec!["request", "host"]))
         .returning(Some("cars.toystore.com".as_bytes()))
         .expect_log(
             Some(LogLevel::Debug),
-            Some("get_property:  selector: request.method path: [\"request\", \"method\"]"),
+            Some("get_property: path: [\"request\", \"method\"]"),
         )
         .expect_get_property(Some(vec!["request", "method"]))
         .returning(Some("POST".as_bytes()))
@@ -593,7 +593,7 @@ fn it_does_not_rate_limits_when_selector_does_not_exist_and_misses_default_value
         // retrieving properties for RateLimitRequest
         .expect_log(
             Some(LogLevel::Debug),
-            Some("get_property:  selector: unknown.path path: [\"unknown\", \"path\"]"),
+            Some("get_property: path: [\"unknown\", \"path\"]"),
         )
         .expect_get_property(Some(vec!["unknown", "path"]))
         .returning(None)

--- a/tests/remote_address.rs
+++ b/tests/remote_address.rs
@@ -1,0 +1,155 @@
+use crate::util::wasm_module;
+use proxy_wasm_test_framework::tester;
+use proxy_wasm_test_framework::types::{Action, BufferType, LogLevel, MapType, ReturnType};
+use serial_test::serial;
+
+pub(crate) mod util;
+
+#[test]
+#[serial]
+fn it_limits_based_on_source_address() {
+    let args = tester::MockSettings {
+        wasm_path: wasm_module(),
+        quiet: false,
+        allow_unexpected: false,
+    };
+    let mut module = tester::mock(args).unwrap();
+
+    module
+        .call_start()
+        .execute_and_expect(ReturnType::None)
+        .unwrap();
+
+    let root_context = 1;
+    let cfg = r#"{
+        "extensions": {
+            "limitador": {
+                "type": "ratelimit",
+                "endpoint": "limitador-cluster",
+                "failureMode": "deny",
+                "timeout": "5s"
+            }
+        },
+        "policies": [
+            {
+                "name": "some-name",
+                "hostnames": ["*.example.com"],
+                "rules": [
+                    {
+                        "conditions": [
+                            {
+                                "allOf": [
+                                    {
+                                        "selector": "source.remote_address",
+                                        "operator": "neq",
+                                        "value": "50.0.0.1"
+                                    }
+                                ]
+                            }
+                        ],
+                        "actions": [
+                            {
+                                "extension": "limitador",
+                                "scope": "RLS-domain",
+                                "data": [
+                                    {
+                                        "selector": {
+                                            "selector": "source.remote_address",
+                                            "value": "1"
+                                        }
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                ]
+            }
+        ]
+    }"#;
+
+    module
+        .call_proxy_on_context_create(root_context, 0)
+        .expect_log(Some(LogLevel::Info), Some("#1 set_root_context"))
+        .execute_and_expect(ReturnType::None)
+        .unwrap();
+    module
+        .call_proxy_on_configure(root_context, 0)
+        .expect_log(Some(LogLevel::Info), Some("#1 on_configure"))
+        .expect_get_buffer_bytes(Some(BufferType::PluginConfiguration))
+        .returning(Some(cfg.as_bytes()))
+        .expect_log(Some(LogLevel::Info), None)
+        .execute_and_expect(ReturnType::Bool(true))
+        .unwrap();
+
+    let http_context = 2;
+    module
+        .call_proxy_on_context_create(http_context, root_context)
+        .expect_log(Some(LogLevel::Debug), Some("#2 create_http_context"))
+        .execute_and_expect(ReturnType::None)
+        .unwrap();
+
+    module
+        .call_proxy_on_request_headers(http_context, 0, false)
+        .expect_log(Some(LogLevel::Debug), Some("#2 on_http_request_headers"))
+        .expect_get_header_map_value(Some(MapType::HttpRequestHeaders), Some(":authority"))
+        .returning(Some("test.example.com"))
+        // retrieving properties for conditions
+        .expect_log(
+            Some(LogLevel::Debug),
+            Some("get_property: path: [\"source\", \"address\"]"),
+        )
+        .expect_get_property(Some(vec!["source", "address"]))
+        .returning(Some("40.0.0.1:0".as_bytes()))
+        .expect_log(Some(LogLevel::Debug), Some("#2 policy selected some-name"))
+        // retrieving properties for data
+        .expect_log(
+            Some(LogLevel::Debug),
+            Some("get_property: path: [\"source\", \"address\"]"),
+        )
+        .expect_get_property(Some(vec!["source", "address"]))
+        .returning(Some("40.0.0.1:0".as_bytes()))
+        // retrieving tracing headers
+        .expect_get_header_map_value(Some(MapType::HttpRequestHeaders), Some("traceparent"))
+        .returning(None)
+        .expect_get_header_map_value(Some(MapType::HttpRequestHeaders), Some("tracestate"))
+        .returning(None)
+        .expect_get_header_map_value(Some(MapType::HttpRequestHeaders), Some("baggage"))
+        .returning(None)
+        .expect_grpc_call(
+            Some("limitador-cluster"),
+            Some("envoy.service.ratelimit.v3.RateLimitService"),
+            Some("ShouldRateLimit"),
+            Some(&[0, 0, 0, 0]),
+            Some(&[
+                10, 10, 82, 76, 83, 45, 100, 111, 109, 97, 105, 110, 18, 35, 10, 33, 10, 21, 115,
+                111, 117, 114, 99, 101, 46, 114, 101, 109, 111, 116, 101, 95, 97, 100, 100, 114,
+                101, 115, 115, 18, 8, 52, 48, 46, 48, 46, 48, 46, 49, 24, 1,
+            ]),
+            Some(5000),
+        )
+        .returning(Some(42))
+        .expect_log(
+            Some(LogLevel::Debug),
+            Some("#2 initiated gRPC call (id# 42)"),
+        )
+        .execute_and_expect(ReturnType::Action(Action::Pause))
+        .unwrap();
+
+    let grpc_response: [u8; 2] = [8, 1];
+    module
+        .call_proxy_on_grpc_receive(http_context, 42, grpc_response.len() as i32)
+        .expect_log(
+            Some(LogLevel::Debug),
+            Some("#2 on_grpc_call_response: received gRPC call response: token: 42, status: 0"),
+        )
+        .expect_get_buffer_bytes(Some(BufferType::GrpcReceiveBuffer))
+        .returning(Some(&grpc_response))
+        .execute_and_expect(ReturnType::None)
+        .unwrap();
+
+    module
+        .call_proxy_on_response_headers(http_context, 0, false)
+        .expect_log(Some(LogLevel::Debug), Some("#2 on_http_response_headers"))
+        .execute_and_expect(ReturnType::Action(Action::Continue))
+        .unwrap();
+}

--- a/utils/deploy/envoy-notls.yaml
+++ b/utils/deploy/envoy-notls.yaml
@@ -99,6 +99,8 @@ data:
                   typed_config:
                     "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
                     stat_prefix: local
+                    use_remote_address: true
+                    xff_num_trusted_hops: 1
                     route_config:
                       name: local_route
                       virtual_hosts:
@@ -274,6 +276,11 @@ data:
                                                 },
                                                 {
                                                   "selector": {
+                                                    "selector": "source.remote_address"
+                                                  }
+                                                },
+                                                {
+                                                  "selector": {
                                                     "selector": "source.address"
                                                   }
                                                 },
@@ -338,7 +345,7 @@ data:
                       - name: envoy.filters.http.router
                         typed_config:
                           "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
-                    
+
                     # # Uncomment to enable tracing
                     # tracing:
                     #   provider:

--- a/utils/deploy/envoy-notls.yaml
+++ b/utils/deploy/envoy-notls.yaml
@@ -276,11 +276,6 @@ data:
                                                 },
                                                 {
                                                   "selector": {
-                                                    "selector": "source.remote_address"
-                                                  }
-                                                },
-                                                {
-                                                  "selector": {
                                                     "selector": "source.address"
                                                   }
                                                 },
@@ -293,6 +288,40 @@ data:
                                                   "selector": {
                                                     "selector": "metadata.filter_metadata.envoy\\.filters\\.http\\.header_to_metadata.user_id",
                                                     "key": "user_id"
+                                                  }
+                                                }
+                                              ]
+                                            }
+                                          ]
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "name": "rlp-ns-D/rlp-name-D",
+                                      "hostnames": [
+                                        "*.d.rlp.com"
+                                      ],
+                                      "rules": [
+                                        {
+                                          "conditions": [
+                                            {
+                                              "allOf": [
+                                                {
+                                                  "selector": "source.remote_address",
+                                                  "operator": "neq",
+                                                  "value": "50.0.0.1"
+                                                }
+                                              ]
+                                            }
+                                          ],
+                                          "actions": [
+                                            {
+                                              "extension": "limitador",
+                                              "scope": "rlp-ns-D/rlp-name-D",
+                                              "data": [
+                                                {
+                                                  "selector": {
+                                                    "selector": "source.remote_address"
                                                   }
                                                 }
                                               ]

--- a/utils/deploy/envoy-tls.yaml
+++ b/utils/deploy/envoy-tls.yaml
@@ -108,6 +108,7 @@ data:
                     "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
                     stat_prefix: local
                     use_remote_address: true
+                    xff_num_trusted_hops: 1
                     route_config:
                       name: local_route
                       virtual_hosts:
@@ -283,6 +284,11 @@ data:
                                                 },
                                                 {
                                                   "selector": {
+                                                    "selector": "source.remote_address"
+                                                  }
+                                                },
+                                                {
+                                                  "selector": {
                                                     "selector": "source.address"
                                                   }
                                                 },
@@ -347,7 +353,7 @@ data:
                       - name: envoy.filters.http.router
                         typed_config:
                           "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
-                    
+
                     # # Uncomment to enable tracing
                     # tracing:
                     #   provider:

--- a/utils/deploy/envoy-tls.yaml
+++ b/utils/deploy/envoy-tls.yaml
@@ -284,11 +284,6 @@ data:
                                                 },
                                                 {
                                                   "selector": {
-                                                    "selector": "source.remote_address"
-                                                  }
-                                                },
-                                                {
-                                                  "selector": {
                                                     "selector": "source.address"
                                                   }
                                                 },
@@ -301,6 +296,40 @@ data:
                                                   "selector": {
                                                     "selector": "metadata.filter_metadata.envoy\\.filters\\.http\\.header_to_metadata.user_id",
                                                     "key": "user_id"
+                                                  }
+                                                }
+                                              ]
+                                            }
+                                          ]
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "name": "rlp-ns-D/rlp-name-D",
+                                      "hostnames": [
+                                        "*.d.rlp.com"
+                                      ],
+                                      "rules": [
+                                        {
+                                          "conditions": [
+                                            {
+                                              "allOf": [
+                                                {
+                                                  "selector": "source.remote_address",
+                                                  "operator": "neq",
+                                                  "value": "50.0.0.1"
+                                                }
+                                              ]
+                                            }
+                                          ],
+                                          "actions": [
+                                            {
+                                              "extension": "limitador",
+                                              "scope": "rlp-ns-D/rlp-name-D",
+                                              "data": [
+                                                {
+                                                  "selector": {
+                                                    "selector": "source.remote_address"
                                                   }
                                                 }
                                               ]

--- a/utils/deploy/limits.yaml
+++ b/utils/deploy/limits.yaml
@@ -18,3 +18,9 @@
   conditions:
     - "user_id == 'bob'"
   variables: []
+- namespace: rlp-ns-D/rlp-name-D
+  max_value: 2
+  seconds: 10
+  conditions: []
+  variables:
+    - source.remote_address


### PR DESCRIPTION
## What

This PR introduces a new *Well Known Attribute* called `source.remote_address`. 

#### Why
Envoy's `source.address` (well known) [attribute](https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/advanced/attributes#connection-attributes) includes the port as `IP:PORT`. It is desirable to run rate limiting or auth policies relying only on the client address. Hence, this `source.remote_address` can be used to implement those policies. 

#### Attribute Value
This attribute evaluates to the `trusted client address` (IP address without port) as it is being defined by [Envoy Doc](https://www.envoyproxy.io/docs/envoy/latest/configuration/http/http_conn_man/headers#x-forwarded-for). 

In summary, the `trusted client address` is calculated as follows: By default, Envoy gateway instances are configured to append the source IP address of the immediate downstream node’s connection of the incoming HTTP connections to the `X-Forwarded-For` header. By default Envoy sets the number of trusted hops to 0, 
indicating that Envoy should use the address the connection is opened from, 
rather than a value inside the X-Forwarded-For list. 
Increasing this count will have Envoy use the `n`th value from the list, counting from the right.

#### Where can I use it?
This attribute can be used on `selector` fields.  

As conditions:

```yaml
- conditions:
  - allOf:
    - selector: source.remote_address
      operator: eq
      value: 50.0.0.1
``` 

As `SelectorItem` to generate descriptor entries. 

```yaml
data:
- selector:
    selector: source.remote_address
``` 

Fixes #97 

## Verification Steps

For the verification steps, this PR adds a new configuration to the existing local development environment. It's the new set of rules for `*.d.rlp.com`.

```yaml
{                                                
  "name": "rlp-ns-D/rlp-name-D",                 
  "hostnames": [                                 
    "*.d.rlp.com"                                
  ],                                             
  "rules": [                                     
     {                                            
          "conditions": [
               {
                    "allOf": [
                           {
                                "selector": "source.remote_address",
                                 "operator": "neq",
                                 "value": "50.0.0.1"
                             }
                     ]
                }
        ], 
       "actions": [                               
           {                                        
               "extension": "limitador",              
               "scope": "rlp-ns-D/rlp-name-D",        
               "data": [                              
                    {                                 
                         "selector": {                      
                                 "selector": "source.remote_address"
                          }                                  
                     }                                    
                 ]                                      
            }                                        
         ]                                          
      }                                            
   ]                                              
},                                               
```

And a new limit configuration

```yaml
- namespace: rlp-ns-D/rlp-name-D  
  max_value: 2                    
  seconds: 10                     
  conditions: []                  
  variables:                      
  - source.remote_address       
```

That configuration enables source based rate limiting on `*.d.rlp.com` subdomains, with only one "privileged" exception: IP "50.0.0.1" will not be rate limited. 

* Run the environment

```
make build && make local-setup
```

Port-forward envoy:
```
kubectl port-forward --namespace default deployment/envoy 8000:8000
```

Alice (IP: `40.0.0.1`) has 2 requests per 10 seconds:
```
while :; do curl --write-out '%{http_code}\n' --silent --output /dev/null  -H "X-Forwarded-For: 40.0.0.1" -H "Host: test.d.rlp.com" http://127.0.0.1:8000/get | grep -E --color "\b(429)\b|$"; sleep 1; done
```
Curl tool logs should show only two requests allowed for every 10 requests. 

Bob (IP: `30.0.0.1`) has 2 requests per 10 seconds:
```
while :; do curl --write-out '%{http_code}\n' --silent --output /dev/null  -H "X-Forwarded-For: 30.0.0.1" -H "Host: test.d.rlp.com" http://127.0.0.1:8000/get | grep -E --color "\b(429)\b|$"; sleep 1; done
```
Curl tool logs should show only two requests allowed for every 10 requests. 

Charley (the *Boss*) with privileged IP `50.0.0.1` does not get rate limited.

```
while :; do curl --write-out '%{http_code}\n' --silent --output /dev/null  -H "X-Forwarded-For: 50.0.0.1" -H "Host: test.d.rlp.com" http://127.0.0.1:8000/get | grep -E --color "\b(429)\b|$"; sleep 1; done
```
Curl tool logs should show all requests being accepted. 

> Note: running all the three clients also shows that rate limiting counter is not shared and they have their own counter.  IOW, each one has 2 requests every 10 seconds.
