### PR TITLE
Error handling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -561,6 +561,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
 
 [[package]]
+name = "foldhash"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0d2fde1f7b3d48b8395d5f2de76c18a528bd6a9cdde438df747bfcba3e05d6f"
+
+[[package]]
 name = "form_urlencoded"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -731,16 +737,17 @@ name = "hashbrown"
 version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
-dependencies = [
- "ahash",
- "allocator-api2",
-]
 
 [[package]]
 name = "hashbrown"
 version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e087f84d4f86bf4b218b927129862374b72199ae7d8657835f1e89000eea4fb"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash",
+]
 
 [[package]]
 name = "heck"
@@ -1303,11 +1310,10 @@ dependencies = [
 
 [[package]]
 name = "proxy-wasm"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14a5a4df5a1ab77235e36a0a0f638687ee1586d21ee9774037693001e94d4e11"
+version = "0.2.3-dev"
+source = "git+https://github.com/Kuadrant/proxy-wasm-rust-sdk.git?branch=kuadrant#ceeb7c1f5263c30d835d87eee11660348d2179e8"
 dependencies = [
- "hashbrown 0.14.5",
+ "hashbrown 0.15.0",
  "log",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ with-serde = ["protobuf/with-serde"]
 debug-host-behaviour = []
 
 [dependencies]
-proxy-wasm = "0.2.1"
+proxy-wasm = { git = "https://github.com/Kuadrant/proxy-wasm-rust-sdk.git", branch = "kuadrant"}
 serde_json = "1.0"
 log = "0.4"
 serde = { version = "1.0", features = ["derive"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,3 +43,10 @@ serial_test = "2.0.0"
 
 [build-dependencies]
 protoc-rust = "2.27"
+
+[lints.clippy]
+panic = "deny"
+unwrap_used = "deny"
+expect_used = "deny"
+#eventually clean all these up as well
+#indexing_slicing = "deny"

--- a/build.rs
+++ b/build.rs
@@ -22,6 +22,7 @@ fn set_features(env: &str) {
     println!("cargo:rustc-env={env}={features:?}");
 }
 
+#[allow(clippy::indexing_slicing)]
 fn set_git_hash(env: &str) {
     let git_sha = Command::new("/usr/bin/git")
         .args(["rev-parse", "HEAD"])
@@ -52,6 +53,7 @@ fn set_git_hash(env: &str) {
     }
 }
 
+#[allow(clippy::expect_used)]
 fn generate_protobuf() -> Result<(), Box<dyn Error>> {
     let custom = protoc_rust::Customize {
         serde_derive: Some(true),

--- a/clippy.toml
+++ b/clippy.toml
@@ -1,0 +1,2 @@
+allow-unwrap-in-tests = true
+allow-expect-in-tests = true

--- a/src/auth_action.rs
+++ b/src/auth_action.rs
@@ -197,15 +197,13 @@ mod test {
     #[test]
     fn empty_predicates_do_apply() {
         let auth_action = build_auth_action_with_predicates(Vec::default());
-        assert!(auth_action.conditions_apply().is_ok());
-        assert!(auth_action.conditions_apply().expect("is ok"));
+        assert_eq!(auth_action.conditions_apply(), Ok(true));
     }
 
     #[test]
     fn when_all_predicates_are_truthy_action_apply() {
         let auth_action = build_auth_action_with_predicates(vec!["true".into(), "true".into()]);
-        assert!(auth_action.conditions_apply().is_ok());
-        assert!(auth_action.conditions_apply().expect("is ok"));
+        assert_eq!(auth_action.conditions_apply(), Ok(true));
     }
 
     #[test]
@@ -216,8 +214,7 @@ mod test {
             "true".into(),
             "false".into(),
         ]);
-        assert!(auth_action.conditions_apply().is_ok());
-        assert!(!auth_action.conditions_apply().expect("is ok"));
+        assert_eq!(auth_action.conditions_apply(), Ok(false));
     }
 
     #[test]

--- a/src/auth_action.rs
+++ b/src/auth_action.rs
@@ -35,7 +35,8 @@ impl AuthAction {
     }
 
     pub fn conditions_apply(&self) -> bool {
-        self.predicates.apply()
+        //todo(adam-cattermole): do not expect
+        self.predicates.apply().expect("REMOVE")
     }
 
     pub fn get_failure_mode(&self) -> FailureMode {

--- a/src/auth_action.rs
+++ b/src/auth_action.rs
@@ -58,7 +58,9 @@ impl AuthAction {
         //todo(adam-cattermole):hostvar resolver?
         // store dynamic metadata in filter state
         debug!("process_response(auth): store_metadata");
-        store_metadata(check_response.get_dynamic_metadata());
+        if store_metadata(check_response.get_dynamic_metadata()).is_err() {
+            return self.resolve_failure_mode();
+        }
 
         match check_response.http_response {
             None => {

--- a/src/auth_action.rs
+++ b/src/auth_action.rs
@@ -237,7 +237,7 @@ mod test {
 
         match result.expect("is ok") {
             HeaderKind::Response(_headers) => {
-                panic!("check_response should not return Response headers")
+                unreachable!("check_response should not return Response headers")
             }
             HeaderKind::Request(headers) => assert!(headers.is_empty()),
         }
@@ -249,7 +249,7 @@ mod test {
 
         match result.expect("is ok") {
             HeaderKind::Response(_headers) => {
-                panic!("check_response should not return Response headers")
+                unreachable!("check_response should not return Response headers")
             }
             HeaderKind::Request(headers) => {
                 assert!(!headers.is_empty());

--- a/src/configuration.rs
+++ b/src/configuration.rs
@@ -236,7 +236,7 @@ mod test {
             assert_eq!(auth_service.failure_mode, FailureMode::Deny);
             assert_eq!(auth_service.timeout, Timeout(Duration::from_millis(24)))
         } else {
-            panic!()
+            unreachable!()
         }
 
         if let Some(rl_service) = services.get("limitador") {
@@ -245,7 +245,7 @@ mod test {
             assert_eq!(rl_service.failure_mode, FailureMode::Allow);
             assert_eq!(rl_service.timeout, Timeout(Duration::from_millis(42)))
         } else {
-            panic!()
+            unreachable!()
         }
 
         let predicates = &plugin_config.action_sets[0]
@@ -277,14 +277,14 @@ mod test {
             assert_eq!(static_item.key, "rlp-ns-A/rlp-name-A");
             assert_eq!(static_item.value, "1");
         } else {
-            panic!();
+            unreachable!();
         }
 
         if let DataType::Expression(exp) = &rl_data_items[1].item {
             assert_eq!(exp.key, "username");
             assert_eq!(exp.value, "auth.metadata.username");
         } else {
-            panic!();
+            unreachable!();
         }
     }
 

--- a/src/data/attribute.rs
+++ b/src/data/attribute.rs
@@ -78,46 +78,40 @@ impl AttributeValue for String {
 
 impl AttributeValue for i64 {
     fn parse(raw_attribute: Vec<u8>) -> Result<Self, PropError> {
-        let bytes: Result<[u8; 8], _> = raw_attribute[..8].try_into();
-        if bytes.is_ok() && raw_attribute.len() == 8 {
-            if let Ok(bytes) = bytes {
-                return Ok(i64::from_le_bytes(bytes));
-            }
+        let ra_len = raw_attribute.len();
+        match <[u8; 8]>::try_from(raw_attribute) {
+            Ok(bytes) => Ok(i64::from_le_bytes(bytes)),
+            Err(_) => Err(PropError::new(format!(
+                "parse: Int value expected to be 8 bytes, but got {}",
+                ra_len,
+            ))),
         }
-        Err(PropError::new(format!(
-            "parse: Int value expected to be 8 bytes, but got {}",
-            raw_attribute.len()
-        )))
     }
 }
 
 impl AttributeValue for u64 {
     fn parse(raw_attribute: Vec<u8>) -> Result<Self, PropError> {
-        let bytes: Result<[u8; 8], _> = raw_attribute[..8].try_into();
-        if bytes.is_ok() && raw_attribute.len() == 8 {
-            if let Ok(bytes) = bytes {
-                return Ok(u64::from_le_bytes(bytes));
-            }
+        let ra_len = raw_attribute.len();
+        match <[u8; 8]>::try_from(raw_attribute) {
+            Ok(bytes) => Ok(u64::from_le_bytes(bytes)),
+            Err(_) => Err(PropError::new(format!(
+                "parse: UInt value expected to be 8 bytes, but got {}",
+                ra_len,
+            ))),
         }
-        Err(PropError::new(format!(
-            "parse: UInt value expected to be 8 bytes, but got {}",
-            raw_attribute.len()
-        )))
     }
 }
 
 impl AttributeValue for f64 {
     fn parse(raw_attribute: Vec<u8>) -> Result<Self, PropError> {
-        let bytes: Result<[u8; 8], _> = raw_attribute[..8].try_into();
-        if bytes.is_ok() && raw_attribute.len() == 8 {
-            if let Ok(bytes) = bytes {
-                return Ok(f64::from_le_bytes(bytes));
-            }
+        let ra_len = raw_attribute.len();
+        match <[u8; 8]>::try_from(raw_attribute) {
+            Ok(bytes) => Ok(f64::from_le_bytes(bytes)),
+            Err(_) => Err(PropError::new(format!(
+                "parse: Float value expected to be 8 bytes, but got {}",
+                ra_len,
+            ))),
         }
-        Err(PropError::new(format!(
-            "parse: Float value expected to be 8 bytes, but got {}",
-            raw_attribute.len()
-        )))
     }
 }
 
@@ -141,17 +135,17 @@ impl AttributeValue for bool {
 
 impl AttributeValue for DateTime<FixedOffset> {
     fn parse(raw_attribute: Vec<u8>) -> Result<Self, PropError> {
-        let bytes: Result<[u8; 8], _> = raw_attribute[..8].try_into();
-        if bytes.is_ok() && raw_attribute.len() == 8 {
-            if let Ok(bytes) = bytes {
+        let ra_len = raw_attribute.len();
+        match <[u8; 8]>::try_from(raw_attribute) {
+            Ok(bytes) => {
                 let nanos = i64::from_le_bytes(bytes);
-                return Ok(DateTime::from_timestamp_nanos(nanos).into());
+                Ok(DateTime::from_timestamp_nanos(nanos).into())
             }
+            Err(_) => Err(PropError::new(format!(
+                "parse: Timestamp expected to be 8 bytes, but got {}",
+                ra_len,
+            ))),
         }
-        Err(PropError::new(format!(
-            "parse: Timestamp expected to be 8 bytes, but got {}",
-            raw_attribute.len()
-        )))
     }
 }
 

--- a/src/data/attribute.rs
+++ b/src/data/attribute.rs
@@ -11,17 +11,17 @@ pub(super) mod errors {
     use std::error::Error;
     use std::fmt::{Debug, Display, Formatter};
 
-    #[derive(PartialEq)]
+    #[derive(Debug, PartialEq)]
     pub enum PropertyError {
-        GetPropertyError(PropError),
-        ParsePropertyError(PropError),
+        Get(PropError),
+        Parse(PropError),
     }
 
     impl Error for PropertyError {
         fn source(&self) -> Option<&(dyn Error + 'static)> {
             match self {
-                PropertyError::GetPropertyError(err) => Some(err),
-                PropertyError::ParsePropertyError(err) => Some(err),
+                PropertyError::Get(err) => Some(err),
+                PropertyError::Parse(err) => Some(err),
             }
         }
     }
@@ -29,36 +29,24 @@ pub(super) mod errors {
     impl Display for PropertyError {
         fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
             match self {
-                PropertyError::GetPropertyError(e) => {
-                    write!(f, "PropertyError::GetPropertyError {{ {} }}", e)
+                PropertyError::Get(e) => {
+                    write!(f, "PropertyError::Get {{ {:?} }}", e)
                 }
-                PropertyError::ParsePropertyError(e) => {
-                    write!(f, "PropertyError::ParsePropertyError {{ {} }}", e)
+                PropertyError::Parse(e) => {
+                    write!(f, "PropertyError::Parse {{ {:?} }}", e)
                 }
             }
         }
     }
 
-    impl Debug for PropertyError {
-        fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-            write!(f, "{}", self)
-        }
-    }
-
-    #[derive(PartialEq)]
+    #[derive(Debug, PartialEq)]
     pub struct PropError {
         message: String,
     }
 
     impl Display for PropError {
         fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-            write!(f, "PropError {{ message: {} }}", self.message)
-        }
-    }
-
-    impl Debug for PropError {
-        fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-            write!(f, "{}", self)
+            write!(f, "PropError {{ message: {:?} }}", self.message)
         }
     }
 
@@ -173,10 +161,10 @@ where
 {
     match crate::data::property::get_property(path) {
         Ok(Some(attribute_bytes)) => Ok(Some(
-            T::parse(attribute_bytes).map_err(PropertyError::ParsePropertyError)?,
+            T::parse(attribute_bytes).map_err(PropertyError::Parse)?,
         )),
         Ok(None) => Ok(None),
-        Err(e) => Err(PropertyError::GetPropertyError(PropError::new(format!(
+        Err(e) => Err(PropertyError::Get(PropError::new(format!(
             "get_attribute: error: {e:?}"
         )))),
     }

--- a/src/data/attribute.rs
+++ b/src/data/attribute.rs
@@ -1,4 +1,5 @@
-use crate::data::PropertyPath;
+use crate::data::attribute::errors::PropError;
+use crate::data::{PropertyError, PropertyPath};
 use chrono::{DateTime, FixedOffset};
 use log::{debug, error, warn};
 use protobuf::well_known_types::Struct;
@@ -6,115 +7,178 @@ use serde_json::Value;
 
 pub const KUADRANT_NAMESPACE: &str = "kuadrant";
 
+pub(super) mod errors {
+    use std::error::Error;
+    use std::fmt::{Debug, Display, Formatter};
+
+    #[derive(PartialEq)]
+    pub enum PropertyError {
+        GetPropertyError(PropError),
+        ParsePropertyError(PropError),
+    }
+
+    impl Error for PropertyError {
+        fn source(&self) -> Option<&(dyn Error + 'static)> {
+            match self {
+                PropertyError::GetPropertyError(err) => Some(err),
+                PropertyError::ParsePropertyError(err) => Some(err),
+            }
+        }
+    }
+
+    impl Display for PropertyError {
+        fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+            match self {
+                PropertyError::GetPropertyError(e) => {
+                    write!(f, "PropertyError::GetPropertyError {{ {} }}", e)
+                }
+                PropertyError::ParsePropertyError(e) => {
+                    write!(f, "PropertyError::ParsePropertyError {{ {} }}", e)
+                }
+            }
+        }
+    }
+
+    impl Debug for PropertyError {
+        fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+            write!(f, "{}", self)
+        }
+    }
+
+    #[derive(PartialEq)]
+    pub struct PropError {
+        message: String,
+    }
+
+    impl Display for PropError {
+        fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+            write!(f, "PropError {{ message: {} }}", self.message)
+        }
+    }
+
+    impl Debug for PropError {
+        fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+            write!(f, "{}", self)
+        }
+    }
+
+    impl Error for PropError {}
+
+    impl PropError {
+        pub fn new(message: String) -> PropError {
+            PropError { message }
+        }
+    }
+}
+
 pub trait AttributeValue {
-    fn parse(raw_attribute: Vec<u8>) -> Result<Self, String>
+    fn parse(raw_attribute: Vec<u8>) -> Result<Self, PropError>
     where
         Self: Sized;
 }
 
 impl AttributeValue for String {
-    fn parse(raw_attribute: Vec<u8>) -> Result<Self, String> {
+    fn parse(raw_attribute: Vec<u8>) -> Result<Self, PropError> {
         String::from_utf8(raw_attribute).map_err(|err| {
-            format!(
+            PropError::new(format!(
                 "parse: failed to parse selector String value, error: {}",
                 err
-            )
+            ))
         })
     }
 }
 
 impl AttributeValue for i64 {
-    fn parse(raw_attribute: Vec<u8>) -> Result<Self, String> {
-        if raw_attribute.len() != 8 {
-            return Err(format!(
-                "parse: Int value expected to be 8 bytes, but got {}",
-                raw_attribute.len()
-            ));
+    fn parse(raw_attribute: Vec<u8>) -> Result<Self, PropError> {
+        let bytes: Result<[u8; 8], _> = raw_attribute[..8].try_into();
+        if bytes.is_ok() && raw_attribute.len() == 8 {
+            if let Ok(bytes) = bytes {
+                return Ok(i64::from_le_bytes(bytes));
+            }
         }
-        Ok(i64::from_le_bytes(
-            raw_attribute[..8]
-                .try_into()
-                .expect("This has to be 8 bytes long!"),
-        ))
+        Err(PropError::new(format!(
+            "parse: Int value expected to be 8 bytes, but got {}",
+            raw_attribute.len()
+        )))
     }
 }
 
 impl AttributeValue for u64 {
-    fn parse(raw_attribute: Vec<u8>) -> Result<Self, String> {
-        if raw_attribute.len() != 8 {
-            return Err(format!(
-                "parse: UInt value expected to be 8 bytes, but got {}",
-                raw_attribute.len()
-            ));
+    fn parse(raw_attribute: Vec<u8>) -> Result<Self, PropError> {
+        let bytes: Result<[u8; 8], _> = raw_attribute[..8].try_into();
+        if bytes.is_ok() && raw_attribute.len() == 8 {
+            if let Ok(bytes) = bytes {
+                return Ok(u64::from_le_bytes(bytes));
+            }
         }
-        Ok(u64::from_le_bytes(
-            raw_attribute[..8]
-                .try_into()
-                .expect("This has to be 8 bytes long!"),
-        ))
+        Err(PropError::new(format!(
+            "parse: UInt value expected to be 8 bytes, but got {}",
+            raw_attribute.len()
+        )))
     }
 }
 
 impl AttributeValue for f64 {
-    fn parse(raw_attribute: Vec<u8>) -> Result<Self, String> {
-        if raw_attribute.len() != 8 {
-            return Err(format!(
-                "parse: Float value expected to be 8 bytes, but got {}",
-                raw_attribute.len()
-            ));
+    fn parse(raw_attribute: Vec<u8>) -> Result<Self, PropError> {
+        let bytes: Result<[u8; 8], _> = raw_attribute[..8].try_into();
+        if bytes.is_ok() && raw_attribute.len() == 8 {
+            if let Ok(bytes) = bytes {
+                return Ok(f64::from_le_bytes(bytes));
+            }
         }
-        Ok(f64::from_le_bytes(
-            raw_attribute[..8]
-                .try_into()
-                .expect("This has to be 8 bytes long!"),
-        ))
+        Err(PropError::new(format!(
+            "parse: Float value expected to be 8 bytes, but got {}",
+            raw_attribute.len()
+        )))
     }
 }
 
 impl AttributeValue for Vec<u8> {
-    fn parse(raw_attribute: Vec<u8>) -> Result<Self, String> {
+    fn parse(raw_attribute: Vec<u8>) -> Result<Self, PropError> {
         Ok(raw_attribute)
     }
 }
 
 impl AttributeValue for bool {
-    fn parse(raw_attribute: Vec<u8>) -> Result<Self, String> {
-        if raw_attribute.len() != 1 {
-            return Err(format!(
-                "parse: Bool value expected to be 1 byte, but got {}",
-                raw_attribute.len()
-            ));
+    fn parse(raw_attribute: Vec<u8>) -> Result<Self, PropError> {
+        if raw_attribute.len() == 1 {
+            return Ok(raw_attribute[0] & 1 == 1);
         }
-        Ok(raw_attribute[0] & 1 == 1)
+        Err(PropError::new(format!(
+            "parse: Bool value expected to be 1 byte, but got {}",
+            raw_attribute.len()
+        )))
     }
 }
 
 impl AttributeValue for DateTime<FixedOffset> {
-    fn parse(raw_attribute: Vec<u8>) -> Result<Self, String> {
-        if raw_attribute.len() != 8 {
-            return Err(format!(
-                "parse: Timestamp expected to be 8 bytes, but got {}",
-                raw_attribute.len()
-            ));
+    fn parse(raw_attribute: Vec<u8>) -> Result<Self, PropError> {
+        let bytes: Result<[u8; 8], _> = raw_attribute[..8].try_into();
+        if bytes.is_ok() && raw_attribute.len() == 8 {
+            if let Ok(bytes) = bytes {
+                let nanos = i64::from_le_bytes(bytes);
+                return Ok(DateTime::from_timestamp_nanos(nanos).into());
+            }
         }
-
-        let nanos = i64::from_le_bytes(
-            raw_attribute.as_slice()[..8]
-                .try_into()
-                .expect("This has to be 8 bytes long!"),
-        );
-        Ok(DateTime::from_timestamp_nanos(nanos).into())
+        Err(PropError::new(format!(
+            "parse: Timestamp expected to be 8 bytes, but got {}",
+            raw_attribute.len()
+        )))
     }
 }
 
-pub fn get_attribute<T>(path: &PropertyPath) -> Result<Option<T>, String>
+pub fn get_attribute<T>(path: &PropertyPath) -> Result<Option<T>, PropertyError>
 where
     T: AttributeValue,
 {
     match crate::data::property::get_property(path) {
-        Ok(Some(attribute_bytes)) => Ok(Some(T::parse(attribute_bytes)?)),
+        Ok(Some(attribute_bytes)) => Ok(Some(
+            T::parse(attribute_bytes).map_err(PropertyError::ParsePropertyError)?,
+        )),
         Ok(None) => Ok(None),
-        Err(e) => Err(format!("get_attribute: error: {e:?}")),
+        Err(e) => Err(PropertyError::GetPropertyError(PropError::new(format!(
+            "get_attribute: error: {e:?}"
+        )))),
     }
 }
 

--- a/src/data/cel.rs
+++ b/src/data/cel.rs
@@ -1,5 +1,6 @@
-use crate::data::get_attribute;
+use crate::data::cel::errors::{CelError, EvaluationError};
 use crate::data::property::{host_get_map, Path};
+use crate::data::{get_attribute, PropertyError};
 use cel_interpreter::extractors::{Arguments, This};
 use cel_interpreter::objects::{Key, Map, ValueType};
 use cel_interpreter::{Context, ExecutionError, ResolveResult, Value};
@@ -7,7 +8,7 @@ use cel_parser::{parse, Expression as CelExpression, Member, ParseError};
 use chrono::{DateTime, FixedOffset};
 #[cfg(feature = "debug-host-behaviour")]
 use log::debug;
-use log::{error, warn};
+use log::warn;
 use proxy_wasm::types::{Bytes, Status};
 use serde_json::Value as JsonValue;
 use std::borrow::Cow;
@@ -16,6 +17,99 @@ use std::collections::HashMap;
 use std::fmt::{Debug, Formatter};
 use std::sync::{Arc, OnceLock};
 use urlencoding::decode;
+
+pub(super) mod errors {
+    use crate::data::{Expression, PropertyError};
+    use cel_interpreter::ExecutionError;
+    use std::error::Error;
+    use std::fmt::{Debug, Display, Formatter};
+
+    pub struct EvaluationError {
+        expression: Expression,
+        message: String,
+    }
+
+    impl PartialEq for EvaluationError {
+        fn eq(&self, other: &Self) -> bool {
+            self.message == other.message
+        }
+    }
+
+    #[derive(PartialEq)]
+    pub enum CelError {
+        PropertyError(PropertyError),
+        ResolveError(ExecutionError),
+    }
+
+    impl Error for CelError {
+        fn source(&self) -> Option<&(dyn Error + 'static)> {
+            match self {
+                CelError::PropertyError(err) => Some(err),
+                CelError::ResolveError(err) => Some(err),
+            }
+        }
+    }
+
+    impl From<PropertyError> for CelError {
+        fn from(e: PropertyError) -> Self {
+            CelError::PropertyError(e)
+        }
+    }
+
+    impl From<ExecutionError> for CelError {
+        fn from(e: ExecutionError) -> Self {
+            CelError::ResolveError(e)
+        }
+    }
+
+    impl Display for CelError {
+        fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+            match self {
+                CelError::PropertyError(e) => {
+                    write!(f, "CelError::PropertyError {{ {} }}", e)
+                }
+                CelError::ResolveError(e) => {
+                    write!(f, "CelError::ResolveError {{ {} }}", e)
+                }
+            }
+        }
+    }
+
+    impl Debug for CelError {
+        fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+            write!(f, "{}", self)
+        }
+    }
+
+    impl EvaluationError {
+        pub fn new(expression: Expression, message: String) -> EvaluationError {
+            EvaluationError {
+                expression,
+                message,
+            }
+        }
+    }
+
+    impl Debug for EvaluationError {
+        fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+            write!(
+                f,
+                "EvaluationError {{ expression: {:?}, message: {} }}",
+                self.expression, self.message
+            )
+        }
+    }
+
+    impl Display for EvaluationError {
+        fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+            write!(
+                f,
+                "EvaluationError {{ expression: {:?}, message: {} }}",
+                self.expression, self.message
+            )
+        }
+    }
+}
 
 #[derive(Clone, Debug)]
 pub struct Expression {
@@ -59,12 +153,12 @@ impl Expression {
         Self::new_expression(expression, true)
     }
 
-    pub fn eval(&self) -> Result<Value, String> {
+    pub fn eval(&self) -> Result<Value, CelError> {
         let mut ctx = create_context();
         if self.extended {
             Self::add_extended_capabilities(&mut ctx)
         }
-        let Map { map } = self.build_data_map();
+        let Map { map } = self.build_data_map()?;
 
         ctx.add_function("getHostProperty", get_host_property);
 
@@ -74,7 +168,7 @@ impl Expression {
                 map.get(&binding.into()).cloned().unwrap_or(Value::Null),
             );
         }
-        Value::resolve(&self.expression, &ctx).map_err(|err| format!("{err:?}"))
+        Value::resolve(&self.expression, &ctx).map_err(|e| e.into())
     }
 
     /// Add support for `queryMap`, see [`decode_query_string`]
@@ -82,7 +176,7 @@ impl Expression {
         ctx.add_function("queryMap", decode_query_string);
     }
 
-    fn build_data_map(&self) -> Map {
+    fn build_data_map(&self) -> Result<Map, PropertyError> {
         data::AttributeMap::new(self.attributes.clone()).into()
     }
 }
@@ -224,31 +318,39 @@ impl Predicate {
         })
     }
 
-    pub fn test(&self) -> Result<bool, String> {
+    pub fn test(&self) -> Result<bool, EvaluationError> {
         match self.expression.eval() {
             Ok(value) => match value {
                 Value::Bool(result) => Ok(result),
-                _ => Err(format!("Expected boolean value, got {value:?}")),
+                _ => Err(EvaluationError::new(
+                    self.expression.clone(),
+                    format!("Expected boolean value, got {value:?}"),
+                )),
             },
-            Err(err) => Err(err),
+            Err(err) => Err(EvaluationError::new(
+                self.expression.clone(),
+                err.to_string(),
+            )),
         }
     }
 }
 
 pub trait PredicateVec {
-    fn apply(&self) -> bool;
+    fn apply(&self) -> Result<bool, EvaluationError>;
 }
 
 impl PredicateVec for Vec<Predicate> {
-    fn apply(&self) -> bool {
-        self.is_empty()
-            || self.iter().all(|predicate| match predicate.test() {
-                Ok(b) => b,
-                Err(err) => {
-                    error!("Failed to evaluate {:?}: {}", predicate, err);
-                    panic!("Err out of this!")
-                }
-            })
+    fn apply(&self) -> Result<bool, EvaluationError> {
+        if self.is_empty() {
+            return Ok(true);
+        }
+        for predicate in self.iter() {
+            // if it does not apply or errors exit early
+            if !predicate.test()? {
+                return Ok(false);
+            }
+        }
+        Ok(true)
     }
 }
 
@@ -273,46 +375,39 @@ impl Clone for Attribute {
 }
 
 impl Attribute {
-    pub fn get(&self) -> Value {
+    pub fn get(&self) -> Result<Value, PropertyError> {
         match &self.cel_type {
             Some(t) => match t {
-                ValueType::String => get_attribute::<String>(&self.path)
-                    .expect("Failed getting to known attribute")
+                ValueType::String => Ok(get_attribute::<String>(&self.path)?
                     .map(|v| Value::String(v.into()))
-                    .unwrap_or(Value::Null),
-                ValueType::Int => get_attribute::<i64>(&self.path)
-                    .expect("Failed getting to known attribute")
+                    .unwrap_or(Value::Null)),
+                ValueType::Int => Ok(get_attribute::<i64>(&self.path)?
                     .map(Value::Int)
-                    .unwrap_or(Value::Null),
-                ValueType::UInt => get_attribute::<u64>(&self.path)
-                    .expect("Failed getting to known attribute")
+                    .unwrap_or(Value::Null)),
+                ValueType::UInt => Ok(get_attribute::<u64>(&self.path)?
                     .map(Value::UInt)
-                    .unwrap_or(Value::Null),
-                ValueType::Float => get_attribute::<f64>(&self.path)
-                    .expect("Failed getting to known attribute")
+                    .unwrap_or(Value::Null)),
+                ValueType::Float => Ok(get_attribute::<f64>(&self.path)?
                     .map(Value::Float)
-                    .unwrap_or(Value::Null),
-                ValueType::Bool => get_attribute::<bool>(&self.path)
-                    .expect("Failed getting to known attribute")
+                    .unwrap_or(Value::Null)),
+                ValueType::Bool => Ok(get_attribute::<bool>(&self.path)?
                     .map(Value::Bool)
-                    .unwrap_or(Value::Null),
-                ValueType::Bytes => get_attribute::<Vec<u8>>(&self.path)
-                    .expect("Failed getting to known attribute")
+                    .unwrap_or(Value::Null)),
+                ValueType::Bytes => Ok(get_attribute::<Vec<u8>>(&self.path)?
                     .map(|v| Value::Bytes(v.into()))
-                    .unwrap_or(Value::Null),
-                ValueType::Timestamp => get_attribute::<DateTime<FixedOffset>>(&self.path)
-                    .expect("Failed getting to known attribute")
+                    .unwrap_or(Value::Null)),
+                ValueType::Timestamp => Ok(get_attribute::<DateTime<FixedOffset>>(&self.path)?
                     .map(Value::Timestamp)
-                    .unwrap_or(Value::Null),
-                ValueType::Map => host_get_map(&self.path)
+                    .unwrap_or(Value::Null)),
+                ValueType::Map => Ok(host_get_map(&self.path)
                     .map(cel_interpreter::objects::Map::from)
                     .map(Value::Map)
-                    .unwrap_or(Value::Null),
+                    .unwrap_or(Value::Null)),
                 _ => todo!("Need support for `{t}`s!"),
             },
-            None => match get_attribute::<String>(&self.path).expect("Path must resolve!") {
-                None => Value::Null,
-                Some(json) => json_to_cel(&json),
+            None => match get_attribute::<String>(&self.path)? {
+                None => Ok(Value::Null),
+                Some(json) => Ok(json_to_cel(&json)),
             },
         }
     }
@@ -505,6 +600,7 @@ pub fn debug_all_well_known_attributes() {
 
 pub mod data {
     use crate::data::cel::Attribute;
+    use crate::data::PropertyError;
     use cel_interpreter::objects::{Key, Map};
     use cel_interpreter::Value;
     use std::collections::HashMap;
@@ -546,23 +642,23 @@ pub mod data {
         }
     }
 
-    impl From<AttributeMap> for Map {
+    impl From<AttributeMap> for Result<Map, PropertyError> {
         fn from(value: AttributeMap) -> Self {
             map_to_value(value.data)
         }
     }
 
-    fn map_to_value(map: HashMap<String, Token>) -> Map {
+    fn map_to_value(map: HashMap<String, Token>) -> Result<Map, PropertyError> {
         let mut out: HashMap<Key, Value> = HashMap::default();
         for (key, value) in map {
             let k = key.into();
             let v = match value {
-                Token::Value(v) => v.get(),
-                Token::Node(map) => Value::Map(map_to_value(map)),
+                Token::Value(v) => v.get()?,
+                Token::Node(map) => Value::Map(map_to_value(map)?),
             };
             out.insert(k, v);
         }
-        Map { map: Arc::new(out) }
+        Ok(Map { map: Arc::new(out) })
     }
 
     #[cfg(test)]
@@ -797,13 +893,15 @@ mod tests {
         )));
         let value = known_attribute_for(&"destination.port".into())
             .expect("destination.port known attribute exists")
-            .get();
+            .get()
+            .expect("There is no property error!");
         assert_eq!(value, 80.into());
         property::test::TEST_PROPERTY_VALUE
             .set(Some(("request.method".into(), "GET".bytes().collect())));
         let value = known_attribute_for(&"request.method".into())
             .expect("request.method known attribute exists")
-            .get();
+            .get()
+            .expect("There is no property error!");
         assert_eq!(value, "GET".into());
     }
 

--- a/src/data/cel.rs
+++ b/src/data/cel.rs
@@ -190,15 +190,13 @@ fn decode_query_string(This(s): This<Arc<String>>, Arguments(args): Arguments) -
                 })
                 .into_owned()
                 .into();
-            match map.entry(
-                decode(key)
-                    .unwrap_or_else(|e| {
-                        warn!("failed to decode query key, using default: {e:?}");
-                        Cow::from(key)
-                    })
-                    .into_owned()
-                    .into(),
-            ) {
+            let key = decode(key)
+                .unwrap_or_else(|e| {
+                    warn!("failed to decode query key, using default: {e:?}");
+                    Cow::from(key)
+                })
+                .into_owned();
+            match map.entry(key.into()) {
                 Entry::Occupied(mut e) => {
                     if allow_repeats {
                         if let Value::List(ref mut list) = e.get_mut() {

--- a/src/data/cel.rs
+++ b/src/data/cel.rs
@@ -24,6 +24,7 @@ pub(super) mod errors {
     use std::error::Error;
     use std::fmt::{Debug, Display, Formatter};
 
+    #[derive(Debug)]
     pub struct EvaluationError {
         expression: Expression,
         message: String,
@@ -35,49 +36,43 @@ pub(super) mod errors {
         }
     }
 
-    #[derive(PartialEq)]
+    #[derive(Debug, PartialEq)]
     pub enum CelError {
-        PropertyError(PropertyError),
-        ResolveError(ExecutionError),
+        Property(PropertyError),
+        Resolve(ExecutionError),
     }
 
     impl Error for CelError {
         fn source(&self) -> Option<&(dyn Error + 'static)> {
             match self {
-                CelError::PropertyError(err) => Some(err),
-                CelError::ResolveError(err) => Some(err),
+                CelError::Property(err) => Some(err),
+                CelError::Resolve(err) => Some(err),
             }
         }
     }
 
     impl From<PropertyError> for CelError {
         fn from(e: PropertyError) -> Self {
-            CelError::PropertyError(e)
+            CelError::Property(e)
         }
     }
 
     impl From<ExecutionError> for CelError {
         fn from(e: ExecutionError) -> Self {
-            CelError::ResolveError(e)
+            CelError::Resolve(e)
         }
     }
 
     impl Display for CelError {
         fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
             match self {
-                CelError::PropertyError(e) => {
-                    write!(f, "CelError::PropertyError {{ {} }}", e)
+                CelError::Property(e) => {
+                    write!(f, "CelError::Property {{ {:?} }}", e)
                 }
-                CelError::ResolveError(e) => {
-                    write!(f, "CelError::ResolveError {{ {} }}", e)
+                CelError::Resolve(e) => {
+                    write!(f, "CelError::Resolve {{ {:?} }}", e)
                 }
             }
-        }
-    }
-
-    impl Debug for CelError {
-        fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-            write!(f, "{}", self)
         }
     }
 
@@ -87,16 +82,6 @@ pub(super) mod errors {
                 expression,
                 message,
             }
-        }
-    }
-
-    impl Debug for EvaluationError {
-        fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-            write!(
-                f,
-                "EvaluationError {{ expression: {:?}, message: {} }}",
-                self.expression, self.message
-            )
         }
     }
 

--- a/src/data/cel.rs
+++ b/src/data/cel.rs
@@ -302,6 +302,8 @@ pub struct Predicate {
     expression: Expression,
 }
 
+pub type PredicateResult = Result<bool, EvaluationError>;
+
 impl Predicate {
     pub fn new(predicate: &str) -> Result<Self, ParseError> {
         Ok(Self {
@@ -318,7 +320,7 @@ impl Predicate {
         })
     }
 
-    pub fn test(&self) -> Result<bool, EvaluationError> {
+    pub fn test(&self) -> PredicateResult {
         match self.expression.eval() {
             Ok(value) => match value {
                 Value::Bool(result) => Ok(result),
@@ -336,11 +338,11 @@ impl Predicate {
 }
 
 pub trait PredicateVec {
-    fn apply(&self) -> Result<bool, EvaluationError>;
+    fn apply(&self) -> PredicateResult;
 }
 
 impl PredicateVec for Vec<Predicate> {
-    fn apply(&self) -> Result<bool, EvaluationError> {
+    fn apply(&self) -> PredicateResult {
         if self.is_empty() {
             return Ok(true);
         }

--- a/src/data/mod.rs
+++ b/src/data/mod.rs
@@ -8,10 +8,11 @@ pub use attribute::store_metadata;
 #[cfg(feature = "debug-host-behaviour")]
 pub use cel::debug_all_well_known_attributes;
 
+pub use cel::errors::EvaluationError;
 pub use cel::Expression;
 pub use cel::Predicate;
 pub use cel::PredicateResult;
 pub use cel::PredicateVec;
 
-pub use attribute::errors::PropertyError;
+pub use attribute::errors::{PropError, PropertyError};
 pub use property::Path as PropertyPath;

--- a/src/data/mod.rs
+++ b/src/data/mod.rs
@@ -12,4 +12,5 @@ pub use cel::Expression;
 pub use cel::Predicate;
 pub use cel::PredicateVec;
 
+pub use attribute::errors::PropertyError;
 pub use property::Path as PropertyPath;

--- a/src/data/mod.rs
+++ b/src/data/mod.rs
@@ -10,6 +10,7 @@ pub use cel::debug_all_well_known_attributes;
 
 pub use cel::Expression;
 pub use cel::Predicate;
+pub use cel::PredicateResult;
 pub use cel::PredicateVec;
 
 pub use attribute::errors::PropertyError;

--- a/src/data/property.rs
+++ b/src/data/property.rs
@@ -67,13 +67,10 @@ pub fn host_set_property(path: Path, value: Option<&[u8]>) -> Result<(), Status>
 pub fn host_get_map(path: &Path) -> Result<HashMap<String, String>, String> {
     match *path.tokens() {
         ["request", "headers"] => {
-            let map =
-                proxy_wasm::hostcalls::get_map(proxy_wasm::types::MapType::HttpRequestHeaders)
-                    .expect("Failed to get_map request.headers")
-                    .into_iter()
-                    .collect();
-            debug!("get_map: {map:#?}");
-            Ok(map)
+            match proxy_wasm::hostcalls::get_map(proxy_wasm::types::MapType::HttpRequestHeaders) {
+                Ok(map) => Ok(map.into_iter().collect()),
+                Err(status) => Err(format!("Error get request.headers: {:?}", status)),
+            }
         }
         _ => Err(format!("Unknown map requested {:?}", path)),
     }

--- a/src/filter/kuadrant_filter.rs
+++ b/src/filter/kuadrant_filter.rs
@@ -129,10 +129,11 @@ impl KuadrantFilter {
     fn start_flow(&mut self, action_set: Rc<RuntimeActionSet>) -> Action {
         let grpc_request = action_set.find_first_grpc_request();
         let op = match grpc_request {
-            None => Operation::Done(),
-            Some(indexed_req) => {
+            Ok(None) => Operation::Done(),
+            Ok(Some(indexed_req)) => {
                 Operation::SendGrpcRequest(GrpcMessageSenderOperation::new(action_set, indexed_req))
             }
+            Err(grpc_err_response) => Operation::Die(grpc_err_response),
         };
         self.handle_operation(op)
     }

--- a/src/filter/kuadrant_filter.rs
+++ b/src/filter/kuadrant_filter.rs
@@ -37,6 +37,7 @@ impl Context for KuadrantFilter {
                 } else if let Some(response_body) =
                     hostcalls::get_buffer(BufferType::GrpcReceiveBuffer, 0, resp_size)
                         .unwrap_or_else(|e| {
+                            // get_buffer panics instead of returning an Error so this will not happen
                             error!(
                                 "on_grpc_call_response failed to read gRPC receive buffer: `{:?}`",
                                 e
@@ -212,6 +213,7 @@ impl KuadrantFilter {
                 Err(Status::NotFound)
             }
             Err(e) => {
+                // get_map_value panics instead of returning an Error so this will not happen
                 error!("failed to retrieve :authority header: {:?}", e);
                 Err(e)
             }

--- a/src/filter/root_context.rs
+++ b/src/filter/root_context.rs
@@ -45,8 +45,14 @@ impl RootContext for FilterRoot {
     fn on_configure(&mut self, _config_size: usize) -> bool {
         info!("#{} on_configure", self.context_id);
         let configuration: Vec<u8> = match self.get_plugin_configuration() {
-            Some(c) => c,
-            None => return false,
+            Ok(cfg) => match cfg {
+                Some(c) => c,
+                None => return false,
+            },
+            Err(status) => {
+                log::error!("#{} on_configure: {:?}", self.context_id, status);
+                return false;
+            }
         };
         match serde_json::from_slice::<PluginConfiguration>(&configuration) {
             Ok(config) => {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,7 +2,7 @@ mod action_set_index;
 mod auth_action;
 mod configuration;
 mod data;
-#[allow(renamed_and_removed_lints)]
+#[allow(renamed_and_removed_lints, clippy::panic, clippy::unwrap_used)]
 mod envoy;
 mod filter;
 mod ratelimit_action;
@@ -36,8 +36,7 @@ extern "C" fn start() {
 
     proxy_wasm::set_log_level(LogLevel::Trace);
     std::panic::set_hook(Box::new(|panic_info| {
-        proxy_wasm::hostcalls::log(LogLevel::Critical, &panic_info.to_string())
-            .expect("failed to log panic_info");
+        let _ = proxy_wasm::hostcalls::log(LogLevel::Critical, &panic_info.to_string());
     }));
     proxy_wasm::set_root_context(|context_id| -> Box<dyn RootContext> {
         info!("#{} set_root_context", context_id);

--- a/src/ratelimit_action.rs
+++ b/src/ratelimit_action.rs
@@ -454,7 +454,7 @@ mod test {
                 );
             }
             HeaderKind::Request(_headers) => {
-                panic!("ratelimitresponse should not return Request headers")
+                unreachable!("ratelimitresponse should not return Request headers")
             }
         }
     }

--- a/src/ratelimit_action.rs
+++ b/src/ratelimit_action.rs
@@ -296,8 +296,7 @@ mod test {
         let service = build_service();
         let rl_action = RateLimitAction::new(&action, &service)
             .expect("action building failed. Maybe predicates compilation?");
-        assert!(rl_action.conditions_apply().is_ok());
-        assert!(rl_action.conditions_apply().expect("is ok"));
+        assert_eq!(rl_action.conditions_apply(), Ok(true));
     }
 
     #[test]
@@ -306,8 +305,7 @@ mod test {
         let service = build_service();
         let rl_action = RateLimitAction::new(&action, &service)
             .expect("action building failed. Maybe predicates compilation?");
-        assert!(rl_action.conditions_apply().is_ok());
-        assert!(rl_action.conditions_apply().expect("is ok"));
+        assert_eq!(rl_action.conditions_apply(), Ok(true));
     }
 
     #[test]
@@ -316,10 +314,10 @@ mod test {
         let service = build_service();
         let rl_action = RateLimitAction::new(&action, &service)
             .expect("action building failed. Maybe predicates compilation?");
-        let descriptor_result = rl_action.build_descriptor();
-        assert!(descriptor_result.is_ok());
-        let descriptor = descriptor_result.expect("is ok");
-        assert_eq!(descriptor, RateLimitDescriptor::default());
+        assert_eq!(
+            rl_action.build_descriptor(),
+            Ok(RateLimitDescriptor::default())
+        );
     }
 
     #[test]
@@ -334,9 +332,7 @@ mod test {
         let service = build_service();
         let rl_action = RateLimitAction::new(&action, &service)
             .expect("action building failed. Maybe predicates compilation?");
-        let descriptor_result = rl_action.build_descriptor();
-        assert!(descriptor_result.is_ok());
-        let descriptor = descriptor_result.expect("is ok");
+        let descriptor = rl_action.build_descriptor().expect("is ok");
         assert_eq!(descriptor.get_entries().len(), 1);
         assert_eq!(descriptor.get_entries()[0].key, String::from("key_1"));
         assert_eq!(descriptor.get_entries()[0].value, String::from("value_1"));
@@ -354,9 +350,7 @@ mod test {
         let service = build_service();
         let rl_action = RateLimitAction::new(&action, &service)
             .expect("action building failed. Maybe predicates compilation?");
-        let descriptor_result = rl_action.build_descriptor();
-        assert!(descriptor_result.is_ok());
-        let descriptor = descriptor_result.expect("is ok");
+        let descriptor = rl_action.build_descriptor().expect("is ok");
         assert_eq!(descriptor.get_entries().len(), 1);
         assert_eq!(descriptor.get_entries()[0].key, String::from("key_1"));
         assert_eq!(descriptor.get_entries()[0].value, String::from("value_1"));
@@ -376,9 +370,7 @@ mod test {
         let service = build_service();
         let rl_action = RateLimitAction::new(&action, &service)
             .expect("action building failed. Maybe predicates compilation?");
-        let descriptor_result = rl_action.build_descriptor();
-        assert!(descriptor_result.is_ok());
-        let descriptor = descriptor_result.expect("is ok");
+        let descriptor = rl_action.build_descriptor().expect("is ok");
         assert_eq!(descriptor, RateLimitDescriptor::default());
     }
 
@@ -423,10 +415,7 @@ mod test {
         assert!(rl_action_1.merge(rl_action_3).is_none());
 
         // it should generate descriptor entries from action 1 and action 3
-
-        let descriptor_result = rl_action_1.build_descriptor();
-        assert!(descriptor_result.is_ok());
-        let descriptor = descriptor_result.expect("is ok");
+        let descriptor = rl_action_1.build_descriptor().expect("is ok");
         assert_eq!(descriptor.get_entries().len(), 2);
         assert_eq!(descriptor.get_entries()[0].key, String::from("key_1"));
         assert_eq!(descriptor.get_entries()[0].value, String::from("value_1"));

--- a/src/runtime_action.rs
+++ b/src/runtime_action.rs
@@ -1,7 +1,10 @@
 use crate::auth_action::AuthAction;
 use crate::configuration::{Action, FailureMode, Service, ServiceType};
+use crate::data::PredicateResult;
 use crate::ratelimit_action::RateLimitAction;
+use crate::runtime_action::errors::NewActionError;
 use crate::service::auth::AuthService;
+use crate::service::errors::BuildMessageError;
 use crate::service::rate_limit::RateLimitService;
 use crate::service::{GrpcErrResponse, GrpcRequest, GrpcService, HeaderKind};
 use log::debug;
@@ -15,11 +18,60 @@ pub enum RuntimeAction {
     RateLimit(RateLimitAction),
 }
 
+pub(super) mod errors {
+    use cel_parser::ParseError;
+    use std::fmt::{Debug, Display, Formatter};
+
+    #[derive(Debug)]
+    pub enum NewActionError {
+        Parse(ParseError),
+        UnknownService(String),
+    }
+
+    impl From<ParseError> for NewActionError {
+        fn from(e: ParseError) -> NewActionError {
+            NewActionError::Parse(e)
+        }
+    }
+
+    impl PartialEq for NewActionError {
+        fn eq(&self, other: &NewActionError) -> bool {
+            match (self, other) {
+                (NewActionError::Parse(_), NewActionError::Parse(_)) => false,
+                (NewActionError::UnknownService(a), NewActionError::UnknownService(b)) => a == b,
+                _ => false,
+            }
+        }
+    }
+
+    impl Display for NewActionError {
+        fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+            match self {
+                NewActionError::Parse(e) => {
+                    write!(f, "NewActionError::Parse {{ {:?} }}", e)
+                }
+                NewActionError::UnknownService(e) => {
+                    write!(f, "NewActionError::UnknownService {{ {:?} }}", e)
+                }
+            }
+        }
+    }
+}
+
+pub type RequestResult = Result<Option<GrpcRequest>, GrpcErrResponse>;
+pub type ResponseResult = Result<HeaderKind, GrpcErrResponse>;
+
 impl RuntimeAction {
-    pub fn new(action: &Action, services: &HashMap<String, Service>) -> Result<Self, String> {
+    pub fn new(
+        action: &Action,
+        services: &HashMap<String, Service>,
+    ) -> Result<Self, NewActionError> {
         let service = services
             .get(&action.service)
-            .ok_or(format!("Unknown service: {}", action.service))?;
+            .ok_or(NewActionError::UnknownService(format!(
+                "Unknown service: {}",
+                action.service
+            )))?;
 
         match service.service_type {
             ServiceType::RateLimit => Ok(Self::RateLimit(RateLimitAction::new(action, service)?)),
@@ -34,7 +86,7 @@ impl RuntimeAction {
         }
     }
 
-    pub fn conditions_apply(&self) -> bool {
+    pub fn conditions_apply(&self) -> PredicateResult {
         match self {
             Self::Auth(auth_action) => auth_action.conditions_apply(),
             Self::RateLimit(rl_action) => rl_action.conditions_apply(),
@@ -48,7 +100,7 @@ impl RuntimeAction {
         }
     }
 
-    pub fn resolve_failure_mode(&self) -> Result<HeaderKind, GrpcErrResponse> {
+    pub fn resolve_failure_mode(&self) -> ResponseResult {
         match self {
             Self::Auth(auth_action) => auth_action.resolve_failure_mode(),
             Self::RateLimit(rl_action) => rl_action.resolve_failure_mode(),
@@ -66,15 +118,18 @@ impl RuntimeAction {
         Some(other)
     }
 
-    pub fn process_request(&self) -> Option<GrpcRequest> {
-        if !self.conditions_apply() {
-            None
-        } else {
-            self.grpc_service().build_request(self.build_message())
+    pub fn process_request(&self) -> RequestResult {
+        match self.conditions_apply() {
+            Ok(false) => Ok(None),
+            Ok(true) => match self.build_message() {
+                Ok(message) => Ok(self.grpc_service().build_request(message)),
+                Err(_) => self.resolve_failure_mode().map(|_| None),
+            },
+            Err(_) => self.resolve_failure_mode().map(|_| None),
         }
     }
 
-    pub fn process_response(&self, msg: &[u8]) -> Result<HeaderKind, GrpcErrResponse> {
+    pub fn process_response(&self, msg: &[u8]) -> ResponseResult {
         match self {
             Self::Auth(auth_action) => match Message::parse_from_bytes(msg) {
                 Ok(check_response) => auth_action.process_response(check_response),
@@ -93,22 +148,23 @@ impl RuntimeAction {
         }
     }
 
-    pub fn build_message(&self) -> Option<Vec<u8>> {
+    pub fn build_message(&self) -> Result<Option<Vec<u8>>, BuildMessageError> {
         match self {
             RuntimeAction::RateLimit(rl_action) => {
-                let descriptor = rl_action.build_descriptor();
+                let descriptor = rl_action.build_descriptor()?;
                 if descriptor.entries.is_empty() {
                     debug!("build_message(rl): empty descriptors");
-                    None
+                    Ok(None)
                 } else {
                     RateLimitService::request_message_as_bytes(
                         String::from(rl_action.scope()),
                         vec![descriptor].into(),
                     )
+                    .map(Some)
                 }
             }
             RuntimeAction::Auth(auth_action) => {
-                AuthService::request_message_as_bytes(String::from(auth_action.scope()))
+                AuthService::request_message_as_bytes(String::from(auth_action.scope())).map(Some)
             }
         }
     }

--- a/src/runtime_action_set.rs
+++ b/src/runtime_action_set.rs
@@ -1,6 +1,6 @@
 use crate::configuration::{ActionSet, Service};
 use crate::data::{Predicate, PredicateResult, PredicateVec};
-use crate::runtime_action::errors::NewActionError;
+use crate::runtime_action::errors::ActionCreationError;
 use crate::runtime_action::RuntimeAction;
 use crate::service::{GrpcErrResponse, HeaderKind, IndexedGrpcRequest};
 use std::collections::HashMap;
@@ -19,7 +19,7 @@ impl RuntimeActionSet {
     pub fn new(
         action_set: &ActionSet,
         services: &HashMap<String, Service>,
-    ) -> Result<Self, NewActionError> {
+    ) -> Result<Self, ActionCreationError> {
         // route predicates
         let mut route_rule_predicates = Vec::default();
         for predicate in &action_set.route_rule_conditions.predicates {

--- a/src/runtime_action_set.rs
+++ b/src/runtime_action_set.rs
@@ -106,9 +106,7 @@ mod test {
 
         let runtime_action_set = RuntimeActionSet::new(&action_set, &HashMap::default())
             .expect("should not happen from an empty set of actions");
-
-        assert!(runtime_action_set.conditions_apply().is_ok());
-        assert!(runtime_action_set.conditions_apply().expect("is ok"));
+        assert_eq!(runtime_action_set.conditions_apply(), Ok(true));
     }
 
     #[test]
@@ -124,9 +122,7 @@ mod test {
 
         let runtime_action_set = RuntimeActionSet::new(&action_set, &HashMap::default())
             .expect("should not happen from an empty set of actions");
-
-        assert!(runtime_action_set.conditions_apply().is_ok());
-        assert!(runtime_action_set.conditions_apply().expect("is ok"));
+        assert_eq!(runtime_action_set.conditions_apply(), Ok(true));
     }
 
     #[test]
@@ -142,9 +138,7 @@ mod test {
 
         let runtime_action_set = RuntimeActionSet::new(&action_set, &HashMap::default())
             .expect("should not happen from an empty set of actions");
-
-        assert!(runtime_action_set.conditions_apply().is_ok());
-        assert!(!runtime_action_set.conditions_apply().expect("is ok"));
+        assert_eq!(runtime_action_set.conditions_apply(), Ok(false));
     }
 
     #[test]

--- a/src/runtime_action_set.rs
+++ b/src/runtime_action_set.rs
@@ -57,7 +57,8 @@ impl RuntimeActionSet {
     }
 
     pub fn conditions_apply(&self) -> bool {
-        self.route_rule_predicates.apply()
+        //todo(adam-cattermole): do not expect
+        self.route_rule_predicates.apply().expect("REMOVE")
     }
 
     pub fn find_first_grpc_request(&self) -> Option<IndexedGrpcRequest> {

--- a/src/runtime_config.rs
+++ b/src/runtime_config.rs
@@ -1,11 +1,11 @@
 use crate::action_set_index::ActionSetIndex;
 use crate::configuration::PluginConfiguration;
-use crate::runtime_action::errors::NewActionError;
+use crate::runtime_action::errors::ActionCreationError;
 use crate::runtime_action_set::RuntimeActionSet;
 use std::rc::Rc;
 
 impl TryFrom<PluginConfiguration> for ActionSetIndex {
-    type Error = NewActionError;
+    type Error = ActionCreationError;
 
     fn try_from(config: PluginConfiguration) -> Result<Self, Self::Error> {
         let mut index = ActionSetIndex::new();
@@ -143,7 +143,7 @@ mod test {
         let result = ActionSetIndex::try_from(serde_res.expect("That didn't work"));
         assert_eq!(
             result.err(),
-            Some(NewActionError::UnknownService(
+            Some(ActionCreationError::UnknownService(
                 "Unknown service: unknown".to_string()
             ))
         );

--- a/src/runtime_config.rs
+++ b/src/runtime_config.rs
@@ -1,10 +1,11 @@
 use crate::action_set_index::ActionSetIndex;
 use crate::configuration::PluginConfiguration;
+use crate::runtime_action::errors::NewActionError;
 use crate::runtime_action_set::RuntimeActionSet;
 use std::rc::Rc;
 
 impl TryFrom<PluginConfiguration> for ActionSetIndex {
-    type Error = String;
+    type Error = NewActionError;
 
     fn try_from(config: PluginConfiguration) -> Result<Self, Self::Error> {
         let mut index = ActionSetIndex::new();
@@ -140,6 +141,11 @@ mod test {
         assert!(serde_res.is_ok());
 
         let result = ActionSetIndex::try_from(serde_res.expect("That didn't work"));
-        assert_eq!(result.err(), Some("Unknown service: unknown".into()));
+        assert_eq!(
+            result.err(),
+            Some(NewActionError::UnknownService(
+                "Unknown service: unknown".to_string()
+            ))
+        );
     }
 }

--- a/src/service.rs
+++ b/src/service.rs
@@ -11,6 +11,41 @@ use std::cell::OnceCell;
 use std::rc::Rc;
 use std::time::Duration;
 
+pub(super) mod errors {
+    use crate::data::{EvaluationError, PropertyError};
+    use protobuf::ProtobufError;
+    use std::fmt::{Debug, Display, Formatter};
+
+    #[derive(Debug)]
+    pub enum BuildMessageError {
+        Evaluation(EvaluationError),
+        Property(PropertyError),
+        Serialization(ProtobufError),
+    }
+
+    impl From<EvaluationError> for BuildMessageError {
+        fn from(e: EvaluationError) -> Self {
+            BuildMessageError::Evaluation(e)
+        }
+    }
+
+    impl Display for BuildMessageError {
+        fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+            match self {
+                BuildMessageError::Evaluation(e) => {
+                    write!(f, "BuildMessageError::Evaluation {{ {:?} }}", e)
+                }
+                BuildMessageError::Property(e) => {
+                    write!(f, "BuildMessageError::Property {{ {:?} }}", e)
+                }
+                BuildMessageError::Serialization(e) => {
+                    write!(f, "BuildMessageError::Serialization {{ {:?} }}", e)
+                }
+            }
+        }
+    }
+}
+
 #[derive(Default, Debug)]
 pub struct GrpcService {
     service: Rc<Service>,

--- a/src/service/auth.rs
+++ b/src/service/auth.rs
@@ -61,23 +61,35 @@ impl AuthService {
             }
         };
 
-        // todo(adam-cattermole): should these be treated as error cases
-        http.set_host(get_attribute::<String>(&"request.host".into())?.unwrap_or_default());
-        http.set_method(get_attribute::<String>(&"request.method".into())?.unwrap_or_default());
-        http.set_scheme(get_attribute::<String>(&"request.scheme".into())?.unwrap_or_default());
-        http.set_path(get_attribute::<String>(&"request.path".into())?.unwrap_or_default());
-        http.set_protocol(get_attribute::<String>(&"request.protocol".into())?.unwrap_or_default());
+        http.set_host(get_attribute::<String>(&"request.host".into())?.ok_or(
+            PropertyError::Get(PropError::new("request.host not set".to_string())),
+        )?);
+        http.set_method(get_attribute::<String>(&"request.method".into())?.ok_or(
+            PropertyError::Get(PropError::new("request.method not set".to_string())),
+        )?);
+        http.set_scheme(get_attribute::<String>(&"request.scheme".into())?.ok_or(
+            PropertyError::Get(PropError::new("request.scheme not set".to_string())),
+        )?);
+        http.set_path(get_attribute::<String>(&"request.path".into())?.ok_or(
+            PropertyError::Get(PropError::new("request.path not set".to_string())),
+        )?);
+        http.set_protocol(get_attribute::<String>(&"request.protocol".into())?.ok_or(
+            PropertyError::Get(PropError::new("request.protocol not set".to_string())),
+        )?);
 
         http.set_headers(headers);
-        request.set_time(get_attribute(&"request.time".into())?.map_or(
-            Timestamp::new(),
-            |date_time: DateTime<FixedOffset>| Timestamp {
-                nanos: date_time.timestamp_subsec_nanos() as i32,
-                seconds: date_time.timestamp(),
-                unknown_fields: Default::default(),
-                cached_size: Default::default(),
-            },
-        ));
+        request.set_time(
+            get_attribute(&"request.time".into())?
+                .map(|date_time: DateTime<FixedOffset>| Timestamp {
+                    nanos: date_time.timestamp_subsec_nanos() as i32,
+                    seconds: date_time.timestamp(),
+                    unknown_fields: Default::default(),
+                    cached_size: Default::default(),
+                })
+                .ok_or(PropertyError::Get(PropError::new(
+                    "request.time not set".to_string(),
+                )))?,
+        );
         request.set_http(http);
         Ok(request)
     }

--- a/src/service/auth.rs
+++ b/src/service/auth.rs
@@ -1,10 +1,10 @@
-use crate::data::get_attribute;
+use crate::data::{get_attribute, PropError, PropertyError};
 use crate::envoy::{
     Address, AttributeContext, AttributeContext_HttpRequest, AttributeContext_Peer,
     AttributeContext_Request, CheckRequest, Metadata, SocketAddress,
 };
+use crate::service::errors::BuildMessageError;
 use chrono::{DateTime, FixedOffset};
-use log::debug;
 use protobuf::well_known_types::Timestamp;
 use protobuf::Message;
 use proxy_wasm::hostcalls;
@@ -17,94 +17,69 @@ pub const AUTH_METHOD_NAME: &str = "Check";
 pub struct AuthService;
 
 impl AuthService {
-    pub fn request_message(ce_host: String) -> CheckRequest {
+    pub fn request_message(ce_host: String) -> Result<CheckRequest, PropertyError> {
         AuthService::build_check_req(ce_host)
     }
 
-    pub fn request_message_as_bytes(ce_host: String) -> Option<Vec<u8>> {
+    pub fn request_message_as_bytes(ce_host: String) -> Result<Vec<u8>, BuildMessageError> {
         Self::request_message(ce_host)
+            .map_err(BuildMessageError::Property)?
             .write_to_bytes()
-            .map_err(|e| debug!("Failed to write protobuf message to bytes: {e:?}"))
-            .ok()
+            .map_err(BuildMessageError::Serialization)
     }
 
-    fn build_check_req(ce_host: String) -> CheckRequest {
+    fn build_check_req(ce_host: String) -> Result<CheckRequest, PropertyError> {
         let mut auth_req = CheckRequest::default();
         let mut attr = AttributeContext::default();
-        attr.set_request(AuthService::build_request());
+        attr.set_request(AuthService::build_request()?);
         attr.set_destination(AuthService::build_peer(
-            get_attribute::<String>(&"destination.address".into())
-                .expect("Error!")
-                .unwrap_or_default(),
-            get_attribute::<i64>(&"destination.port".into())
-                .expect("Error!")
-                .unwrap_or_default() as u32,
+            get_attribute::<String>(&"destination.address".into())?.unwrap_or_default(),
+            get_attribute::<i64>(&"destination.port".into())?.unwrap_or_default() as u32,
         ));
         attr.set_source(AuthService::build_peer(
-            get_attribute::<String>(&"source.address".into())
-                .expect("Error!")
-                .unwrap_or_default(),
-            get_attribute::<i64>(&"source.port".into())
-                .expect("Error!")
-                .unwrap_or_default() as u32,
+            get_attribute::<String>(&"source.address".into())?.unwrap_or_default(),
+            get_attribute::<i64>(&"source.port".into())?.unwrap_or_default() as u32,
         ));
         // the ce_host is the identifier for authorino to determine which authconfig to use
         let context_extensions = HashMap::from([("host".to_string(), ce_host)]);
         attr.set_context_extensions(context_extensions);
         attr.set_metadata_context(Metadata::default());
         auth_req.set_attributes(attr);
-        auth_req
+        Ok(auth_req)
     }
 
-    fn build_request() -> AttributeContext_Request {
+    fn build_request() -> Result<AttributeContext_Request, PropertyError> {
         let mut request = AttributeContext_Request::default();
         let mut http = AttributeContext_HttpRequest::default();
-        let headers: HashMap<String, String> = hostcalls::get_map(MapType::HttpRequestHeaders)
-            .expect("failed to retrieve HttpRequestHeaders from host")
-            .into_iter()
-            .collect();
+        let headers: HashMap<String, String> = match hostcalls::get_map(MapType::HttpRequestHeaders)
+        {
+            Ok(header_map) => header_map.into_iter().collect(),
+            Err(_) => {
+                return Err(PropertyError::Get(PropError::new(
+                    "Failed to retrieve headers".to_string(),
+                )))
+            }
+        };
 
-        http.set_host(
-            get_attribute::<String>(&"request.host".into())
-                .expect("Error!")
-                .unwrap_or_default(),
-        );
-        http.set_method(
-            get_attribute::<String>(&"request.method".into())
-                .expect("Error!")
-                .unwrap_or_default(),
-        );
-        http.set_scheme(
-            get_attribute::<String>(&"request.scheme".into())
-                .expect("Error!")
-                .unwrap_or_default(),
-        );
-        http.set_path(
-            get_attribute::<String>(&"request.path".into())
-                .expect("Error!")
-                .unwrap_or_default(),
-        );
-        http.set_protocol(
-            get_attribute::<String>(&"request.protocol".into())
-                .expect("Error!")
-                .unwrap_or_default(),
-        );
+        // todo(adam-cattermole): should these be treated as error cases
+        http.set_host(get_attribute::<String>(&"request.host".into())?.unwrap_or_default());
+        http.set_method(get_attribute::<String>(&"request.method".into())?.unwrap_or_default());
+        http.set_scheme(get_attribute::<String>(&"request.scheme".into())?.unwrap_or_default());
+        http.set_path(get_attribute::<String>(&"request.path".into())?.unwrap_or_default());
+        http.set_protocol(get_attribute::<String>(&"request.protocol".into())?.unwrap_or_default());
 
         http.set_headers(headers);
-        request.set_time(
-            get_attribute(&"request.time".into())
-                .expect("Error!")
-                .map_or(Timestamp::new(), |date_time: DateTime<FixedOffset>| {
-                    Timestamp {
-                        nanos: date_time.timestamp_subsec_nanos() as i32,
-                        seconds: date_time.timestamp(),
-                        unknown_fields: Default::default(),
-                        cached_size: Default::default(),
-                    }
-                }),
-        );
+        request.set_time(get_attribute(&"request.time".into())?.map_or(
+            Timestamp::new(),
+            |date_time: DateTime<FixedOffset>| Timestamp {
+                nanos: date_time.timestamp_subsec_nanos() as i32,
+                seconds: date_time.timestamp(),
+                unknown_fields: Default::default(),
+                cached_size: Default::default(),
+            },
+        ));
         request.set_http(http);
-        request
+        Ok(request)
     }
 
     fn build_peer(host: String, port: u32) -> AttributeContext_Peer {

--- a/src/service/rate_limit.rs
+++ b/src/service/rate_limit.rs
@@ -1,5 +1,5 @@
 use crate::envoy::{RateLimitDescriptor, RateLimitRequest};
-use log::debug;
+use crate::service::errors::BuildMessageError;
 use protobuf::{Message, RepeatedField};
 
 pub const RATELIMIT_SERVICE_NAME: &str = "envoy.service.ratelimit.v3.RateLimitService";
@@ -24,11 +24,10 @@ impl RateLimitService {
     pub fn request_message_as_bytes(
         domain: String,
         descriptors: RepeatedField<RateLimitDescriptor>,
-    ) -> Option<Vec<u8>> {
+    ) -> Result<Vec<u8>, BuildMessageError> {
         Self::request_message(domain, descriptors)
             .write_to_bytes()
-            .map_err(|e| debug!("Failed to write protobuf message to bytes: {e:?}"))
-            .ok()
+            .map_err(BuildMessageError::Serialization)
     }
 }
 

--- a/tests/util/common.rs
+++ b/tests/util/common.rs
@@ -1,5 +1,6 @@
 use std::path::Path;
 
+#[allow(clippy::unwrap_used)]
 pub fn wasm_module() -> String {
     let wasm_file = Path::new("target/wasm32-unknown-unknown/release/wasm_shim.wasm");
     assert!(


### PR DESCRIPTION
## Changes

I have tried to improve our error handling to reduce the occurrences of panics, which has resulted in the introduction of several new types
* Existing mapping of errors to `String`s (losing all type information) is gone, and instead we pass errors as their types up the layers
* The panics at lower levels are passed up to the action layer where it decides based on failure mode the respective result
* The filter layer is still informed whether to exit or not by the action beneath it
* ~~I have 'safely' unwrapped a couple of the proxy_wasm hostcalls by calling the underlying functions instead of the trait~~; turns out in these cases it doesn't return an `Err()` but actually `panic!`s at the proxy wasm layers below

### Outstanding:

* I did not choose to 'safely' unwrap `add_request|response_headers`, `resume_http_request`, or `send_http_response` calls as I have been thinking about the expected behaviour here:
    1. If we fail to add headers to the request or response what is the expected outcome? I think we should internal server error regardless of the action failure_mode?
    2. If we fail to `resume_http_request` we could try internal server error but at this stage something is very wrong so perhaps it is okay to panic?
    3. If we fail to `send_http_response` this means we could not send an internal server error... in this case we probably shouldn't silently live where we cannot tell the requester something is wrong
    * For all of the above I am considering a case where this consistently fails, whereas I guess for 2-3 if this is only an error for a single request perhaps we shouldn't panic and let the vm live?

## Verification:

Two of our existing README examples panic, but with the new changes you'll see error logging and an internal server error returned.

Follow the instructions [here](https://github.com/Kuadrant/wasm-shim/?tab=readme-ov-file#running-local-development-environment-kind).

Setup dev env:
```sh
make local-setup
kubectl port-forward --namespace kuadrant-system deployment/envoy 8000:8000
kubecolor logs -f -n kuadrant-system deployments/envoy
```

Make a request:
```sh
curl -H "Host: test.a.rlp.com" http://127.0.0.1:8000/get -i
#HTTP/1.1 500 Internal Server Error
```

Log:
```sh
[2025-03-14 14:31:05.294][45][error][wasm] [source/extensions/common/wasm/context.cc:1201] wasm log kuadrant_wasm kuadrant_wasm vm.sentinel.kuadrant_wasm: Failed to evaluate `Expression { attributes: [Attribute { path: ["unknown", "path"] }], expression: Member(Ident("unknown"), Attribute("path")), extended: false }`: CelError::Resolve { UndeclaredReference("unknown") }
```

Similarly with rlp C, if you did not include the header the request will panic on main:
```sh
curl -H "Host: test.c.rlp.com"  http://127.0.0.1:8000/get -i
#HTTP/1.1 500 Internal Server Error
```

```sh
curl -H "Host: test.c.rlp.com" -H "x-forwarded-for: 50.0.0.1" -H "my-custom-header-01: my-custom-header-value-01" -H "x-dyn-user-id: bob" http://127.0.0.1:8000/get -i
#HTTP/1.1 200 OK
```