### PR TITLE
Replace all unwraps

### DIFF
--- a/src/configuration.rs
+++ b/src/configuration.rs
@@ -106,10 +106,7 @@ impl TryFrom<PluginConfiguration> for FilterConfig {
                     .expect("Predicates must not be compiled yet!");
 
                 for datum in &action.data {
-                    let result = datum.item.compile();
-                    if result.is_err() {
-                        return Err(result.err().unwrap());
-                    }
+                    datum.item.compile()?;
                 }
             }
 
@@ -204,7 +201,10 @@ impl<'de> Visitor<'de> for TimeoutVisitor {
         E: Error,
     {
         match duration(Arc::new(string)) {
-            Ok(Value::Duration(duration)) => Ok(Timeout(duration.to_std().unwrap())),
+            Ok(Value::Duration(duration)) => duration
+                .to_std()
+                .map(Timeout)
+                .map_err(|e| E::custom(e.to_string())),
             Err(e) => Err(E::custom(e)),
             _ => Err(E::custom("Unsupported Duration Value")),
         }

--- a/src/configuration.rs
+++ b/src/configuration.rs
@@ -277,7 +277,7 @@ mod test {
         }
         assert!(res.is_ok());
 
-        let filter_config = res.unwrap();
+        let filter_config = res.expect("result is ok");
         assert_eq!(filter_config.action_sets.len(), 1);
 
         let services = &filter_config.services;
@@ -364,7 +364,7 @@ mod test {
         }
         assert!(res.is_ok());
 
-        let filter_config = res.unwrap();
+        let filter_config = res.expect("result is ok");
         assert_eq!(filter_config.action_sets.len(), 0);
     }
 
@@ -410,12 +410,15 @@ mod test {
         }
         assert!(res.is_ok());
 
-        let filter_config = res.unwrap();
+        let filter_config = res.expect("result is ok");
         assert_eq!(filter_config.action_sets.len(), 1);
 
         let services = &filter_config.services;
         assert_eq!(
-            services.get("limitador").unwrap().timeout,
+            services
+                .get("limitador")
+                .expect("limitador service to be set")
+                .timeout,
             Timeout(Duration::from_millis(20))
         );
 
@@ -510,7 +513,7 @@ mod test {
         }
         assert!(res.is_ok());
 
-        let result = FilterConfig::try_from(res.unwrap());
+        let result = FilterConfig::try_from(res.expect("result is ok"));
         let filter_config = result.expect("That didn't work");
         let rlp_option = filter_config
             .index

--- a/src/configuration/action_set_index.rs
+++ b/src/configuration/action_set_index.rs
@@ -68,7 +68,7 @@ mod tests {
 
         let val = index.get_longest_match_action_sets("example.com");
         assert!(val.is_some());
-        assert_eq!(val.unwrap()[0].name, "rlp1");
+        assert_eq!(val.expect("value must be some")[0].name, "rlp1");
     }
 
     #[test]
@@ -90,7 +90,7 @@ mod tests {
         let val = index.get_longest_match_action_sets("test.example.com");
 
         assert!(val.is_some());
-        assert_eq!(val.unwrap()[0].name, "rlp1");
+        assert_eq!(val.expect("value must be some")[0].name, "rlp1");
     }
 
     #[test]
@@ -103,11 +103,11 @@ mod tests {
 
         let val = index.get_longest_match_action_sets("test.example.com");
         assert!(val.is_some());
-        assert_eq!(val.unwrap()[0].name, "rlp2");
+        assert_eq!(val.expect("value must be some")[0].name, "rlp2");
 
         let val = index.get_longest_match_action_sets("example.com");
         assert!(val.is_some());
-        assert_eq!(val.unwrap()[0].name, "rlp1");
+        assert_eq!(val.expect("value must be some")[0].name, "rlp1");
     }
 
     #[test]
@@ -118,6 +118,6 @@ mod tests {
 
         let val = index.get_longest_match_action_sets("test.example.com");
         assert!(val.is_some());
-        assert_eq!(val.unwrap()[0].name, "rlp1");
+        assert_eq!(val.expect("value must be some")[0].name, "rlp1");
     }
 }

--- a/src/data/attribute.rs
+++ b/src/data/attribute.rs
@@ -166,7 +166,10 @@ fn process_metadata(s: &Struct, prefix: String) -> Vec<(String, String)> {
             let nested_struct = value.get_struct_value();
             result.extend(process_metadata(nested_struct, current_prefix));
         } else if let Some(v) = json {
-            result.push((current_prefix, serde_json::to_string(&v).unwrap()));
+            match serde_json::to_string(&v) {
+                Ok(ser) => result.push((current_prefix, ser)),
+                Err(e) => error!("failed to serialize json Value: {e:?}"),
+            }
         }
     }
     result

