### PR TITLE
Add RL response headers in correct phase

### DIFF
--- a/src/filter/http_context.rs
+++ b/src/filter/http_context.rs
@@ -142,13 +142,9 @@ impl Context for Filter {
 
         match op_res {
             Ok(operation) => {
-                if GrpcService::process_grpc_response(
-                    operation,
-                    resp_size,
-                    &mut self.response_headers_to_add,
-                )
-                .is_ok()
-                {
+                if let Ok(result) = GrpcService::process_grpc_response(operation, resp_size) {
+                    // add the response headers
+                    self.response_headers_to_add.extend(result.response_headers);
                     // call the next op
                     match self.operation_dispatcher.borrow_mut().next() {
                         Ok(some_op) => {

--- a/src/filter/http_context.rs
+++ b/src/filter/http_context.rs
@@ -142,7 +142,13 @@ impl Context for Filter {
 
         match op_res {
             Ok(operation) => {
-                if GrpcService::process_grpc_response(operation, resp_size).is_ok() {
+                if GrpcService::process_grpc_response(
+                    operation,
+                    resp_size,
+                    &mut self.response_headers_to_add,
+                )
+                .is_ok()
+                {
                     // call the next op
                     match self.operation_dispatcher.borrow_mut().next() {
                         Ok(some_op) => {

--- a/src/service.rs
+++ b/src/service.rs
@@ -54,6 +54,7 @@ impl GrpcService {
     pub fn process_grpc_response(
         operation: Rc<Operation>,
         resp_size: usize,
+        response_headers_to_add: &mut Vec<(String, String)>,
     ) -> Result<(), StatusCode> {
         let failure_mode = operation.get_failure_mode();
         if let Some(res_body_bytes) =
@@ -62,9 +63,11 @@ impl GrpcService {
             match GrpcMessageResponse::new(operation.get_service_type(), &res_body_bytes) {
                 Ok(res) => match operation.get_service_type() {
                     ServiceType::Auth => AuthService::process_auth_grpc_response(res, failure_mode),
-                    ServiceType::RateLimit => {
-                        RateLimitService::process_ratelimit_grpc_response(res, failure_mode)
-                    }
+                    ServiceType::RateLimit => RateLimitService::process_ratelimit_grpc_response(
+                        res,
+                        failure_mode,
+                        response_headers_to_add,
+                    ),
                 },
                 Err(e) => {
                     warn!(

--- a/src/service/auth.rs
+++ b/src/service/auth.rs
@@ -6,7 +6,7 @@ use crate::envoy::{
     SocketAddress, StatusCode,
 };
 use crate::service::grpc_message::{GrpcMessageResponse, GrpcMessageResult};
-use crate::service::GrpcService;
+use crate::service::{GrpcResult, GrpcService};
 use chrono::{DateTime, FixedOffset};
 use log::{debug, warn};
 use protobuf::well_known_types::Timestamp;
@@ -125,7 +125,7 @@ impl AuthService {
     pub fn process_auth_grpc_response(
         auth_resp: GrpcMessageResponse,
         failure_mode: FailureMode,
-    ) -> Result<(), StatusCode> {
+    ) -> Result<GrpcResult, StatusCode> {
         if let GrpcMessageResponse::Auth(check_response) = auth_resp {
             // store dynamic metadata in filter state
             store_metadata(check_response.get_dynamic_metadata());
@@ -153,7 +153,7 @@ impl AuthService {
                         )
                         .unwrap()
                     });
-                    Ok(())
+                    Ok(GrpcResult::default())
                 }
                 Some(CheckResponse_oneof_http_response::denied_response(denied_response)) => {
                     debug!("process_auth_grpc_response: received DeniedHttpResponse");

--- a/tests/rate_limited.rs
+++ b/tests/rate_limited.rs
@@ -353,6 +353,12 @@ fn it_passes_additional_headers() {
         )
         .expect_get_buffer_bytes(Some(BufferType::GrpcReceiveBuffer))
         .returning(Some(&grpc_response))
+        .execute_and_expect(ReturnType::None)
+        .unwrap();
+
+    module
+        .call_proxy_on_response_headers(http_context, 0, false)
+        .expect_log(Some(LogLevel::Debug), Some("#2 on_http_response_headers"))
         .expect_add_header_map_value(
             Some(MapType::HttpResponseHeaders),
             Some("test"),
@@ -363,12 +369,6 @@ fn it_passes_additional_headers() {
             Some("other"),
             Some("header value"),
         )
-        .execute_and_expect(ReturnType::None)
-        .unwrap();
-
-    module
-        .call_proxy_on_response_headers(http_context, 0, false)
-        .expect_log(Some(LogLevel::Debug), Some("#2 on_http_response_headers"))
         .execute_and_expect(ReturnType::Action(Action::Continue))
         .unwrap();
 }


### PR DESCRIPTION
This passes the `response_headers` back up to the filter layer so that we can add the headers only at the last phase

Adding these headers before we send to the upstream service is not allowed, and if you set `rateLimitHeaders: DRAFT_VERSION_03` for limitador the shim will panic without this change.