### PR TITLE
Alternate proposal

### DIFF
--- a/src/filter.rs
+++ b/src/filter.rs
@@ -1,4 +1,5 @@
 pub(crate) mod http_context;
+#[allow(dead_code)]
 pub(crate) mod proposal_context;
 mod root_context;
 

--- a/src/filter.rs
+++ b/src/filter.rs
@@ -1,4 +1,5 @@
 pub(crate) mod http_context;
+pub(crate) mod proposal_context;
 mod root_context;
 
 #[cfg_attr(

--- a/src/filter/proposal_context.rs
+++ b/src/filter/proposal_context.rs
@@ -1,0 +1,109 @@
+use crate::action_set_index::ActionSetIndex;
+use crate::filter::proposal_context::no_implicit_dep::{EndRequestOperation, HeadersOperation};
+use log::warn;
+use proxy_wasm::traits::{Context, HttpContext};
+use proxy_wasm::types::{Action, Status};
+use std::mem;
+
+pub mod no_implicit_dep {
+    use proxy_wasm::traits::HttpContext;
+
+    #[allow(dead_code)]
+    pub enum Operation {
+        AwaitGrpcResponse(GrpcMessageReceiverOperation),
+        AddHeaders(HeadersOperation),
+        Die(EndRequestOperation),
+    }
+    pub struct GrpcMessageReceiverOperation {}
+
+    impl GrpcMessageReceiverOperation {
+        pub fn process<T: HttpContext>(self, _msg: &[u8], _ctx: &mut T) -> Operation {
+            todo!()
+        }
+
+        pub fn fail<T: HttpContext>(self, _ctx: &mut T) -> Operation {
+            Operation::Die(EndRequestOperation { status: 500 })
+        }
+    }
+
+    pub struct HeadersOperation {}
+
+    pub struct EndRequestOperation {
+        pub status: u32,
+    }
+}
+
+struct Filter {
+    index: ActionSetIndex,
+
+    grpc_message_receiver_operation: Option<no_implicit_dep::GrpcMessageReceiverOperation>,
+    headers_operations: Vec<HeadersOperation>,
+}
+
+impl Context for Filter {
+    fn on_grpc_call_response(&mut self, _token_id: u32, status_code: u32, _resp_size: usize) {
+        let receiver = mem::take(&mut self.grpc_message_receiver_operation)
+            .expect("We need an operation pending a gRPC response");
+        let next = if status_code != Status::Ok as u32 {
+            receiver.process(&[], self)
+        } else {
+            receiver.fail(self)
+        };
+        self.handle_operation(next);
+    }
+}
+
+impl HttpContext for Filter {
+    fn on_http_request_headers(&mut self, _: usize, _: bool) -> Action {
+        if let Some(action_sets) = self
+            .index
+            .get_longest_match_action_sets(self.request_authority().as_ref())
+        {
+            if let Some(action_set) = action_sets
+                .iter()
+                .find(|action_set| action_set.conditions_apply(/* self */))
+            {
+                self.handle_operation(action_set.start_flow(self))
+            }
+        }
+        Action::Continue
+    }
+
+    fn on_http_response_headers(&mut self, _num_headers: usize, _end_of_stream: bool) -> Action {
+        for _op in self.headers_operations.drain(..) {
+            todo!("Add the headers")
+        }
+        Action::Continue
+    }
+}
+
+impl Filter {
+    fn handle_operation(&mut self, operation: no_implicit_dep::Operation) {
+        match operation {
+            no_implicit_dep::Operation::AwaitGrpcResponse(msg) => {
+                self.grpc_message_receiver_operation = Some(msg)
+            }
+            no_implicit_dep::Operation::AddHeaders(headers) => {
+                self.headers_operations.push(headers)
+            }
+            no_implicit_dep::Operation::Die(die) => self.die(die),
+        }
+    }
+
+    fn die(&mut self, die: EndRequestOperation) {
+        self.send_http_response(die.status, Vec::default(), None);
+    }
+
+    fn request_authority(&self) -> String {
+        match self.get_http_request_header(":authority") {
+            None => {
+                warn!(":authority header not found");
+                String::new()
+            }
+            Some(host) => {
+                let split_host = host.split(':').collect::<Vec<_>>();
+                split_host[0].to_owned()
+            }
+        }
+    }
+}

--- a/src/runtime_action_set.rs
+++ b/src/runtime_action_set.rs
@@ -67,6 +67,13 @@ impl RuntimeActionSet {
                 }
             })
     }
+
+    pub fn start_flow<T: proxy_wasm::traits::HttpContext>(
+        &self,
+        _ctx: &T,
+    ) -> crate::filter::proposal_context::no_implicit_dep::Operation {
+        todo!("implement me!")
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Since @eguzki was very much against the idea of splitting the responsibility of sending the message from the actual `Action` underneath all of the layers in between, I came up with something that I thing would let you do that, while composing the state rather than folding it all together in a ball of mud.

`proposal_context::Filter` only responsibility is to hold on to the state relative to each phase of the request being handled:

 - `on_http_request_headers`: where a possible start of a "flow" happens, otherwise `Status::Continue`;
 - `on_grpc_call_response`: where an `Operation` is pending a response from a (single here, but it could expose the token associated with all of the) request(s) it's made;
 - `on_http_response_headers`: where possible additional headers added by some service need to be added

Most of the coordination now happens in `handle_operation` which will either associate the `Operation` with the proper field, or let the request `die`, i.e. deny it... 

"`FallibleOperation`s", tho not an explicit type, do expose a `.fail() -> Operation` method. So to handle a GrpcMessage sending failure for instance.

Code in the `no_implicit_dep` module, take an explicit `&mut T: HttpContext` in, which in production would be the `Filter` itself, while in testing can be a mock of it, so no _implicit_ dependency, mostly funtion calls, to the proxy wasm sdk exists. They are all explicit... 

This comes with the downside there is now a ever so thin dependency on the proxy wasm sdk types in our implementation. It also will need to be passed along all the way down thru `Core` layers to the individual `Auth_Module` & `RateLimiting_Module` from @eguzki 's design, but still makes this all cleaner than what we have today... 

Anyways, throwing this out there... This is very obviously _not_ to be merged ever. At best, if someone thinks this can be a useful basis for further improvement, possibly this single commit _could_ be reused. But I was mostly trying to highlight different options...
