### PR TITLE
gRPC calls at request body phase & `requestBodyJSON` CEL function

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,14 +23,18 @@ endif
 $(PROTOC_BIN):
 	$(call get-protoc,$(PROJECT_PATH),https://github.com/protocolbuffers/protobuf/releases/download/v${PROTOC_VERSION}/protoc-$(PROTOC_VERSION)-$(PROTOC_OS).zip)
 
+.PHONY: protoc
+protoc: $(PROTOC_BIN) ## Download protoc locally if necessary.
+
+BUILD_OPTS=
+ifeq ($(BUILD),release)
+	BUILD_OPTS=--release
+endif
+
 # builds the module and move to deploy folder
 build: $(PROTOC_BIN)
 	@echo "Building the wasm filter"
-    ifeq ($(BUILD), release)
-		export PATH=$(PROJECT_PATH)/bin:$$PATH; cargo build --target=wasm32-unknown-unknown --release $(FEATURE_CMD)
-    else
-		export PATH=$(PROJECT_PATH)/bin:$$PATH; cargo build --target=wasm32-unknown-unknown $(FEATURE_CMD)
-    endif
+	PATH=$(PROJECT_PATH)/bin:$$PATH cargo build --target=wasm32-unknown-unknown $(BUILD_OPTS) $(FEATURE_CMD)
 
 # Remove old ones and fetch the latest third-party protobufs
 update-protobufs:

--- a/examples/request_body/Makefile
+++ b/examples/request_body/Makefile
@@ -1,0 +1,13 @@
+SHELL = /usr/bin/env bash -o pipefail
+.SHELLFLAGS = -ec
+.DEFAULT_GOAL := run
+MKFILE_PATH := $(abspath $(lastword $(MAKEFILE_LIST)))
+WORKDIR := $(patsubst %/,%,$(dir $(MKFILE_PATH)))
+DOCKER ?= $(shell which docker 2> /dev/null || echo "docker")
+
+run:
+	$(DOCKER) compose -f docker-compose.yaml run start_services
+
+clean:
+	$(DOCKER) compose down --volumes --remove-orphans
+	$(DOCKER) compose -f docker-compose.yaml down --volumes --remove-orphans

--- a/examples/request_body/README.md
+++ b/examples/request_body/README.md
@@ -1,0 +1,46 @@
+## Wasm-shim configuration example: gRPC call at the request body phase
+
+### Description
+
+The Wasm module configuration that performs gRPC call with descriptors populated
+from the downstream request body, json formatted, data.
+
+### Run Manually
+
+It requires Wasm module being built at `target/wasm32-unknown-unknown/debug/wasm_shim.wasm`.
+Check *Makefile* at the root of the project to build the module.
+
+```sh
+make run
+```
+
+* Send the request with expected body
+
+```sh
+curl --resolve body-request.example.com:18000:127.0.0.1 "http://body-request.example.com:18000"/v1/responses \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "gpt-4.1",
+    "input": "Tell me a three sentence bedtime story about a unicorn."
+  }'
+```
+
+It should return `200 OK`.
+
+Expected rate limiting service logs:
+
+```sh
+docker compose logs -f rlsbin
+```
+
+```console
+rlsbin-1  | 2025-06-17T08:19:30.014Z DEBUG [rlsbin::envoy_rls::server] Request received: Request { metadata: MetadataMap { headers: {"te": "trailers", "grpc-timeout": "20m", "content-type": "application/grpc", "x-envoy-internal": "true", "x-envoy-expected-rq-timeout-ms": "20"} }, message: RateLimitRequest { domain: "domain-a", descriptors: [RateLimitDescriptor { entries: [Entry { key: "model", value: "gpt-4.1" }], limit: None }], hits_addend: 1 }, extensions: Extensions }
+```
+
+which contains the desired descriptor entry `entries: [Entry { key: "model", value: "gpt-4.1" }]`.
+
+### Clean up
+
+```
+make clean
+```

--- a/examples/request_body/docker-compose.yaml
+++ b/examples/request_body/docker-compose.yaml
@@ -1,0 +1,55 @@
+---
+services:
+  envoy:
+    image: envoyproxy/envoy:v1.31-latest
+    depends_on:
+    - rlsbin
+    - upstream
+    command:
+    - /usr/local/bin/envoy
+    - --config-path
+    - /etc/envoy.yaml
+    - --log-level
+    - info
+    - --component-log-level
+    - wasm:debug,http:debug,router:debug
+    - --service-cluster
+    - proxy
+    expose:
+    - "80"
+    - "8001"
+    ports:
+    - "18000:80"
+    - "18001:8001"
+    volumes:
+    - ./envoy.yaml:/etc/envoy.yaml
+    - ../../target/wasm32-unknown-unknown/debug/wasm_shim.wasm:/opt/kuadrant/wasm/wasm_shim.wasm
+  rlsbin:
+    image: quay.io/eastizle/rlsbin:v0.1.0
+    command:
+    - rlsbin
+    - -vvv
+    ports:
+    - "18081:8081"
+    expose:
+    - "8081"
+  upstream:
+    image: quay.io/kuadrant/authorino-examples:talker-api
+    environment:
+      PORT: 3000
+      LOG_LEVEL: debug
+    expose:
+    - "3000"
+  start_services:
+    image: alpine
+    depends_on:
+    - envoy
+    command: >
+      /bin/sh -c "
+      while ! nc -z envoy 80;
+      do
+      echo sleeping;
+      sleep 1;
+      done;
+      echo Connected!
+      "

--- a/examples/request_body/envoy.yaml
+++ b/examples/request_body/envoy.yaml
@@ -1,0 +1,117 @@
+---
+static_resources:
+  listeners:
+  - name: main
+    address:
+      socket_address:
+        address: 0.0.0.0
+        port_value: 80
+    filter_chains:
+      - filters:
+        - name: envoy.filters.network.http_connection_manager
+          typed_config:
+            "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+            stat_prefix: ingress_http
+            use_remote_address: true
+            xff_num_trusted_hops: 1
+            route_config:
+              name: local_route
+              virtual_hosts:
+                - name: local_service
+                  domains:
+                    - "*"
+                  routes:
+                    - match:
+                        prefix: "/"
+                      route:
+                        cluster: upstream
+            http_filters:
+              - name: envoy.filters.http.wasm
+                typed_config:
+                  "@type": type.googleapis.com/envoy.extensions.filters.http.wasm.v3.Wasm
+                  config:
+                    name: kuadrant_wasm
+                    root_id: kuadrant_wasm
+                    vm_config:
+                      vm_id: vm.sentinel.kuadrant_wasm
+                      runtime: envoy.wasm.runtime.v8
+                      code:
+                        local:
+                          filename: /opt/kuadrant/wasm/wasm_shim.wasm
+                      allow_precompiled: true
+                    configuration:
+                      "@type": "type.googleapis.com/google.protobuf.StringValue"
+                      value: >
+                        {
+                          "services": {
+                            "rlsbin": {
+                              "type": "ratelimit",
+                              "endpoint": "rlsbin",
+                              "failureMode": "deny"
+                            }
+                          },
+                          "actionSets": [
+                            {
+                              "name": "basic",
+                              "routeRuleConditions": {
+                                "hostnames": [
+                                  "*.example.com"
+                                ]
+                              },
+                              "actions": [
+                                {
+                                  "service": "rlsbin",
+                                  "scope": "domain-a",
+                                  "data": [
+                                    {
+                                      "expression": {
+                                        "key": "model",
+                                        "value": "requestBodyJSON('model')"
+                                      }
+                                    }
+                                  ]
+                                }
+                              ]
+                            }
+                          ]
+                        }
+              - name: envoy.filters.http.router
+                typed_config:
+                  "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
+  clusters:
+    - name: upstream
+      connect_timeout: 0.25s
+      type: STRICT_DNS
+      lb_policy: round_robin
+      load_assignment:
+        cluster_name: upstream
+        endpoints:
+        - lb_endpoints:
+          - endpoint:
+              address:
+                socket_address:
+                  address: upstream
+                  port_value: 3000
+    - name: rlsbin
+      connect_timeout: 0.25s
+      type: STRICT_DNS
+      lb_policy: round_robin
+      typed_extension_protocol_options:
+        envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
+          "@type": type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
+          explicit_http_config:
+            http2_protocol_options: {}
+      load_assignment:
+        cluster_name: rlsbin
+        endpoints:
+        - lb_endpoints:
+          - endpoint:
+              address:
+                socket_address:
+                  address: rlsbin
+                  port_value: 8081
+admin:
+  address:
+    socket_address:
+      address: 0.0.0.0
+      port_value: 8001


### PR DESCRIPTION
### What

Fixes #179 

TODO:
- [ ] gRPC calls at request body phase
- [ ] `requestBodyJSON` CEL function
- [ ] e2e tests

Additionally:

- [X] Makefile: protoc build target
- [X] examples/request_body
- [X] kuadrant_filter: refactor on_http_request_headers for more idiomatic code

 ### Verification steps

* Compile the wasm module

```sh
make build
```

* Apply the current patch on the configuration example to activate action at request body phase
```patch
patch -p0 <<EOF
diff --git e2e/basic/docker-compose.yaml e2e/basic/docker-compose.yaml
index bcecea7..c9bedd9 100644
--- e2e/basic/docker-compose.yaml
+++ e2e/basic/docker-compose.yaml
@@ -25,7 +25,7 @@ services:
     - ./envoy.yaml:/etc/envoy.yaml
     - ../../target/wasm32-unknown-unknown/debug/wasm_shim.wasm:/opt/kuadrant/wasm/wasm_shim.wasm
   limitador:
-    image: quay.io/kuadrant/limitador:latest
+    image: quay.io/kuadrant/limitador:eguzki-respect-hits-addend
     command: ["limitador-server", "-vvv", "/opt/kuadrant/limits/limits.yaml"]
     ports:
     - "18080:8080"
@@ -36,9 +36,16 @@ services:
     volumes:
     - ./limits.yaml:/opt/kuadrant/limits/limits.yaml
   upstream:
-    image: quay.io/kuadrant/authorino-examples:talker-api
-    environment:
-      PORT: 3000
+    image: ghcr.io/llm-d/llm-d-inference-sim:v0.1.1
+    command:
+    - --model
+    - meta-llama/Llama-3.1-8B-Instruct
+    - --port
+    - "3000"
+    - --max-loras
+    - "2"
+    - --lora
+    - food-review-1
     expose:
     - "3000"
   start_services:
diff --git e2e/basic/envoy.yaml e2e/basic/envoy.yaml
index 04dad50..d5c9576 100644
--- e2e/basic/envoy.yaml
+++ e2e/basic/envoy.yaml
@@ -70,20 +70,8 @@ static_resources:
                                   "data": [
                                     {
                                       "expression": {
-                                        "key": "a",
-                                        "value": "1"
-                                      }
-                                    }
-                                  ]
-                                },
-                                {
-                                  "service": "limitadorB",
-                                  "scope": "basic",
-                                  "data": [
-                                    {
-                                      "expression": {
-                                        "key": "a",
-                                        "value": "1"
+                                        "key": "model",
+                                        "value": "requestBodyJSON('model')"
                                       }
                                     }
                                   ]
diff --git e2e/basic/limits.yaml e2e/basic/limits.yaml
index 03e2ae2..d73906e 100644
--- e2e/basic/limits.yaml
+++ e2e/basic/limits.yaml
@@ -1,7 +1,7 @@
 ---
 - namespace: basic
-  max_value: 30
-  seconds: 60
+  max_value: 1
+  seconds: 5
   conditions:
-  - "descriptors[0]['a'] == '1'"
+  - "descriptors[0]['model'] == 'meta-llama/Llama-3.1-8B-Instruct'"
   variables: []
EOF
```

This configuration parses the request body as a JSON serialized string and picks the `model` key whose value is sent to limitador. The rate limiting is based on the value of the `model` key.

* change directory
```sh
cd e2e/basic
```
* Run environment
```sh
make run
```

* Check model based rate limiting works (1 req max in 5 sec window)
```
curl --resolve llm.example.com:18000:127.0.0.1 \
     -H 'Content-Type: application/json' \
     -X POST http://llm.example.com:18000/v1/chat/completions \
     -d '{
           "model": "meta-llama/Llama-3.1-8B-Instruct",
           "messages": [
             { "role": "user", "content": "What is Kubernetes?" }
           ],
           "max_tokens": 100,
           "stream": false,
           "usage": true
         }'
```

The second request (in less than 5 secs) should be rejected with `Too Many Requests`

Expected rate limiting service logs:

```sh
docker compose logs -f limitador
```

```console
limitador-1  | 2025-06-17T09:56:27.052685Z DEBUG should_rate_limit: limitador_server::envoy_rls::server: Request received: Request { metadata: MetadataMap { headers: {"te": "trailers", "grpc-timeout": "20m", "content-type": "application/grpc", "x-envoy-internal": "true", "x-envoy-expected-rq-timeout-ms": "20"} }, message: RateLimitRequest { domain: "basic", descriptors: [RateLimitDescriptor { entries: [Entry { key: "model", value: "meta-llama/Llama-3.1-8B-Instruct" }], limit: None }], hits_addend: 1 }, extensions: Extensions }
```

which contains the desired descriptor entry `entries: [Entry { key: "model", value: "meta-llama/Llama-3.1-8B-Instruct" }],`.

