### PR TITLE
Add HeaderKind to enable setting request headers

### DIFF
--- a/src/filter/operations.rs
+++ b/src/filter/operations.rs
@@ -1,13 +1,13 @@
 use crate::configuration::FailureMode;
 use crate::filter::operations::Operation::SendGrpcRequest;
 use crate::runtime_action_set::RuntimeActionSet;
-use crate::service::{GrpcErrResponse, GrpcRequest, Headers, IndexedGrpcRequest};
+use crate::service::{GrpcErrResponse, GrpcRequest, HeaderKind, IndexedGrpcRequest};
 use std::rc::Rc;
 
 pub enum Operation {
     SendGrpcRequest(GrpcMessageSenderOperation),
     AwaitGrpcResponse(GrpcMessageReceiverOperation),
-    AddHeaders(HeadersOperation),
+    AddHeaders(HeaderOperation),
     Die(GrpcErrResponse),
     // Done indicates that we have no more operations and can resume the http request flow
     Done(),
@@ -60,7 +60,7 @@ impl GrpcMessageReceiverOperation {
             Ok((next_msg, headers)) => {
                 let mut operations = Vec::new();
                 if !headers.is_empty() {
-                    operations.push(Operation::AddHeaders(HeadersOperation::new(headers)))
+                    operations.push(Operation::AddHeaders(HeaderOperation::new(headers)))
                 }
                 operations.push(match next_msg {
                     None => Operation::Done(),
@@ -92,16 +92,16 @@ impl GrpcMessageReceiverOperation {
     }
 }
 
-pub struct HeadersOperation {
-    headers: Headers,
+pub struct HeaderOperation {
+    headers: HeaderKind,
 }
 
-impl HeadersOperation {
-    pub fn new(headers: Headers) -> Self {
+impl HeaderOperation {
+    pub fn new(headers: HeaderKind) -> Self {
         Self { headers }
     }
 
-    pub fn headers(self) -> Headers {
+    pub fn into_inner(self) -> HeaderKind {
         self.headers
     }
 }

--- a/src/runtime_action.rs
+++ b/src/runtime_action.rs
@@ -3,7 +3,7 @@ use crate::configuration::{Action, FailureMode, Service, ServiceType};
 use crate::ratelimit_action::RateLimitAction;
 use crate::service::auth::AuthService;
 use crate::service::rate_limit::RateLimitService;
-use crate::service::{GrpcErrResponse, GrpcRequest, GrpcService, Headers};
+use crate::service::{GrpcErrResponse, GrpcRequest, GrpcService, HeaderKind};
 use log::debug;
 use protobuf::Message;
 use std::collections::HashMap;
@@ -67,7 +67,7 @@ impl RuntimeAction {
         }
     }
 
-    pub fn process_response(&self, msg: &[u8]) -> Result<Headers, GrpcErrResponse> {
+    pub fn process_response(&self, msg: &[u8]) -> Result<HeaderKind, GrpcErrResponse> {
         match self {
             Self::Auth(auth_action) => match Message::parse_from_bytes(msg) {
                 Ok(check_response) => auth_action.process_response(check_response),
@@ -77,7 +77,7 @@ impl RuntimeAction {
                         FailureMode::Deny => Err(GrpcErrResponse::new_internal_server_error()),
                         FailureMode::Allow => {
                             debug!("process_response(auth): continuing as FailureMode Allow");
-                            Ok(Vec::default())
+                            Ok(HeaderKind::Request(Vec::default()))
                         }
                     }
                 }
@@ -90,7 +90,7 @@ impl RuntimeAction {
                         FailureMode::Deny => Err(GrpcErrResponse::new_internal_server_error()),
                         FailureMode::Allow => {
                             debug!("process_response(rl): continuing as FailureMode Allow");
-                            Ok(Vec::default())
+                            Ok(HeaderKind::Response(Vec::default()))
                         }
                     }
                 }

--- a/src/runtime_action_set.rs
+++ b/src/runtime_action_set.rs
@@ -1,7 +1,7 @@
 use crate::configuration::{ActionSet, Service};
 use crate::data::{Predicate, PredicateVec};
 use crate::runtime_action::RuntimeAction;
-use crate::service::{GrpcErrResponse, Headers, IndexedGrpcRequest};
+use crate::service::{GrpcErrResponse, HeaderKind, IndexedGrpcRequest};
 use std::collections::HashMap;
 use std::rc::Rc;
 
@@ -80,7 +80,7 @@ impl RuntimeActionSet {
         &self,
         index: usize,
         msg: &[u8],
-    ) -> Result<(Option<IndexedGrpcRequest>, Headers), GrpcErrResponse> {
+    ) -> Result<(Option<IndexedGrpcRequest>, HeaderKind), GrpcErrResponse> {
         self.runtime_actions[index]
             .process_response(msg)
             .map(|headers| {

--- a/src/service.rs
+++ b/src/service.rs
@@ -132,6 +132,20 @@ impl GrpcRequest {
 
 pub type Headers = Vec<(String, String)>;
 #[derive(Debug)]
+pub enum HeaderKind {
+    Response(Headers),
+    Request(Headers),
+}
+
+impl HeaderKind {
+    pub fn is_empty(&self) -> bool {
+        match self {
+            HeaderKind::Response(headers) | HeaderKind::Request(headers) => headers.is_empty(),
+        }
+    }
+}
+
+#[derive(Debug)]
 pub struct GrpcErrResponse {
     status_code: u32,
     response_headers: Headers,

--- a/utils/deploy/authconfig.yaml
+++ b/utils/deploy/authconfig.yaml
@@ -31,6 +31,12 @@ spec:
                 value: 42
               "missing":
                 value: null
+      headers:
+        "my-header":
+          json:
+            properties:
+              "my-key":
+                value: true
 ---
 apiVersion: v1
 kind: Secret


### PR DESCRIPTION
In the wasm-shim refactor the request vs response headers that was fixed prior (#143) was missed. I've introduced an enum called `HeaderKind` which explicitly differentiates the `Request` vs `Response` types for the specific actions, and have enforced that these can only be added at the correct phase.

I've updated the authconfig to add request headers, so this is verifiable as follows:

```sh
make local-setup
```
```sh
kubectl port-forward --namespace kuadrant-system deployment/envoy 8000:8000
```
```sh
curl -H "Host: test.a.auth.com" -H "Authorization: APIKEY IAMALICE" http://127.0.0.1:8000/get -i
```

See `My-Header` in the **_echoed_** request:
```sh
HTTP/1.1 200 OK
content-type: application/json
server: envoy
date: Wed, 05 Feb 2025 16:10:52 GMT
content-length: 545
x-envoy-upstream-service-time: 2

{
  "method": "GET",
  "path": "/get",
  "query_string": null,
  "body": "",
  "headers": {
    "Host": "test.a.auth.com",
    "User-Agent": "curl/8.7.1",
    "Accept": "*/*",
    "Authorization": "APIKEY IAMALICE",
    "X-Forwarded-For": "10.244.0.10",
    "X-Forwarded-Proto": "http",
    "X-Envoy-Internal": "true",
    "X-Request-Id": "9641a263-bfdb-49b7-b1c2-a7662ec1e74e",
    "My-Header": "{\"my-key\":true}",
    "X-Envoy-Expected-Rq-Timeout-Ms": "15000",
    "Version": "HTTP/1.1"
  },
  "uuid": "fbbaad8b-2d15-42b1-9c3d-c21721d37b59"
}
```

Resolves #164