### PR TITLE
Correctly add auth headers that should be sent to the upstream

### DIFF
--- a/src/service/auth.rs
+++ b/src/service/auth.rs
@@ -133,28 +133,26 @@ impl AuthService {
             match check_response.http_response {
                 Some(CheckResponse_oneof_http_response::ok_response(ok_response)) => {
                     debug!("process_auth_grpc_response: received OkHttpResponse");
-                    ok_response
-                        .get_headers_to_remove()
-                        .iter()
-                        .for_each(|header| {
-                            hostcalls::set_map_value(
-                                MapType::HttpResponseHeaders,
-                                header.as_str(),
-                                None,
-                            )
-                            .unwrap()
-                        });
-                    ok_response
-                        .get_response_headers_to_add()
-                        .iter()
-                        .for_each(|header| {
-                            hostcalls::add_map_value(
-                                MapType::HttpResponseHeaders,
-                                header.get_header().get_key(),
-                                header.get_header().get_value(),
-                            )
-                            .unwrap()
-                        });
+                    if !ok_response.get_response_headers_to_add().is_empty() {
+                        panic!("process_auth_grpc_response: response contained response_headers_to_add which is unsupported!")
+                    }
+                    if !ok_response.get_headers_to_remove().is_empty() {
+                        panic!("process_auth_grpc_response: response contained headers_to_remove which is unsupported!")
+                    }
+                    if !ok_response.get_query_parameters_to_set().is_empty() {
+                        panic!("process_auth_grpc_response: response contained query_parameters_to_set which is unsupported!")
+                    }
+                    if !ok_response.get_query_parameters_to_remove().is_empty() {
+                        panic!("process_auth_grpc_response: response contained query_parameters_to_remove which is unsupported!")
+                    }
+                    ok_response.get_headers().iter().for_each(|header| {
+                        hostcalls::add_map_value(
+                            MapType::HttpRequestHeaders,
+                            header.get_header().get_key(),
+                            header.get_header().get_value(),
+                        )
+                        .unwrap()
+                    });
                     Ok(())
                 }
                 Some(CheckResponse_oneof_http_response::denied_response(denied_response)) => {

--- a/src/service/rate_limit.rs
+++ b/src/service/rate_limit.rs
@@ -65,6 +65,7 @@ impl RateLimitService {
                 response_headers_to_add: additional_headers,
                 ..
             }) => {
+                // TODO: This should not be sent to the upstream!
                 additional_headers.iter().for_each(|header| {
                     hostcalls::add_map_value(
                         MapType::HttpResponseHeaders,


### PR DESCRIPTION
Authorino does not support the following fields in an `OkHttpResponse`:

* `response_headers_to_add`
* `headers_to_remove`
* `query_parameters_to_set`
* `query_parameters_to_remove`

If any of these are set we panic with an appropriate response.

We now (correctly) set headers sent to the upstream from the [`headers`](https://www.envoyproxy.io/docs/envoy/latest/api-v3/service/auth/v3/external_auth.proto#service-auth-v3-okhttpresponse) field.

Confirmed this locally by adding the following to the authconfig:

```yaml
headers:
  "simple":
    json:
      properties:
        "data":
          value: true
```

Make the request:
```sh
curl -H "Host: test.a.auth.com" -H "Authorization: APIKEY IAMALICE" http://127.0.0.1:8000/get -i
```

See in the _echo response_ of the upstream that it receives the header:

```json
{
  "method": "GET",
  "path": "/get",
  "query_string": null,
  "body": "",
  "headers": {
    "Host": "test.a.auth.com",
    "User-Agent": "curl/8.7.1",
    "Accept": "*/*",
    "Authorization": "APIKEY IAMALICE",
    "X-Forwarded-For": "10.244.0.18",
    "X-Forwarded-Proto": "http",
    "X-Envoy-Internal": "true",
    "X-Request-Id": "ebd0ab64-73c4-4a03-ad20-9ce810a3f057",
    "Simple": "{\"data\":true}",
    "X-Envoy-Expected-Rq-Timeout-Ms": "15000",
    "Version": "HTTP/1.1"
  },
  "uuid": "4a8906a8-31ec-493f-98a9-513ff7b4c79b"
}
```