--- a/src/data/cel.rs
+++ b/src/data/cel.rs
@@ -557,10 +557,14 @@ pub mod data {
         fn it_works() {
             let map = AttributeMap::new(
                 [
-                    known_attribute_for(&"request.method".into()).unwrap(),
-                    known_attribute_for(&"request.referer".into()).unwrap(),
-                    known_attribute_for(&"source.address".into()).unwrap(),
-                    known_attribute_for(&"destination.port".into()).unwrap(),
+                    known_attribute_for(&"request.method".into())
+                        .expect("request.method known attribute exists"),
+                    known_attribute_for(&"request.referer".into())
+                        .expect("request.referer known attribute exists"),
+                    known_attribute_for(&"source.address".into())
+                        .expect("source.address known attribute exists"),
+                    known_attribute_for(&"destination.port".into())
+                        .expect("destination.port known attribute exists"),
                 ]
                 .into(),
             );
@@ -572,10 +576,10 @@ pub mod data {
             assert!(map.data.contains_key("destination"));
             assert!(map.data.contains_key("request"));
 
-            match map.data.get("source").unwrap() {
+            match map.data.get("source").expect("source is some") {
                 Token::Node(map) => {
                     assert_eq!(map.len(), 1);
-                    match map.get("address").unwrap() {
+                    match map.get("address").expect("address is some") {
                         Token::Node(_) => panic!("Not supposed to get here!"),
                         Token::Value(v) => assert_eq!(v.path, "source.address".into()),
                     }
@@ -583,10 +587,10 @@ pub mod data {
                 Token::Value(_) => panic!("Not supposed to get here!"),
             }
 
-            match map.data.get("destination").unwrap() {
+            match map.data.get("destination").expect("destination is some") {
                 Token::Node(map) => {
                     assert_eq!(map.len(), 1);
-                    match map.get("port").unwrap() {
+                    match map.get("port").expect("port is some") {
                         Token::Node(_) => panic!("Not supposed to get here!"),
                         Token::Value(v) => assert_eq!(v.path, "destination.port".into()),
                     }
@@ -594,16 +598,16 @@ pub mod data {
                 Token::Value(_) => panic!("Not supposed to get here!"),
             }
 
-            match map.data.get("request").unwrap() {
+            match map.data.get("request").expect("request is some") {
                 Token::Node(map) => {
                     assert_eq!(map.len(), 2);
                     assert!(map.get("method").is_some());
-                    match map.get("method").unwrap() {
+                    match map.get("method").expect("method is some") {
                         Token::Node(_) => panic!("Not supposed to get here!"),
                         Token::Value(v) => assert_eq!(v.path, "request.method".into()),
                     }
                     assert!(map.get("referer").is_some());
-                    match map.get("referer").unwrap() {
+                    match map.get("referer").expect("referer is some") {
                         Token::Node(_) => panic!("Not supposed to get here!"),
                         Token::Value(v) => assert_eq!(v.path, "request.referer".into()),
                     }
@@ -635,7 +639,7 @@ mod tests {
         let value = Expression::new(
             "auth.identity.anonymous && auth.identity != null && auth.identity.foo > 3",
         )
-        .unwrap();
+        .expect("This is valid CEL!");
         assert_eq!(value.attributes.len(), 3);
         assert_eq!(value.attributes[0].path, "auth.identity".into());
     }
@@ -650,7 +654,7 @@ mod tests {
             "true".bytes().collect(),
         )));
         let value = Expression::new("auth.identity.anonymous")
-            .unwrap()
+            .expect("This is valid CEL!")
             .eval()
             .expect("This must evaluate!");
         assert_eq!(value, true.into());
@@ -660,7 +664,7 @@ mod tests {
             "42".bytes().collect(),
         )));
         let value = Expression::new("auth.identity.age")
-            .unwrap()
+            .expect("This is valid CEL!")
             .eval()
             .expect("This must evaluate!");
         assert_eq!(value, 42.into());
@@ -670,7 +674,7 @@ mod tests {
             "42.3".bytes().collect(),
         )));
         let value = Expression::new("auth.identity.age")
-            .unwrap()
+            .expect("This is valid CEL!")
             .eval()
             .expect("This must evaluate!");
         assert_eq!(value, 42.3.into());
@@ -680,7 +684,7 @@ mod tests {
             "\"John\"".bytes().collect(),
         )));
         let value = Expression::new("auth.identity.age")
-            .unwrap()
+            .expect("This is valid CEL!")
             .eval()
             .expect("This must evaluate!");
         assert_eq!(value, "John".into());
@@ -690,7 +694,7 @@ mod tests {
             "-42".bytes().collect(),
         )));
         let value = Expression::new("auth.identity.name")
-            .unwrap()
+            .expect("This is valid CEL!")
             .eval()
             .expect("This must evaluate!");
         assert_eq!(value, (-42).into());
@@ -701,7 +705,7 @@ mod tests {
             "some random crap".bytes().collect(),
         )));
         let value = Expression::new("auth.identity.age")
-            .unwrap()
+            .expect("This is valid CEL!")
             .eval()
             .expect("This must evaluate!");
         assert_eq!(value, "some random crap".into());
@@ -775,12 +779,14 @@ mod tests {
             80_i64.to_le_bytes().into(),
         )));
         let value = known_attribute_for(&"destination.port".into())
-            .unwrap()
+            .expect("destination.port known attribute exists")
             .get();
         assert_eq!(value, 80.into());
         property::test::TEST_PROPERTY_VALUE
             .set(Some(("request.method".into(), "GET".bytes().collect())));
-        let value = known_attribute_for(&"request.method".into()).unwrap().get();
+        let value = known_attribute_for(&"request.method".into())
+            .expect("request.method known attribute exists")
+            .get();
         assert_eq!(value, "GET".into());
     }
 
@@ -802,7 +808,7 @@ mod tests {
             b"\xCA\xFE".to_vec(),
         )));
         let value = Expression::new("getHostProperty(['foo', 'bar.baz'])")
