### PR TITLE
Operation dispatcher err handling

### DIFF
--- a/src/configuration.rs
+++ b/src/configuration.rs
@@ -518,7 +518,7 @@ impl TryFrom<PluginConfiguration> for FilterConfig {
     }
 }
 
-#[derive(Deserialize, Debug, Clone, Default, PartialEq)]
+#[derive(Deserialize, Debug, Copy, Clone, Default, PartialEq)]
 #[serde(rename_all = "lowercase")]
 pub enum FailureMode {
     #[default]

--- a/src/filter/http_context.rs
+++ b/src/filter/http_context.rs
@@ -131,10 +131,15 @@ impl Context for Filter {
         match op_res {
             Ok(operation) => {
                 if GrpcService::process_grpc_response(operation, resp_size).is_ok() {
-                    if let Ok(Some(_op)) = self.operation_dispatcher.borrow_mut().next() {
-                    } else {
-                        self.resume_http_request()
+                    // call the next op
+                    match self.operation_dispatcher.borrow_mut().next() {
+                        Ok(_) => {} // no action needed
+                        Err(op_err) => {
+                            // If desired, we could check the error status.
+                            GrpcService::handle_error_on_grpc_response(op_err.failure_mode);
+                        }
                     }
+                    self.resume_http_request();
                 }
             }
             Err(e) => {

--- a/src/filter/http_context.rs
+++ b/src/filter/http_context.rs
@@ -73,12 +73,19 @@ impl Filter {
             }
             Err(OperationError {
                 failure_mode: FailureMode::Deny,
-                ..
+                status,
             }) => {
+                warn!("OperationError Status: {status:?}");
                 self.send_http_response(500, vec![], Some(b"Internal Server Error.\n"));
                 Action::Continue
             }
-            _ => Action::Continue,
+            Err(OperationError {
+                failure_mode: FailureMode::Allow,
+                status,
+            }) => {
+                warn!("OperationError Status: {status:?}");
+                Action::Continue
+            }
         }
     }
 }

--- a/src/operation_dispatcher.rs
+++ b/src/operation_dispatcher.rs
@@ -160,8 +160,18 @@ impl OperationDispatcher {
         }
     }
 
-    pub fn get_operation(&self, token_id: u32) -> Option<Rc<Operation>> {
-        self.waiting_operations.get(&token_id).cloned()
+    pub fn get_waiting_operation(&self, token_id: u32) -> Result<Rc<Operation>, OperationError> {
+        let op = self.waiting_operations.get(&token_id);
+        match op {
+            Some(op) => {
+                op.next_state();
+                Ok(op.clone())
+            }
+            None => Err(OperationError::new(
+                Status::NotFound,
+                FailureMode::default(),
+            )),
+        }
     }
 
     pub fn build_operations(&mut self, actions: &[Action]) -> Result<(), OperationError> {

--- a/src/service.rs
+++ b/src/service.rs
@@ -18,7 +18,7 @@ use std::cell::OnceCell;
 use std::rc::Rc;
 use std::time::Duration;
 
-#[derive(Default)]
+#[derive(Default, Debug)]
 pub struct GrpcService {
     service: Rc<Service>,
     name: &'static str,
@@ -81,7 +81,7 @@ impl GrpcService {
         }
     }
 
-    pub fn handle_error_on_grpc_response(failure_mode: &FailureMode) {
+    pub fn handle_error_on_grpc_response(failure_mode: FailureMode) {
         match failure_mode {
             FailureMode::Deny => {
                 hostcalls::send_http_response(500, vec![], Some(b"Internal Server Error.\n"))
@@ -105,7 +105,7 @@ pub type GetMapValuesBytesFn = fn(map_type: MapType, key: &str) -> Result<Option
 
 pub type GrpcMessageBuildFn =
     fn(service_type: &ServiceType, action: &Action) -> Option<GrpcMessageRequest>;
-
+#[derive(Debug)]
 pub struct GrpcServiceHandler {
     grpc_service: Rc<GrpcService>,
     header_resolver: Rc<HeaderResolver>,
@@ -148,7 +148,7 @@ impl GrpcServiceHandler {
         Rc::clone(&self.grpc_service.service)
     }
 }
-
+#[derive(Debug)]
 pub struct HeaderResolver {
     headers: OnceCell<Vec<(&'static str, Bytes)>>,
 }

--- a/src/service.rs
+++ b/src/service.rs
@@ -85,7 +85,7 @@ impl GrpcService {
         match failure_mode {
             FailureMode::Deny => {
                 hostcalls::send_http_response(500, vec![], Some(b"Internal Server Error.\n"))
-                    .unwrap()
+                    .unwrap();
             }
             FailureMode::Allow => hostcalls::resume_http_request().unwrap(),
         }

--- a/src/service/auth.rs
+++ b/src/service/auth.rs
@@ -124,7 +124,7 @@ impl AuthService {
 
     pub fn process_auth_grpc_response(
         auth_resp: GrpcMessageResponse,
-        failure_mode: &FailureMode,
+        failure_mode: FailureMode,
     ) -> Result<(), StatusCode> {
         if let GrpcMessageResponse::Auth(check_response) = auth_resp {
             // store dynamic metadata in filter state

--- a/src/service/rate_limit.rs
+++ b/src/service/rate_limit.rs
@@ -37,7 +37,7 @@ impl RateLimitService {
 
     pub fn process_ratelimit_grpc_response(
         rl_resp: GrpcMessageResponse,
-        failure_mode: &FailureMode,
+        failure_mode: FailureMode,
     ) -> Result<(), StatusCode> {
         match rl_resp {
             GrpcMessageResponse::RateLimit(RateLimitResponse {


### PR DESCRIPTION
Fixes https://github.com/Kuadrant/wasm-shim/issues/123

Also fixes the following e2e tests:
* https://github.com/Kuadrant/wasm-shim/pull/124
* https://github.com/Kuadrant/wasm-shim/pull/121
* https://github.com/Kuadrant/wasm-shim/pull/122

This PR introduces a refactor that besides fixing the issue #123, makes the code a bit more consistent regarding the flow of the `Operation`s State controlled by the `OperationHandler`. It aims to handle all the exceptions raised and report back to the Filter (or any caller).

