### PR TITLE
`parseJSON` CEL  function

### DIFF
--- a/src/data/cel.rs
+++ b/src/data/cel.rs
@@ -728,8 +728,9 @@ pub mod data {
 mod tests {
     use crate::data::cel::{known_attribute_for, Expression, Predicate};
     use crate::data::property;
-    use cel_interpreter::objects::ValueType;
+    use cel_interpreter::objects::{Map, ValueType};
     use cel_interpreter::Value;
+    use std::collections::HashMap;
     use std::sync::Arc;
 
     #[test]
@@ -920,5 +921,83 @@ mod tests {
             .eval()
             .expect("This must evaluate!");
         assert_eq!(value, Value::Bytes(Arc::new(b"\xCA\xFE".to_vec())));
+    }
+
+    #[test]
+    fn parse_json_cel_function() {
+        let value = Expression::new(
+            r#"
+            parseJSON('{ "foo" : "bar" }').foo == 'bar'
+            "#,
+        )
+        .expect("This is valid CEL!")
+        .eval()
+        .expect("This must evaluate!");
+        assert_eq!(value, true.into());
+
+        let value = Expression::new(
+            r#"
+            parseJSON('null')
+            "#,
+        )
+        .expect("This is valid CEL!")
+        .eval()
+        .expect("This must evaluate!");
+        assert_eq!(value, Value::Null);
+
+        let value = Expression::new(
+            r#"
+            parseJSON('true')'
+            "#,
+        )
+        .expect("This is valid CEL!")
+        .eval()
+        .expect("This must evaluate!");
+        assert_eq!(value, true.into());
+
+        let value = Expression::new(
+            r#"
+            parseJSON('1')'
+            "#,
+        )
+        .expect("This is valid CEL!")
+        .eval()
+        .expect("This must evaluate!");
+        assert_eq!(value, 1.into());
+
+        let value = Expression::new(
+            r#"
+            parseJSON('"this is a string"')'
+            "#,
+        )
+        .expect("This is valid CEL!")
+        .eval()
+        .expect("This must evaluate!");
+        assert_eq!(value, "this is a string".into());
+
+        let value = Expression::new(
+            r#"
+            parseJSON('[]')'
+            "#,
+        )
+        .expect("This is valid CEL!")
+        .eval()
+        .expect("This must evaluate!");
+        assert_eq!(value, Value::List(vec!().into()));
+
+        let value = Expression::new(
+            r#"
+            parseJSON('{}')'
+            "#,
+        )
+        .expect("This is valid CEL!")
+        .eval()
+        .expect("This must evaluate!");
+        assert_eq!(
+            value,
+            Value::Map(Map {
+                map: Arc::new(HashMap::default()),
+            })
+        );
     }
 }


### PR DESCRIPTION
### What

Fixes #184 

New custom CEL function called `parseJSON` available for all CEL expressions used in the configuration. Not surprisingly, at the names suggests, it can parse JSON serialized strings and allows building CEL expressions based on the deserialized JSON object. 

For instance, the following expressions are valid

```cel
parseJSON( ' [1, "a", { "foo" : "bar" }] ' )[0] == 1       # ==> true

parseJSON( ' [1, "a", { "foo" : "bar" }] ' )[2].foo       # ==> "bar"

parseJSON( ' { "foo" : "bar" } ' ).foo       # ==> "bar"

parseJSON( ' some crap ' )      # ==> invalid json
```

### Verification steps

:construction: WIP :construction: 

* Compile the wasm module

```sh
make build
```

* Apply the current patch on the configuration example
```patch
patch -p0 <<EOF
diff --git e2e/basic/envoy.yaml e2e/basic/envoy.yaml
index 04dad50..5952240 100644
--- e2e/basic/envoy.yaml
+++ e2e/basic/envoy.yaml
@@ -71,19 +71,7 @@ static_resources:
                                     {
                                       "expression": {
                                         "key": "a",
-                                        "value": "1"
-                                      }
-                                    }
-                                  ]
-                                },
-                                {
-                                  "service": "limitadorB",
-                                  "scope": "basic",
-                                  "data": [
-                                    {
-                                      "expression": {
-                                        "key": "a",
-                                        "value": "1"
+                                        "value": "parseJSON(request.headers['x-foo']).foo"
                                       }
                                     }
                                   ]
diff --git e2e/basic/limits.yaml e2e/basic/limits.yaml
index 03e2ae2..b149bb8 100644
--- e2e/basic/limits.yaml
+++ e2e/basic/limits.yaml
@@ -1,7 +1,7 @@
 ---
 - namespace: basic
-  max_value: 30
+  max_value: 1
   seconds: 60
   conditions:
-  - "descriptors[0]['a'] == '1'"
+  - "descriptors[0]['a'] == 'bar'"
   variables: []
EOF
```

This configuration parses the header value as a JSON serialized string and picks the `foo` key whose value is sent to limitador. The rate limiting is based on the value of the `foo` key of the content in the header `X-Foo`.

* change directory
```sh
cd e2e/basic
```
* Run environment
```sh
make run
```

* Run 