### PR TITLE
Support request.query decoding

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1908,6 +1908,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "urlencoding"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
+
+[[package]]
 name = "uuid"
 version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1958,6 +1964,7 @@ dependencies = [
  "serde_json",
  "serial_test",
  "thiserror",
+ "urlencoding",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,7 @@ const_format = "0.2.31"
 chrono = { version = "0.4.38", default-features = false, features = ["alloc", "std"] }
 cel-interpreter = "0.8.1"
 cel-parser = "0.7.1"
+urlencoding = "2.1.3"
 
 [dev-dependencies]
 proxy-wasm-test-framework = { git = "https://github.com/Kuadrant/wasm-test-framework.git", branch = "kuadrant" }

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ actionSets:
     - service: ratelimit-service
       scope: ratelimit-scope-a
       predicates:
-      - auth.identity.anonymous == "true"
+      - auth.identity.anonymous == true
       data:
       - expression:
           key: my_header

--- a/src/configuration.rs
+++ b/src/configuration.rs
@@ -468,7 +468,7 @@ impl TryFrom<PluginConfiguration> for FilterConfig {
             }
             let mut predicates = Vec::default();
             for predicate in &action_set.route_rule_conditions.predicates {
-                predicates.push(Predicate::new(predicate).map_err(|e| e.to_string())?);
+                predicates.push(Predicate::route_rule(predicate).map_err(|e| e.to_string())?);
             }
             action_set
                 .route_rule_conditions

--- a/src/data/cel.rs
+++ b/src/data/cel.rs
@@ -73,9 +73,9 @@ impl Expression {
         Value::resolve(&self.expression, &ctx).expect("Cel expression couldn't be evaluated")
     }
 
-    /// Add support for `decodeQueryString`, see [`decode_query_string`]
+    /// Add support for `queryMap`, see [`decode_query_string`]
     fn add_extended_capabilities(ctx: &mut Context) {
-        ctx.add_function("decodeQueryString", decode_query_string);
+        ctx.add_function("queryMap", decode_query_string);
     }
 
     fn build_data_map(&self) -> Map {
@@ -653,11 +653,11 @@ mod tests {
                 .collect(),
         )));
         let predicate = Predicate::route_rule(
-            "decodeQueryString(request.query, true)['param1'] == '👾 ' && \
-            decodeQueryString(request.query, true)['param2'] == 'Exterminate!' && \
-            decodeQueryString(request.query, true)['👾'][0] == '123' && \
-            decodeQueryString(request.query, true)['👾'][1] == '456' && \
-            decodeQueryString(request.query, true)['👾'][2] == '' \
+            "queryMap(request.query, true)['param1'] == '👾 ' && \
+            queryMap(request.query, true)['param2'] == 'Exterminate!' && \
+            queryMap(request.query, true)['👾'][0] == '123' && \
+            queryMap(request.query, true)['👾'][1] == '456' && \
+            queryMap(request.query, true)['👾'][2] == '' \
                         ",
         )
         .expect("This is valid!");
@@ -670,8 +670,8 @@ mod tests {
                 .collect(),
         )));
         let predicate = Predicate::route_rule(
-            "decodeQueryString(request.query, false)['param2'] == 'Exterminate!' && \
-            decodeQueryString(request.query, false)['👾'] == '123' \
+            "queryMap(request.query, false)['param2'] == 'Exterminate!' && \
+            queryMap(request.query, false)['👾'] == '123' \
                         ",
         )
         .expect("This is valid!");
@@ -681,8 +681,8 @@ mod tests {
             "request.query".into(),
             "%F0%9F%91%BE".bytes().collect(),
         )));
-        let predicate = Predicate::route_rule("decodeQueryString(request.query) == {'👾': ''}")
-            .expect("This is valid!");
+        let predicate =
+            Predicate::route_rule("queryMap(request.query) == {'👾': ''}").expect("This is valid!");
         assert!(predicate.test());
     }
 

--- a/src/data/cel.rs
+++ b/src/data/cel.rs
@@ -91,10 +91,10 @@ fn decode_query_string(This(s): This<Arc<String>>, Arguments(args): Arguments) -
     let allow_repeats = if args.len() == 2 {
         match &args[1] {
             Value::Bool(b) => *b,
-            _ => true,
+            _ => false,
         }
     } else {
-        true
+        false
     };
     let mut map: HashMap<Key, Value> = HashMap::default();
     for part in s.split('&') {
@@ -653,11 +653,11 @@ mod tests {
                 .collect(),
         )));
         let predicate = Predicate::route_rule(
-            "decodeQueryString(request.query)['param1'] == '👾 ' && \
-            decodeQueryString(request.query)['param2'] == 'Exterminate!' && \
-            decodeQueryString(request.query)['👾'][0] == '123' && \
-            decodeQueryString(request.query)['👾'][1] == '456' && \
-            decodeQueryString(request.query)['👾'][2] == '' \
+            "decodeQueryString(request.query, true)['param1'] == '👾 ' && \
+            decodeQueryString(request.query, true)['param2'] == 'Exterminate!' && \
+            decodeQueryString(request.query, true)['👾'][0] == '123' && \
+            decodeQueryString(request.query, true)['👾'][1] == '456' && \
+            decodeQueryString(request.query, true)['👾'][2] == '' \
                         ",
         )
         .expect("This is valid!");

--- a/src/data/cel.rs
+++ b/src/data/cel.rs
@@ -656,10 +656,8 @@ mod tests {
             "request.query".into(),
             "%F0%9F%91%BE".bytes().collect(),
         )));
-        let predicate = Predicate::route_rule(
-            "decodeQueryString(request.query) == {'👾': ''}",
-        )
-        .expect("This is valid!");
+        let predicate = Predicate::route_rule("decodeQueryString(request.query) == {'👾': ''}")
+            .expect("This is valid!");
         assert!(predicate.test());
     }
 


### PR DESCRIPTION
See test, but this effectively works like this, given the query string `param1=%F0%9F%91%BE%20&param2=Exterminate%21&%F0%9F%91%BE=123&%F0%9F%91%BE=456`

```
decodeQueryString(request.query)['param1'] == '👾 ' &&
decodeQueryString(request.query)['param2'] == 'Exterminate!' &&
decodeQueryString(request.query)['👾'][0] == '123' &&
decodeQueryString(request.query)['👾'][1] == '456'
```

i.e.:
 - Doesn't trim
 - decodes all utf-8
 - supports lists of values

It is exposed as an "extension" that's only enabled via `Expression::new_extended`, but mostly thru `Predicate::route_rule` that's now _only_ used in the config, when compiling `RouteRuleConditions`