### PR TITLE
Fix some lints and remove panic in auth action

### DIFF
--- a/src/filter/operations.rs
+++ b/src/filter/operations.rs
@@ -1,5 +1,4 @@
 use crate::configuration::FailureMode;
-use crate::filter::operations::Operation::SendGrpcRequest;
 use crate::runtime_action_set::RuntimeActionSet;
 use crate::service::{GrpcErrResponse, GrpcRequest, HeaderKind, IndexedGrpcRequest};
 use std::rc::Rc;
@@ -64,10 +63,9 @@ impl GrpcMessageReceiverOperation {
                 }
                 operations.push(match next_msg {
                     None => Operation::Done(),
-                    Some(indexed_req) => SendGrpcRequest(GrpcMessageSenderOperation::new(
-                        self.runtime_action_set,
-                        indexed_req,
-                    )),
+                    Some(indexed_req) => Operation::SendGrpcRequest(
+                        GrpcMessageSenderOperation::new(self.runtime_action_set, indexed_req),
+                    ),
                 });
                 operations
             }


### PR DESCRIPTION
Only a couple minor changes:

* Move the logic for `FailureMode` resolution into a `resolve_failure_mode` function to reduce duplication
* Remove the 4 panics in the auth_action and, **ignoring `FailureMode`**, warn and return an `InternalServerError`
    * Currently these fields are **_NOT POPULATED_** by authorino (so these branches won't be hit under usual conditions) and would indicate the `CheckResponse` has been tampered with; that being said we don't want to `panic` and potentially end up denying legitimate requests