### PR TITLE
Move selectors to expressions in dev environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ actionSets:
       data:
       - expression:
           key: my_header
-          value: request.headers["My-Custom-Header"]
+          value: request.headers["my-custom-header"]
 ```
 
 ## Features
@@ -143,7 +143,7 @@ curl -H "Host: test.b.rlp.com" http://127.0.0.1:8000/get -i
 * `rlp-c`: Descriptor entries from multiple data items should be generated. Hence, rate limiting service should be called.
 
 ```sh
-curl -H "Host: test.c.rlp.com" -H "x-forwarded-for: 50.0.0.1" -H "My-Custom-Header-01: my-custom-header-value-01" -H "x-dyn-user-id: bob" http://127.0.0.1:8000/get -i
+curl -H "Host: test.c.rlp.com" -H "x-forwarded-for: 50.0.0.1" -H "my-custom-header-01: my-custom-header-value-01" -H "x-dyn-user-id: bob" http://127.0.0.1:8000/get -i
 ```
 
 Check limitador logs for received descriptor entries.
@@ -163,7 +163,7 @@ Entry { key: "source.address", value: "50.0.0.1:0" }
 ```
 
 ```
-Entry { key: "request.headers.My-Custom-Header-01", value: "my-custom-header-value-01" }
+Entry { key: "request.headers.my-custom-header-01", value: "my-custom-header-value-01" }
 ```
 
 ```

--- a/src/data/property.rs
+++ b/src/data/property.rs
@@ -56,15 +56,12 @@ pub fn host_get_map(path: &Path) -> Result<HashMap<String, String>, String> {
 pub fn host_get_map(path: &Path) -> Result<HashMap<String, String>, String> {
     match *path.tokens() {
         ["request", "headers"] => {
-            debug!(
-                "get_map: {:?}",
-                proxy_wasm::types::MapType::HttpRequestHeaders
-            );
             let map =
                 proxy_wasm::hostcalls::get_map(proxy_wasm::types::MapType::HttpRequestHeaders)
-                    .unwrap()
+                    .expect("Failed to get_map request.headers")
                     .into_iter()
                     .collect();
+            debug!("get_map: {map:#?}");
             Ok(map)
         }
         _ => Err(format!("Unknown map requested {:?}", path)),

--- a/utils/deploy/envoy.yaml
+++ b/utils/deploy/envoy.yaml
@@ -180,8 +180,9 @@ data:
                                           "scope": "rlp-ns-A/rlp-name-A",
                                           "data": [
                                             {
-                                              "selector": {
-                                                "selector": "unknown.path"
+                                              "expression": {
+                                                "key": "unknown.path",
+                                                "value": "unknown.path"
                                               }
                                             }
                                           ]
@@ -237,19 +238,21 @@ data:
                                               }
                                             },
                                             {
-                                              "selector": {
-                                                "selector": "source.address"
+                                              "expression": {
+                                                "key": "source.address",
+                                                "value": "source.address"
                                               }
                                             },
                                             {
-                                              "selector": {
-                                                "selector": "request.headers.My-Custom-Header-01"
+                                              "expression": {
+                                                "key": "request.headers['My-Custom-Header-01']",
+                                                "value": "request.headers['My-Custom-Header-01']"
                                               }
                                             },
                                             {
-                                              "selector": {
-                                                "selector": "metadata.filter_metadata.envoy\\.filters\\.http\\.header_to_metadata.user_id",
-                                                "key": "user_id"
+                                              "expression": {
+                                                "key": "user_id",
+                                                "value": "string(getHostProperty(['metadata', 'filter_metadata', 'envoy.filters.http.header_to_metadata', 'user_id']))"
                                               }
                                             }
                                           ]
@@ -278,8 +281,9 @@ data:
                                               "scope": "rlp-ns-D/rlp-name-D",
                                               "data": [
                                                 {
-                                                  "selector": {
-                                                    "selector": "source.remote_address"
+                                                  "expression": {
+                                                    "key": "source.remote_address",
+                                                    "value": "source.remote_address"
                                                   }
                                                 }
                                               ]

--- a/utils/deploy/envoy.yaml
+++ b/utils/deploy/envoy.yaml
@@ -245,8 +245,8 @@ data:
                                             },
                                             {
                                               "expression": {
-                                                "key": "request.headers['My-Custom-Header-01']",
-                                                "value": "request.headers['My-Custom-Header-01']"
+                                                "key": "request.headers['my-custom-header-01']",
+                                                "value": "request.headers['my-custom-header-01']"
                                               }
                                             },
                                             {


### PR DESCRIPTION
* Update examples to use expressions instead of selectors (accidentally missed from #137)
* Lowercase the header in the example for `request.headers`
* Add `debug` log for the `request.headers` map 