-            .unwrap()
+            .expect("This is valid CEL!")
             .eval()
             .expect("This must evaluate!");
         assert_eq!(value, Value::Bytes(Arc::new(b"\xCA\xFE".to_vec())));

--- a/src/filter.rs
+++ b/src/filter.rs
@@ -26,7 +26,8 @@ extern "C" fn start() {
 
     proxy_wasm::set_log_level(LogLevel::Trace);
     std::panic::set_hook(Box::new(|panic_info| {
-        proxy_wasm::hostcalls::log(LogLevel::Critical, &panic_info.to_string()).unwrap();
+        proxy_wasm::hostcalls::log(LogLevel::Critical, &panic_info.to_string())
+            .expect("failed to log panic_info");
     }));
     proxy_wasm::set_root_context(|context_id| -> Box<dyn RootContext> {
         info!("#{} set_root_context", context_id);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,7 +20,9 @@ mod tests {
             .push(header("test", "some value"));
         resp.response_headers_to_add
             .push(header("other", "header value"));
-        let buffer = resp.write_to_bytes().unwrap();
+        let buffer = resp
+            .write_to_bytes()
+            .expect("must be able to write RateLimitResponse to bytes");
         let expected: [u8; 45] = [
             8, 1, 26, 18, 10, 4, 116, 101, 115, 116, 18, 10, 115, 111, 109, 101, 32, 118, 97, 108,
             117, 101, 26, 21, 10, 5, 111, 116, 104, 101, 114, 18, 12, 104, 101, 97, 100, 101, 114,

--- a/src/operation_dispatcher.rs
+++ b/src/operation_dispatcher.rs
@@ -463,34 +463,84 @@ mod tests {
         assert_eq!(operation_dispatcher.waiting_operations.len(), 0);
 
         let mut op = operation_dispatcher.next();
-        assert_eq!(op.clone().unwrap().unwrap().get_result(), Ok(66));
         assert_eq!(
-            *op.clone().unwrap().unwrap().get_service_type(),
+            op.clone()
+                .expect("ok result")
+                .expect("operation is some")
+                .get_result(),
+            Ok(66)
+        );
+        assert_eq!(
+            *op.clone()
+                .expect("ok result")
+                .expect("operation is some")
+                .get_service_type(),
             ServiceType::RateLimit
         );
-        assert_eq!(op.unwrap().unwrap().get_state(), State::Waiting);
+        assert_eq!(
+            op.expect("ok result")
+                .expect("operation is some")
+                .get_state(),
+            State::Waiting
+        );
         assert_eq!(operation_dispatcher.waiting_operations.len(), 1);
 
         op = operation_dispatcher.next();
-        assert_eq!(op.clone().unwrap().unwrap().get_result(), Ok(66));
-        assert_eq!(op.unwrap().unwrap().get_state(), State::Done);
+        assert_eq!(
+            op.clone()
+                .expect("ok result")
+                .expect("operation is some")
+                .get_result(),
+            Ok(66)
+        );
+        assert_eq!(
+            op.expect("ok result")
+                .expect("operation is some")
+                .get_state(),
+            State::Done
+        );
 
         op = operation_dispatcher.next();
-        assert_eq!(op.clone().unwrap().unwrap().get_result(), Ok(77));
         assert_eq!(
-            *op.clone().unwrap().unwrap().get_service_type(),
+            op.clone()
+                .expect("ok result")
+                .expect("operation is some")
+                .get_result(),
+            Ok(77)
+        );
+        assert_eq!(
+            *op.clone()
+                .expect("ok result")
+                .expect("operation is some")
+                .get_service_type(),
             ServiceType::Auth
         );
-        assert_eq!(op.unwrap().unwrap().get_state(), State::Waiting);
+        assert_eq!(
+            op.expect("ok result")
+                .expect("operation is some")
+                .get_state(),
+            State::Waiting
+        );
         assert_eq!(operation_dispatcher.waiting_operations.len(), 1);
 
         op = operation_dispatcher.next();
-        assert_eq!(op.clone().unwrap().unwrap().get_result(), Ok(77));
-        assert_eq!(op.unwrap().unwrap().get_state(), State::Done);
+        assert_eq!(
+            op.clone()
+                .expect("ok result")
+                .expect("operation is some")
+                .get_result(),
+            Ok(77)
+        );
+        assert_eq!(
+            op.expect("ok result")
+                .expect("operation is some")
+                .get_state(),
+            State::Done
+        );
         assert_eq!(operation_dispatcher.waiting_operations.len(), 1);
 
         op = operation_dispatcher.next();
-        assert!(op.unwrap().is_none());
+        assert!(op.expect("ok result").is_none());
         assert!(operation_dispatcher.get_current_operation_state().is_none());
         assert_eq!(operation_dispatcher.waiting_operations.len(), 0);
     }

--- a/src/service/auth.rs
+++ b/src/service/auth.rs
@@ -64,7 +64,7 @@ impl AuthService {
         let mut request = AttributeContext_Request::default();
         let mut http = AttributeContext_HttpRequest::default();
         let headers: HashMap<String, String> = hostcalls::get_map(MapType::HttpRequestHeaders)
-            .unwrap()
+            .expect("failed to retrieve HttpRequestHeaders from host")
             .into_iter()
             .collect();
 
@@ -151,7 +151,7 @@ impl AuthService {
                             header.get_header().get_key(),
                             header.get_header().get_value(),
                         )
-                        .unwrap()
+                        .expect("failed to add_map_value to HttpRequestHeaders")
                     });
                     Ok(GrpcResult::default())
                 }
@@ -170,7 +170,7 @@ impl AuthService {
                         response_headers,
                         Some(denied_response.get_body().as_ref()),
                     )
-                    .unwrap();
+                    .expect("failed to send_http_response");
                     Err(status_code)
                 }
                 None => {

--- a/src/service/rate_limit.rs
+++ b/src/service/rate_limit.rs
@@ -106,8 +106,22 @@ mod tests {
 
         assert_eq!(msg.hits_addend, 1);
         assert_eq!(msg.domain, "rlp1".to_string());
-        assert_eq!(msg.descriptors.first().unwrap().entries[0].key, "key1");
-        assert_eq!(msg.descriptors.first().unwrap().entries[0].value, "value1");
+        assert_eq!(
+            msg.descriptors
+                .first()
+                .expect("must have a descriptor")
+                .entries[0]
+                .key,
+            "key1"
+        );
+        assert_eq!(
+            msg.descriptors
+                .first()
+                .expect("must have a descriptor")
+                .entries[0]
+                .value,
+            "value1"
+        );
         assert_eq!(msg.unknown_fields, UnknownFields::default());
         assert_eq!(msg.cached_size, CachedSize::default());
     }

--- a/src/service/rate_limit.rs
+++ b/src/service/rate_limit.rs
@@ -57,7 +57,7 @@ impl RateLimitService {
                     response_headers.push((header.get_key(), header.get_value()));
                 }
                 hostcalls::send_http_response(429, response_headers, Some(b"Too Many Requests\n"))
-                    .unwrap();
+                    .expect("failed to send_http_response 429 while OVER_LIMIT");
                 Err(StatusCode::TooManyRequests)
             }
             GrpcMessageResponse::RateLimit(RateLimitResponse {


### PR DESCRIPTION
* Enable clippy lint `unwrap_used` - this is in a separate commit so we can drop it before we merge
* Most cases was replacing unwraps with expect