### PR TITLE
Addition of new check rate limit service for use with ratelimit action

### DIFF
--- a/src/configuration.rs
+++ b/src/configuration.rs
@@ -90,6 +90,8 @@ pub enum ServiceType {
     Auth,
     #[default]
     RateLimit,
+    #[serde(rename = "ratelimit-check")]
+    RateLimitCheck,
 }
 
 #[derive(Deserialize, Debug, Clone)]

--- a/src/service.rs
+++ b/src/service.rs
@@ -4,7 +4,10 @@ pub(crate) mod rate_limit;
 use crate::configuration::{FailureMode, Service, ServiceType};
 use crate::envoy::StatusCode;
 use crate::service::auth::{AUTH_METHOD_NAME, AUTH_SERVICE_NAME};
-use crate::service::rate_limit::{RATELIMIT_METHOD_NAME, RATELIMIT_SERVICE_NAME};
+use crate::service::rate_limit::{
+    KUADRANT_RATELIMIT_METHOD_NAME, KUADRANT_RATELIMIT_SERVICE_NAME, RATELIMIT_METHOD_NAME,
+    RATELIMIT_SERVICE_NAME,
+};
 use crate::service::TracingHeader::{Baggage, Traceparent, Tracestate};
 use proxy_wasm::types::Bytes;
 use std::cell::OnceCell;
@@ -65,6 +68,11 @@ impl GrpcService {
                 service,
                 name: RATELIMIT_SERVICE_NAME,
                 method: RATELIMIT_METHOD_NAME,
+            },
+            ServiceType::RateLimitCheck => Self {
+                service,
+                name: KUADRANT_RATELIMIT_SERVICE_NAME,
+                method: KUADRANT_RATELIMIT_METHOD_NAME,
             },
         }
     }

--- a/src/service/rate_limit.rs
+++ b/src/service/rate_limit.rs
@@ -5,6 +5,9 @@ use protobuf::{Message, RepeatedField};
 pub const RATELIMIT_SERVICE_NAME: &str = "envoy.service.ratelimit.v3.RateLimitService";
 pub const RATELIMIT_METHOD_NAME: &str = "ShouldRateLimit";
 
+pub const KUADRANT_RATELIMIT_SERVICE_NAME: &str = "kuadrant.service.ratelimit.v1.RateLimitService";
+pub const KUADRANT_RATELIMIT_METHOD_NAME: &str = "CheckRateLimit";
+
 pub struct RateLimitService;
 
 impl RateLimitService {


### PR DESCRIPTION
closes https://github.com/Kuadrant/wasm-shim/issues/192

tested with [limitador/pull/430](https://github.com/Kuadrant/limitador/pull/430): quay.io/pstefans/limitador:429

Make the following changes to test
```sh
diff --git a/e2e/basic/Makefile b/e2e/basic/Makefile
index 446c682..78eff3f 100644
--- a/e2e/basic/Makefile
+++ b/e2e/basic/Makefile
@@ -15,7 +15,7 @@ test:
        # only one counter
        NUM_COUNTERS=$$(jq --exit-status 'length' $(TMP)/counters.json) && test $${NUM_COUNTERS} -eq 1
        # check counter value
-       COUNTER=$$(jq -r --exit-status '.[0].remaining' $(TMP)/counters.json) && [ "$${COUNTER}" == "28" ]
+       COUNTER=$$(jq -r --exit-status '.[0].remaining' $(TMP)/counters.json) && [ "$${COUNTER}" == "29" ]
 
 clean:
        $(DOCKER) compose down --volumes --remove-orphans
diff --git a/e2e/basic/docker-compose.yaml b/e2e/basic/docker-compose.yaml
index bcecea7..fab27dd 100644
--- a/e2e/basic/docker-compose.yaml
+++ b/e2e/basic/docker-compose.yaml
@@ -25,7 +25,7 @@ services:
     - ./envoy.yaml:/etc/envoy.yaml
     - ../../target/wasm32-unknown-unknown/debug/wasm_shim.wasm:/opt/kuadrant/wasm/wasm_shim.wasm
   limitador:
-    image: quay.io/kuadrant/limitador:latest
+    image: quay.io/pstefans/limitador:429
     command: ["limitador-server", "-vvv", "/opt/kuadrant/limits/limits.yaml"]
     ports:
     - "18080:8080"
diff --git a/e2e/basic/envoy.yaml b/e2e/basic/envoy.yaml
index 04dad50..3b227bb 100644
--- a/e2e/basic/envoy.yaml
+++ b/e2e/basic/envoy.yaml
@@ -45,7 +45,7 @@ static_resources:
                         {
                           "services": {
                             "limitadorA": {
-                              "type": "ratelimit",
+                              "type": "ratelimit-check",
                               "endpoint": "limitador",
                               "failureMode": "deny"
                             },
```

Verification:
1. `cd e2e/basic`
2. `Make run`
3. Wait a few seconds for the service to become ready.
4. `Make test`
5. `Make clean`


Tests should pass as it expects to only decrement by 1 as the 2nd action calls out to rate limit check

You can also check the logs to see the requests being made 
```
 docker compose logs -f limitador
```

<img width="1636" height="413" alt="image" src="https://github.com/user-attachments/assets/5f1fcf5c-c1ab-4a52-847b-4a0ec5ec4b07" />

