### PR TITLE
Sharing the "request context" with the CEL evaluation context

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,14 +23,18 @@ endif
 $(PROTOC_BIN):
 	$(call get-protoc,$(PROJECT_PATH),https://github.com/protocolbuffers/protobuf/releases/download/v${PROTOC_VERSION}/protoc-$(PROTOC_VERSION)-$(PROTOC_OS).zip)
 
+.PHONY: protoc
+protoc: $(PROTOC_BIN) ## Download protoc locally if necessary.
+
+BUILD_OPTS=
+ifeq ($(BUILD),release)
+	BUILD_OPTS=--release
+endif
+
 # builds the module and move to deploy folder
 build: $(PROTOC_BIN)
 	@echo "Building the wasm filter"
-    ifeq ($(BUILD), release)
-		export PATH=$(PROJECT_PATH)/bin:$$PATH; cargo build --target=wasm32-unknown-unknown --release $(FEATURE_CMD)
-    else
-		export PATH=$(PROJECT_PATH)/bin:$$PATH; cargo build --target=wasm32-unknown-unknown $(FEATURE_CMD)
-    endif
+	PATH=$(PROJECT_PATH)/bin:$$PATH cargo build --target=wasm32-unknown-unknown $(BUILD_OPTS) $(FEATURE_CMD)
 
 # Remove old ones and fetch the latest third-party protobufs
 update-protobufs:

--- a/src/auth_action.rs
+++ b/src/auth_action.rs
@@ -1,5 +1,5 @@
 use crate::configuration::{Action, FailureMode, Service};
-use crate::data::{store_metadata, Predicate, PredicateResult, PredicateVec};
+use crate::data::{store_metadata, AttributeResolver, Predicate, PredicateResult, PredicateVec};
 use crate::envoy::{CheckResponse, CheckResponse_oneof_http_response};
 use crate::filter::operations::{EventualOperation, Operation};
 use crate::runtime_action::ResponseResult;
@@ -38,8 +38,11 @@ impl AuthAction {
         self.scope.as_str()
     }
 
-    pub fn conditions_apply(&self) -> PredicateResult {
-        self.predicates.apply()
+    pub fn conditions_apply<T>(&self, resolver: &mut T) -> PredicateResult
+    where
+        T: AttributeResolver,
+    {
+        self.predicates.apply(resolver)
     }
 
     pub fn get_failure_mode(&self) -> FailureMode {
@@ -51,7 +54,7 @@ impl AuthAction {
         // store dynamic metadata in filter state
         debug!("process_response(auth): store_metadata");
         store_metadata(check_response.get_dynamic_metadata())
-            .map_err(|e| ProcessGrpcMessageError::Property(e))?;
+            .map_err(ProcessGrpcMessageError::Property)?;
 
         match check_response.http_response {
             None => {
@@ -94,6 +97,7 @@ impl AuthAction {
 mod test {
     use super::*;
     use crate::configuration::{Action, FailureMode, Service, ServiceType, Timeout};
+    use crate::data::PathCache;
     use crate::envoy::{
         DeniedHttpResponse, HeaderValue, HeaderValueOption, HttpStatus, OkHttpResponse, StatusCode,
     };
@@ -177,36 +181,40 @@ mod test {
 
     #[test]
     fn empty_predicates_do_apply() {
+        let mut resolver = PathCache::default();
         let auth_action = build_auth_action_with_predicates(Vec::default());
-        assert_eq!(auth_action.conditions_apply(), Ok(true));
+        assert_eq!(auth_action.conditions_apply(&mut resolver), Ok(true));
     }
 
     #[test]
     fn when_all_predicates_are_truthy_action_apply() {
+        let mut resolver = PathCache::default();
         let auth_action = build_auth_action_with_predicates(vec!["true".into(), "true".into()]);
-        assert_eq!(auth_action.conditions_apply(), Ok(true));
+        assert_eq!(auth_action.conditions_apply(&mut resolver), Ok(true));
     }
 
     #[test]
     fn when_not_all_predicates_are_truthy_action_does_not_apply() {
+        let mut resolver = PathCache::default();
         let auth_action = build_auth_action_with_predicates(vec![
             "true".into(),
             "true".into(),
             "true".into(),
             "false".into(),
         ]);
-        assert_eq!(auth_action.conditions_apply(), Ok(false));
+        assert_eq!(auth_action.conditions_apply(&mut resolver), Ok(false));
     }
 
     #[test]
     fn when_a_cel_expression_does_not_evaluate_to_bool_panics() {
+        let mut resolver = PathCache::default();
         let auth_action = build_auth_action_with_predicates(vec![
             "true".into(),
             "true".into(),
             "true".into(),
             "1".into(),
         ]);
-        assert!(auth_action.conditions_apply().is_err());
+        assert!(auth_action.conditions_apply(&mut resolver).is_err());
     }
 
     #[test]

--- a/src/data/cel.rs
+++ b/src/data/cel.rs
@@ -158,12 +158,16 @@ impl Expression {
         Self::new_expression(expression, true)
     }
 
-    pub fn eval(&self) -> Result<Value, CelError> {
+    /// Evaluates the given expression using the provided resolver.
+    pub fn eval<T>(&self, resolver: &mut T) -> Result<Value, CelError>
+    where
+        T: AttributeResolver,
+    {
         let mut ctx = create_context();
         if self.extended {
             Self::add_extended_capabilities(&mut ctx)
         }
-        let Map { map } = self.build_data_map()?;
+        let Map { map } = self.build_data_map(resolver)?;
 
         ctx.add_function("getHostProperty", get_host_property);
 
@@ -181,8 +185,11 @@ impl Expression {
         ctx.add_function("queryMap", decode_query_string);
     }
 
-    fn build_data_map(&self) -> Result<Map, PropertyError> {
-        data::AttributeMap::new(self.attributes.clone()).into()
+    fn build_data_map<T>(&self, resolver: &mut T) -> Result<Map, PropertyError>
+    where
+        T: AttributeResolver,
+    {
+        data::AttributeMap::new(self.attributes.clone(), resolver).into()
     }
 }
 
@@ -330,8 +337,11 @@ impl Predicate {
         })
     }
 
-    pub fn test(&self) -> PredicateResult {
-        match self.expression.eval() {
+    pub fn test<T>(&self, resolver: &mut T) -> PredicateResult
+    where
+        T: AttributeResolver,
+    {
+        match self.expression.eval(resolver) {
             Ok(value) => match value {
                 Value::Bool(result) => Ok(result),
                 _ => Err(EvaluationError::new(
@@ -348,17 +358,22 @@ impl Predicate {
 }
 
 pub trait PredicateVec {
-    fn apply(&self) -> PredicateResult;
+    fn apply<T>(&self, resolver: &mut T) -> PredicateResult
+    where
+        T: AttributeResolver;
 }
 
 impl PredicateVec for Vec<Predicate> {
-    fn apply(&self) -> PredicateResult {
+    fn apply<T>(&self, resolver: &mut T) -> PredicateResult
+    where
+        T: AttributeResolver,
+    {
         if self.is_empty() {
             return Ok(true);
         }
         for predicate in self.iter() {
             // if it does not apply or errors exit early
-            if !predicate.test()? {
+            if !predicate.test(resolver)? {
                 return Ok(false);
             }
         }
@@ -627,7 +642,7 @@ pub fn debug_all_well_known_attributes() {
 }
 
 pub mod data {
-    use crate::data::cel::Attribute;
+    use crate::data::cel::{Attribute, AttributeResolver};
     use crate::data::PropertyError;
     use cel_interpreter::objects::{Key, Map};
     use cel_interpreter::Value;
@@ -640,12 +655,16 @@ pub mod data {
         Value(Attribute),
     }
 
-    pub struct AttributeMap {
+    pub struct AttributeMap<'a, T: AttributeResolver> {
         data: HashMap<String, Token>,
+        resolver: &'a mut T,
     }
 
-    impl AttributeMap {
-        pub fn new(attributes: Vec<Attribute>) -> Self {
+    impl<'a, T> AttributeMap<'a, T>
+    where
+        T: AttributeResolver,
+    {
+        pub fn new(attributes: Vec<Attribute>, resolver: &'a mut T) -> Self {
             let mut root = HashMap::default();
             for attr in attributes {
                 let mut node = &mut root;
@@ -666,23 +685,32 @@ pub mod data {
                     }
                 }
             }
-            Self { data: root }
+            Self {
+                data: root,
+                resolver,
+            }
         }
     }
 
-    impl From<AttributeMap> for Result<Map, PropertyError> {
-        fn from(value: AttributeMap) -> Self {
-            map_to_value(value.data)
+    impl<'a, T> From<AttributeMap<'a, T>> for Result<Map, PropertyError>
+    where
+        T: AttributeResolver,
+    {
+        fn from(value: AttributeMap<'a, T>) -> Self {
+            map_to_value(value.data, value.resolver)
         }
     }
 
-    fn map_to_value(map: HashMap<String, Token>) -> Result<Map, PropertyError> {
+    fn map_to_value<T>(map: HashMap<String, Token>, resolver: &mut T) -> Result<Map, PropertyError>
+    where
+        T: AttributeResolver,
+    {
         let mut out: HashMap<Key, Value> = HashMap::default();
         for (key, value) in map {
             let k = key.into();
             let v = match value {
-                Token::Value(v) => v.get()?,
-                Token::Node(map) => Value::Map(map_to_value(map)?),
+                Token::Value(v) => resolver.resolve(&v)?,
+                Token::Node(map) => Value::Map(map_to_value(map, resolver)?),
             };
             out.insert(k, v);
         }
@@ -693,9 +721,11 @@ pub mod data {
     mod tests {
         use crate::data::cel::data::{AttributeMap, Token};
         use crate::data::cel::known_attribute_for;
+        use crate::data::cel::PathCache;
 
         #[test]
         fn it_works() {
+            let mut resolver = PathCache::default();
             let map = AttributeMap::new(
                 [
                     known_attribute_for(&"request.method".into())
@@ -708,6 +738,7 @@ pub mod data {
                         .expect("destination.port known attribute exists"),
                 ]
                 .into(),
+                &mut resolver,
             );
 
             println!("{:#?}", map.data);
@@ -759,20 +790,62 @@ pub mod data {
     }
 }
 
+pub type AttributeResolverResult = Result<Value, PropertyError>;
+
+pub trait AttributeResolver {
+    fn resolve(&mut self, attribute: &Attribute) -> AttributeResolverResult;
+}
+
+#[derive(Default)]
+pub struct PathCache(std::collections::HashMap<Path, Value>);
+
+impl From<HashMap<Path, Value>> for PathCache {
+    fn from(map: HashMap<Path, Value>) -> Self {
+        PathCache(map)
+    }
+}
+
+impl AttributeResolver for PathCache {
+    fn resolve(&mut self, attribute: &Attribute) -> AttributeResolverResult {
+        match self.0.entry(attribute.path.clone()) {
+            Entry::Occupied(entry) => Ok(entry.get().clone()),
+            Entry::Vacant(entry) => {
+                let value = attribute.get()?;
+                entry.insert(value.clone());
+                Ok(value)
+            }
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
-    use crate::data::cel::{known_attribute_for, Expression, Predicate};
+    use super::Attribute;
+    use crate::data::cel::{known_attribute_for, Expression, PathCache, Predicate};
     use crate::data::property;
+    use crate::data::property::Path;
     use cel_interpreter::objects::ValueType;
     use cel_interpreter::Value;
+    use std::collections::HashMap;
     use std::sync::Arc;
+
+    fn build_resolver(elems: Vec<(Path, Value)>) -> PathCache {
+        let mut map: HashMap<Path, Value> = HashMap::default();
+        for (path, value) in elems {
+            map.insert(path, value);
+        }
+
+        map.into()
+    }
 
     #[test]
     fn predicates() {
         let predicate = Predicate::new("source.port == 65432").expect("This is valid CEL!");
-        property::test::TEST_PROPERTY_VALUE
-            .set(Some(("source.port".into(), 65432_i64.to_le_bytes().into())));
-        assert!(predicate.test().expect("This must evaluate properly!"));
+        let mut resolver: PathCache =
+            build_resolver(vec![("source.port".into(), 65432_i64.into())]);
+        assert!(predicate
+            .test(&mut resolver)
+            .expect("This must evaluate properly!"));
     }
 
     #[test]
@@ -795,7 +868,7 @@ mod tests {
     }
 
     #[test]
-    fn expressions_to_json_resolve() {
+    fn attribute_to_json_resolve() {
         property::test::TEST_PROPERTY_VALUE.set(Some((
             property::Path::new(vec![
                 "filter_state",
@@ -803,50 +876,60 @@ mod tests {
             ]),
             "true".bytes().collect(),
         )));
-        let value = Expression::new("auth.identity.anonymous")
-            .expect("This is valid CEL!")
-            .eval()
-            .expect("This must evaluate!");
+        let value = Attribute {
+            path: "auth.identity.anonymous".into(),
+            cel_type: None,
+        }
+        .get()
+        .expect("This must resolve!");
         assert_eq!(value, true.into());
 
         property::test::TEST_PROPERTY_VALUE.set(Some((
             property::Path::new(vec!["filter_state", "wasm.kuadrant.auth.identity.age"]),
             "42".bytes().collect(),
         )));
-        let value = Expression::new("auth.identity.age")
-            .expect("This is valid CEL!")
-            .eval()
-            .expect("This must evaluate!");
+        let value = Attribute {
+            path: "auth.identity.age".into(),
+            cel_type: None,
+        }
+        .get()
+        .expect("This must evaluate!");
         assert_eq!(value, 42.into());
 
         property::test::TEST_PROPERTY_VALUE.set(Some((
             property::Path::new(vec!["filter_state", "wasm.kuadrant.auth.identity.age"]),
             "42.3".bytes().collect(),
         )));
-        let value = Expression::new("auth.identity.age")
-            .expect("This is valid CEL!")
-            .eval()
-            .expect("This must evaluate!");
+        let value = Attribute {
+            path: "auth.identity.age".into(),
+            cel_type: None,
+        }
+        .get()
+        .expect("This must evaluate!");
         assert_eq!(value, 42.3.into());
 
         property::test::TEST_PROPERTY_VALUE.set(Some((
-            property::Path::new(vec!["filter_state", "wasm.kuadrant.auth.identity.age"]),
+            property::Path::new(vec!["filter_state", "wasm.kuadrant.auth.identity.name"]),
             "\"John\"".bytes().collect(),
         )));
-        let value = Expression::new("auth.identity.age")
-            .expect("This is valid CEL!")
-            .eval()
-            .expect("This must evaluate!");
+        let value = Attribute {
+            path: "auth.identity.name".into(),
+            cel_type: None,
+        }
+        .get()
+        .expect("This must evaluate!");
         assert_eq!(value, "John".into());
 
         property::test::TEST_PROPERTY_VALUE.set(Some((
-            property::Path::new(vec!["filter_state", "wasm.kuadrant.auth.identity.name"]),
+            property::Path::new(vec!["filter_state", "wasm.kuadrant.auth.identity.age"]),
             "-42".bytes().collect(),
         )));
-        let value = Expression::new("auth.identity.name")
-            .expect("This is valid CEL!")
-            .eval()
-            .expect("This must evaluate!");
+        let value = Attribute {
+            path: "auth.identity.age".into(),
+            cel_type: None,
+        }
+        .get()
+        .expect("This must evaluate!");
         assert_eq!(value, (-42).into());
 
         // let's fall back to strings, as that's what we read and set in store_metadata
@@ -854,21 +937,42 @@ mod tests {
             property::Path::new(vec!["filter_state", "wasm.kuadrant.auth.identity.age"]),
             "some random crap".bytes().collect(),
         )));
-        let value = Expression::new("auth.identity.age")
-            .expect("This is valid CEL!")
-            .eval()
-            .expect("This must evaluate!");
+        let value = Attribute {
+            path: "auth.identity.age".into(),
+            cel_type: None,
+        }
+        .get()
+        .expect("This must evaluate!");
         assert_eq!(value, "some random crap".into());
     }
 
     #[test]
-    fn decodes_query_string() {
-        property::test::TEST_PROPERTY_VALUE.set(Some((
-            "request.query".into(),
-            "param1=%F0%9F%91%BE%20&param2=Exterminate%21&%F0%9F%91%BE=123&%F0%9F%91%BE=456&%F0%9F%91%BE"
-                .bytes()
-                .collect(),
+    fn attribute_to_map_resolve() {
+        property::test::TEST_MAP_VALUE.set(Some((
+            "request.headers".into(),
+            HashMap::from([
+                ("key_a".into(), "val_a".into()),
+                ("key_b".into(), "val_b".into()),
+            ]),
         )));
+        let value = known_attribute_for(&"request.headers".into())
+            .expect("This is valid attribute")
+            .get()
+            .expect("This must resolve!");
+        assert_eq!(
+            value,
+            HashMap::<String, String>::from([
+                ("key_a".into(), "val_a".into()),
+                ("key_b".into(), "val_b".into()),
+            ])
+            .into()
+        );
+    }
+
+    #[test]
+    fn decodes_query_string() {
+        let mut resolver: PathCache =
+            build_resolver(vec![("request.query".into(), "param1=%F0%9F%91%BE%20&param2=Exterminate%21&%F0%9F%91%BE=123&%F0%9F%91%BE=456&%F0%9F%91%BE".into())]);
         let predicate = Predicate::route_rule(
             "queryMap(request.query, true)['param1'] == '👾 ' && \
             queryMap(request.query, true)['param2'] == 'Exterminate!' && \
@@ -878,48 +982,48 @@ mod tests {
                         ",
         )
         .expect("This is valid!");
-        assert!(predicate.test().expect("This must evaluate properly!"));
+        assert!(predicate
+            .test(&mut resolver)
+            .expect("This must evaluate properly!"));
 
-        property::test::TEST_PROPERTY_VALUE.set(Some((
-            "request.query".into(),
-            "param1=%F0%9F%91%BE%20&param2=Exterminate%21&%F0%9F%91%BE=123&%F0%9F%91%BE=456&%F0%9F%91%BE"
-                .bytes()
-                .collect(),
-        )));
+        let mut resolver: PathCache =
+            build_resolver(vec![("request.query".into(), "param1=%F0%9F%91%BE%20&param2=Exterminate%21&%F0%9F%91%BE=123&%F0%9F%91%BE=456&%F0%9F%91%BE".into())]);
         let predicate = Predicate::route_rule(
             "queryMap(request.query, false)['param2'] == 'Exterminate!' && \
             queryMap(request.query, false)['👾'] == '123' \
                         ",
         )
         .expect("This is valid!");
-        assert!(predicate.test().expect("This must evaluate properly!"));
+        assert!(predicate
+            .test(&mut resolver)
+            .expect("This must evaluate properly!"));
 
-        property::test::TEST_PROPERTY_VALUE.set(Some((
-            "request.query".into(),
-            "%F0%9F%91%BE".bytes().collect(),
-        )));
+        let mut resolver: PathCache =
+            build_resolver(vec![("request.query".into(), "%F0%9F%91%BE".into())]);
         let predicate =
             Predicate::route_rule("queryMap(request.query) == {'👾': ''}").expect("This is valid!");
-        assert!(predicate.test().expect("This must evaluate properly!"));
-    }
+        assert!(predicate
+            .test(&mut resolver)
+            .expect("This must evaluate properly!"));
 
-    #[test]
-    fn kuadrant_generated_predicates() {
-        property::test::TEST_PROPERTY_VALUE.set(Some((
-            "request.query".into(),
-            "param1=%F0%9F%91%BE%20&param2=Exterminate%21&%F0%9F%91%BE=123&%F0%9F%91%BE=456&%F0%9F%91%BE"
-                .bytes()
-                .collect(),
-        )));
+        let mut resolver: PathCache =
+            build_resolver(vec![("request.query".into(), "param1=%F0%9F%91%BE%20&param2=Exterminate%21&%F0%9F%91%BE=123&%F0%9F%91%BE=456&%F0%9F%91%BE".into())]);
         let predicate = Predicate::route_rule(
             "'👾' in queryMap(request.query) ? queryMap(request.query)['👾'] == '123' : false",
         )
         .expect("This is valid!");
-        assert_eq!(predicate.test(), Ok(true));
+        assert_eq!(predicate.test(&mut resolver), Ok(true));
+    }
 
+    #[test]
+    fn kuadrant_generated_predicates() {
+        let headerr_value_map: HashMap<String, String> =
+            HashMap::from([("X-Auth".into(), "kuadrant".into())]);
+        let mut resolver: PathCache =
+            build_resolver(vec![("request.headers".into(), headerr_value_map.into())]);
         let predicate =
             Predicate::route_rule("request.headers.exists(h, h.lowerAscii() == 'x-auth' && request.headers[h] == 'kuadrant')").expect("This is valid!");
-        assert_eq!(predicate.test(), Ok(true));
+        assert_eq!(predicate.test(&mut resolver), Ok(true));
     }
 
     #[test]
@@ -959,9 +1063,10 @@ mod tests {
             property::Path::new(vec!["foo", "bar.baz"]),
             b"\xCA\xFE".to_vec(),
         )));
+        let mut resolver = PathCache::default();
         let value = Expression::new("getHostProperty(['foo', 'bar.baz'])")
             .expect("This is valid CEL!")
-            .eval()
+            .eval(&mut resolver)
             .expect("This must evaluate!");
         assert_eq!(value, Value::Bytes(Arc::new(b"\xCA\xFE".to_vec())));
     }

--- a/src/data/cel/strings.rs
+++ b/src/data/cel/strings.rs
@@ -270,97 +270,116 @@ pub fn substring(This(this): This<Arc<String>>, Arguments(args): Arguments) -> R
 #[cfg(test)]
 mod tests {
     use crate::data::Expression;
+    use crate::data::PathCache;
     use cel_interpreter::Value;
 
     #[test]
     fn extended_string_fn() {
         let e = Expression::new("'abc'.charAt(1)").expect("This must be valid CEL");
-        assert_eq!(e.eval(), Ok("b".into()));
+        assert_eq!(e.eval(&mut PathCache::default()), Ok("b".into()));
 
         let e = Expression::new("'hello mellow'.indexOf('')").expect("This must be valid CEL");
-        assert_eq!(e.eval(), Ok(0.into()));
+        assert_eq!(e.eval(&mut PathCache::default()), Ok(0.into()));
         let e = Expression::new("'hello mellow'.indexOf('ello')").expect("This must be valid CEL");
-        assert_eq!(e.eval(), Ok(1.into()));
+        assert_eq!(e.eval(&mut PathCache::default()), Ok(1.into()));
         let e = Expression::new("'hello mellow'.indexOf('jello')").expect("This must be valid CEL");
-        assert_eq!(e.eval(), Ok((-1).into()));
+        assert_eq!(e.eval(&mut PathCache::default()), Ok((-1).into()));
         let e = Expression::new("'hello mellow'.indexOf('', 2)").expect("This must be valid CEL");
-        assert_eq!(e.eval(), Ok(2.into()));
+        assert_eq!(e.eval(&mut PathCache::default()), Ok(2.into()));
         let e =
             Expression::new("'hello mellow'.indexOf('ello', 20)").expect("This must be valid CEL");
-        assert_eq!(e.eval(), Ok((-1).into()));
+        assert_eq!(e.eval(&mut PathCache::default()), Ok((-1).into()));
 
         let e = Expression::new("'hello mellow'.lastIndexOf('')").expect("This must be valid CEL");
-        assert_eq!(e.eval(), Ok(12.into()));
+        assert_eq!(e.eval(&mut PathCache::default()), Ok(12.into()));
         let e =
             Expression::new("'hello mellow'.lastIndexOf('ello')").expect("This must be valid CEL");
-        assert_eq!(e.eval(), Ok(7.into()));
+        assert_eq!(e.eval(&mut PathCache::default()), Ok(7.into()));
         let e =
             Expression::new("'hello mellow'.lastIndexOf('jello')").expect("This must be valid CEL");
-        assert_eq!(e.eval(), Ok((-1).into()));
+        assert_eq!(e.eval(&mut PathCache::default()), Ok((-1).into()));
         let e = Expression::new("'hello mellow'.lastIndexOf('ello', 6)")
             .expect("This must be valid CEL");
-        assert_eq!(e.eval(), Ok(1.into()));
+        assert_eq!(e.eval(&mut PathCache::default()), Ok(1.into()));
         let e = Expression::new("'hello mellow'.lastIndexOf('ello', 20)")
             .expect("This must be valid CEL");
-        assert_eq!(e.eval(), Ok((-1).into()));
+        assert_eq!(e.eval(&mut PathCache::default()), Ok((-1).into()));
 
         let e = Expression::new("['hello', 'mellow'].join()").expect("This must be valid CEL");
-        assert_eq!(e.eval(), Ok("hellomellow".into()));
+        assert_eq!(e.eval(&mut PathCache::default()), Ok("hellomellow".into()));
         let e = Expression::new("[].join()").expect("This must be valid CEL");
-        assert_eq!(e.eval(), Ok("".into()));
+        assert_eq!(e.eval(&mut PathCache::default()), Ok("".into()));
         let e = Expression::new("['hello', 'mellow'].join(' ')").expect("This must be valid CEL");
-        assert_eq!(e.eval(), Ok("hello mellow".into()));
+        assert_eq!(e.eval(&mut PathCache::default()), Ok("hello mellow".into()));
 
         let e = Expression::new("'TacoCat'.lowerAscii()").expect("This must be valid CEL");
-        assert_eq!(e.eval(), Ok("tacocat".into()));
+        assert_eq!(e.eval(&mut PathCache::default()), Ok("tacocat".into()));
         let e = Expression::new("'TacoCÆt Xii'.lowerAscii()").expect("This must be valid CEL");
-        assert_eq!(e.eval(), Ok("tacocÆt xii".into()));
+        assert_eq!(e.eval(&mut PathCache::default()), Ok("tacocÆt xii".into()));
 
         let e = Expression::new("'TacoCat'.upperAscii()").expect("This must be valid CEL");
-        assert_eq!(e.eval(), Ok("TACOCAT".into()));
+        assert_eq!(e.eval(&mut PathCache::default()), Ok("TACOCAT".into()));
         let e = Expression::new("'TacoCÆt Xii'.upperAscii()").expect("This must be valid CEL");
-        assert_eq!(e.eval(), Ok("TACOCÆT XII".into()));
+        assert_eq!(e.eval(&mut PathCache::default()), Ok("TACOCÆT XII".into()));
 
         let e = Expression::new("'  \ttrim\n    '.trim()").expect("This must be valid CEL");
-        assert_eq!(e.eval(), Ok("trim".into()));
+        assert_eq!(e.eval(&mut PathCache::default()), Ok("trim".into()));
 
         let e =
             Expression::new("'hello hello'.replace('he', 'we')").expect("This must be valid CEL");
-        assert_eq!(e.eval(), Ok("wello wello".into()));
+        assert_eq!(e.eval(&mut PathCache::default()), Ok("wello wello".into()));
         let e = Expression::new("'hello hello'.replace('he', 'we', -1)")
             .expect("This must be valid CEL");
-        assert_eq!(e.eval(), Ok("wello wello".into()));
+        assert_eq!(e.eval(&mut PathCache::default()), Ok("wello wello".into()));
         let e = Expression::new("'hello hello'.replace('he', 'we', 1)")
             .expect("This must be valid CEL");
-        assert_eq!(e.eval(), Ok("wello hello".into()));
+        assert_eq!(e.eval(&mut PathCache::default()), Ok("wello hello".into()));
         let e = Expression::new("'hello hello'.replace('he', 'we', 0)")
             .expect("This must be valid CEL");
-        assert_eq!(e.eval(), Ok("hello hello".into()));
+        assert_eq!(e.eval(&mut PathCache::default()), Ok("hello hello".into()));
         let e = Expression::new("'hello hello'.replace('', '_')").expect("This must be valid CEL");
-        assert_eq!(e.eval(), Ok("_h_e_l_l_o_ _h_e_l_l_o_".into()));
+        assert_eq!(
+            e.eval(&mut PathCache::default()),
+            Ok("_h_e_l_l_o_ _h_e_l_l_o_".into())
+        );
         let e = Expression::new("'hello hello'.replace('h', '')").expect("This must be valid CEL");
-        assert_eq!(e.eval(), Ok("ello ello".into()));
+        assert_eq!(e.eval(&mut PathCache::default()), Ok("ello ello".into()));
 
         let e = Expression::new("'hello hello hello'.split(' ')").expect("This must be valid CEL");
-        assert_eq!(e.eval(), Ok(vec!["hello", "hello", "hello"].into()));
+        assert_eq!(
+            e.eval(&mut PathCache::default()),
+            Ok(vec!["hello", "hello", "hello"].into())
+        );
         let e =
             Expression::new("'hello hello hello'.split(' ', 0)").expect("This must be valid CEL");
-        assert_eq!(e.eval(), Ok(Value::List(vec![].into())));
+        assert_eq!(
+            e.eval(&mut PathCache::default()),
+            Ok(Value::List(vec![].into()))
+        );
         let e =
             Expression::new("'hello hello hello'.split(' ', 1)").expect("This must be valid CEL");
-        assert_eq!(e.eval(), Ok(vec!["hello hello hello"].into()));
+        assert_eq!(
+            e.eval(&mut PathCache::default()),
+            Ok(vec!["hello hello hello"].into())
+        );
         let e =
             Expression::new("'hello hello hello'.split(' ', 2)").expect("This must be valid CEL");
-        assert_eq!(e.eval(), Ok(vec!["hello", "hello hello"].into()));
+        assert_eq!(
+            e.eval(&mut PathCache::default()),
+            Ok(vec!["hello", "hello hello"].into())
+        );
         let e =
             Expression::new("'hello hello hello'.split(' ', -1)").expect("This must be valid CEL");
-        assert_eq!(e.eval(), Ok(vec!["hello", "hello", "hello"].into()));
+        assert_eq!(
+            e.eval(&mut PathCache::default()),
+            Ok(vec!["hello", "hello", "hello"].into())
+        );
 
         let e = Expression::new("'tacocat'.substring(4)").expect("This must be valid CEL");
-        assert_eq!(e.eval(), Ok("cat".into()));
+        assert_eq!(e.eval(&mut PathCache::default()), Ok("cat".into()));
         let e = Expression::new("'tacocat'.substring(0, 4)").expect("This must be valid CEL");
-        assert_eq!(e.eval(), Ok("taco".into()));
+        assert_eq!(e.eval(&mut PathCache::default()), Ok("taco".into()));
         let e = Expression::new("'ta©o©αT'.substring(2, 6)").expect("This must be valid CEL");
-        assert_eq!(e.eval(), Ok("©o©α".into()));
+        assert_eq!(e.eval(&mut PathCache::default()), Ok("©o©α".into()));
     }
 }

--- a/src/data/mod.rs
+++ b/src/data/mod.rs
@@ -9,7 +9,9 @@ pub use attribute::store_metadata;
 pub use cel::debug_all_well_known_attributes;
 
 pub use cel::errors::EvaluationError;
+pub use cel::AttributeResolver;
 pub use cel::Expression;
+pub use cel::PathCache;
 pub use cel::Predicate;
 pub use cel::PredicateResult;
 pub use cel::PredicateVec;

--- a/src/data/property.rs
+++ b/src/data/property.rs
@@ -46,12 +46,13 @@ pub(super) fn host_get_property(path: &Path) -> Result<Option<Vec<u8>>, Status> 
 
 #[cfg(test)]
 pub fn host_get_map(path: &Path) -> Result<HashMap<String, String>, String> {
-    match *path.tokens() {
-        ["request", "headers"] => Ok(HashMap::from([(
-            "X-Auth".to_string(),
-            "kuadrant".to_string(),
-        )])),
-        _ => Err(format!("Unknown map requested {path:?}")),
+    debug!("host_get_map: {:?}", path);
+    match test::TEST_MAP_VALUE.take() {
+        None => Err(format!("Unknown map requested {path:?}")),
+        Some((expected_path, data)) => {
+            assert_eq!(&expected_path, path);
+            Ok(data)
+        }
     }
 }
 
@@ -168,6 +169,8 @@ pub mod test {
 
     thread_local!(
         pub static TEST_PROPERTY_VALUE: Cell<Option<(Path, Vec<u8>)>> = const { Cell::new(None) };
+        pub static TEST_MAP_VALUE: Cell<Option<(Path, HashMap<String, String>)>> =
+            const { Cell::new(None) };
     );
 
     #[test]

--- a/src/envoy/mod.rs
+++ b/src/envoy/mod.rs
@@ -37,14 +37,13 @@ pub use {
         AttributeContext_Request,
     },
     base::{HeaderValue, HeaderValueOption, Metadata},
-    external_auth::{CheckRequest, CheckResponse, CheckResponse_oneof_http_response},
+    external_auth::{
+        CheckRequest, CheckResponse, CheckResponse_oneof_http_response, DeniedHttpResponse,
+    },
     http_status::StatusCode,
     ratelimit::{RateLimitDescriptor, RateLimitDescriptor_Entry},
     rls::{RateLimitRequest, RateLimitResponse, RateLimitResponse_Code},
 };
 
 #[cfg(test)]
-pub use {
-    external_auth::{DeniedHttpResponse, OkHttpResponse},
-    http_status::HttpStatus,
-};
+pub use {external_auth::OkHttpResponse, http_status::HttpStatus};

--- a/src/filter/kuadrant_filter.rs
+++ b/src/filter/kuadrant_filter.rs
@@ -1,22 +1,24 @@
 use crate::action_set_index::ActionSetIndex;
-use crate::filter::operations::{
-    GrpcMessageReceiverOperation, GrpcMessageSenderOperation, Operation,
-};
+use crate::configuration::FailureMode;
+use crate::filter::operations::{EventualOperation, Operation};
+use crate::runtime_action::IndexedRequestResult;
 use crate::runtime_action_set::RuntimeActionSet;
-use crate::service::{GrpcErrResponse, GrpcRequest, HeaderResolver, Headers};
+use crate::service::errors::ProcessGrpcMessageError;
+use crate::service::{DirectResponse, GrpcRequest, HeaderResolver, Headers, IndexedGrpcRequest};
 use log::{debug, error, warn};
 use proxy_wasm::hostcalls;
 use proxy_wasm::traits::{Context, HttpContext};
 use proxy_wasm::types::{Action, BufferType, MapType, Status};
-use std::mem;
 use std::rc::Rc;
+
+type GrpcMessageReceiver = (usize, Rc<RuntimeActionSet>);
 
 pub(crate) struct KuadrantFilter {
     context_id: u32,
     index: Rc<ActionSetIndex>,
     header_resolver: HeaderResolver,
 
-    grpc_message_receiver_operation: Option<GrpcMessageReceiverOperation>,
+    grpc_message_receiver: Option<GrpcMessageReceiver>,
     response_headers_to_add: Option<Headers>,
     request_headers_to_add: Option<Headers>,
 }
@@ -28,14 +30,24 @@ impl Context for KuadrantFilter {
             self.context_id
         );
 
-        match mem::take(&mut self.grpc_message_receiver_operation) {
-            Some(receiver) => {
-                let mut ops = Vec::new();
-
+        match self.grpc_message_receiver.take() {
+            Some((index, action_set)) => {
                 if status_code != Status::Ok as u32 {
-                    ops.push(receiver.fail());
-                } else if let Some(response_body) =
-                    hostcalls::get_buffer(BufferType::GrpcReceiveBuffer, 0, resp_size)
+                    match action_set.runtime_actions[index].get_failure_mode() {
+                        FailureMode::Deny => {
+                            self.die();
+                            return;
+                        }
+                        FailureMode::Allow => {
+                            // increment index to continue with next
+                            if let Action::Continue = self.run(action_set, index + 1) {
+                                self.done();
+                                return;
+                            }
+                        }
+                    }
+                } else {
+                    match hostcalls::get_buffer(BufferType::GrpcReceiveBuffer, 0, resp_size)
                         .unwrap_or_else(|e| {
                             // get_buffer panics instead of returning an Error so this will not happen
                             error!(
@@ -43,23 +55,74 @@ impl Context for KuadrantFilter {
                                 e
                             );
                             None
-                        })
-                {
-                    ops.extend(receiver.digest_grpc_response(&response_body));
-                } else {
-                    ops.push(receiver.fail());
-                }
+                        }) {
+                        Some(response_body) => {
+                            match action_set.runtime_actions[index].process_response(&response_body)
+                            {
+                                Ok(Operation::EventualOps(ops)) => {
+                                    ops.into_iter().for_each(|op| {
+                                        self.handle_eventual_operation(op);
+                                    });
 
-                ops.into_iter().for_each(|op| {
-                    self.handle_operation(op);
-                })
+                                    // increment index to continue with next
+                                    if let Action::Continue = self.run(action_set, index + 1) {
+                                        self.done();
+                                        return;
+                                    }
+                                }
+                                Ok(Operation::DirectResponse(direct_response)) => {
+                                    self.send_http_reponse(direct_response);
+                                    return;
+                                }
+                                Err(ProcessGrpcMessageError::Protobuf(e)) => {
+                                    // processing the response failed
+                                    // The action failure mode is set to deny, so we log the error and die
+                                    debug!("ProtobufError while processing grpc response: {e:?}");
+                                    self.die();
+                                    return;
+                                }
+                                Err(ProcessGrpcMessageError::Property(e)) => {
+                                    // processing the response failed
+                                    // The action failure mode is set to deny, so we log the error and die
+                                    debug!("PropertyError while processing grpc response: {e:?}");
+                                    self.die();
+                                    return;
+                                }
+                                Err(e) => {
+                                    // processing the response failed
+                                    // The action failure mode is set to deny, so we log the error and die
+                                    debug!(
+                                        "Unexpected error while processing grpc response: {e:?}"
+                                    );
+                                    self.die();
+                                    return;
+                                }
+                            }
+                        }
+                        None => {
+                            match action_set.runtime_actions[index].get_failure_mode() {
+                                FailureMode::Deny => {
+                                    self.die();
+                                    return;
+                                }
+                                FailureMode::Allow => {
+                                    // increment index to continue with next
+                                    if let Action::Continue = self.run(action_set, index + 1) {
+                                        self.done();
+                                        return;
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
             }
             None => {
                 error!(
                     "#{} on_grpc_call_response: received gRPC response but no pending receiver",
                     self.context_id
                 );
-                self.die(GrpcErrResponse::new_internal_server_error())
+                self.die()
             }
         }
     }
@@ -78,7 +141,7 @@ impl HttpContext for KuadrantFilter {
         let authority = match self.request_authority() {
             Ok(authority) => authority,
             Err(_) => {
-                self.die(GrpcErrResponse::new_internal_server_error());
+                self.die();
                 return Action::Continue;
             }
         };
@@ -101,14 +164,14 @@ impl HttpContext for KuadrantFilter {
                             "#{} action_set selected {}",
                             self.context_id, action_set.name
                         );
-                        action = self.start_flow(Rc::clone(action_set));
+                        action = self.run(Rc::clone(action_set), 0);
                     }
                     Err(e) => {
                         error!(
                             "#{} on_http_request_headers: failed to apply conditions: {:?}",
                             self.context_id, e
                         );
-                        self.die(GrpcErrResponse::new_internal_server_error());
+                        self.die();
                         return Action::Continue;
                     }
                 }
@@ -120,7 +183,7 @@ impl HttpContext for KuadrantFilter {
 
     fn on_http_response_headers(&mut self, _num_headers: usize, _end_of_stream: bool) -> Action {
         debug!("#{} on_http_response_headers", self.context_id);
-        if let Some(response_headers) = mem::take(&mut self.response_headers_to_add) {
+        if let Some(response_headers) = self.response_headers_to_add.take() {
             for (header, value) in response_headers {
                 if let Err(status) = self.add_http_response_header(header.as_str(), value.as_str())
                 {
@@ -137,78 +200,100 @@ impl HttpContext for KuadrantFilter {
 }
 
 impl KuadrantFilter {
-    fn start_flow(&mut self, action_set: Rc<RuntimeActionSet>) -> Action {
-        let grpc_request = action_set.find_first_grpc_request();
-        let op = match grpc_request {
-            Ok(None) => Operation::Done(),
-            Ok(Some(indexed_req)) => {
-                Operation::SendGrpcRequest(GrpcMessageSenderOperation::new(action_set, indexed_req))
+    fn next_request(
+        &mut self,
+        action_set: &Rc<RuntimeActionSet>,
+        start: usize,
+    ) -> IndexedRequestResult {
+        for (index, action) in action_set.runtime_actions.iter().skip(start).enumerate() {
+            match action.build_request()? {
+                None => continue,
+                Some(grpc_request) => {
+                    return Ok(Some(IndexedGrpcRequest::new(start + index, grpc_request)));
+                }
             }
-            Err(grpc_err_response) => Operation::Die(grpc_err_response),
-        };
-        self.handle_operation(op)
+        }
+        Ok(None)
     }
 
-    fn handle_operation(&mut self, operation: Operation) -> Action {
-        match operation {
-            Operation::SendGrpcRequest(sender_op) => {
-                debug!("handle_operation: SendGrpcRequest");
-                let next_op = {
-                    let (req, receiver_op) = sender_op.build_receiver_operation();
-                    match self.send_grpc_request(req) {
-                        Ok(_token) => Operation::AwaitGrpcResponse(receiver_op),
+    fn run(&mut self, action_set: Rc<RuntimeActionSet>, start: usize) -> Action {
+        let mut index = start;
+        loop {
+            match self.next_request(&action_set, index) {
+                Ok(None) => {
+                    // Nothing more to do, we can end the flow
+                    return Action::Continue;
+                }
+                Ok(Some(indexed_req)) => {
+                    index = indexed_req.index();
+                    match self.send_grpc_request(indexed_req.request()) {
+                        Ok(_token) => {
+                            self.grpc_message_receiver = Some((index, action_set));
+                            return Action::Pause;
+                        }
                         Err(status) => {
-                            debug!("handle_operation: failed to send grpc request `{status:?}`");
-                            receiver_op.fail()
-                        }
-                    }
-                };
-                self.handle_operation(next_op)
-            }
-            Operation::AwaitGrpcResponse(receiver_op) => {
-                debug!("handle_operation: AwaitGrpcResponse");
-                self.grpc_message_receiver_operation = Some(receiver_op);
-                Action::Pause
-            }
-            Operation::AddHeaders(header_op) => {
-                debug!("handle_operation: AddHeaders");
-                match header_op.into_inner() {
-                    crate::service::HeaderKind::Request(headers) => {
-                        if let Some(existing_headers) = self.request_headers_to_add.as_mut() {
-                            existing_headers.extend(headers);
-                        } else {
-                            warn!("Trying to add request headers after phase has ended!")
-                        }
-                    }
-                    crate::service::HeaderKind::Response(headers) => {
-                        if let Some(existing_headers) = self.response_headers_to_add.as_mut() {
-                            existing_headers.extend(headers);
-                        } else {
-                            warn!("Trying to add response headers after phase has ended!")
+                            debug!(
+                                "#{} run: failed to send grpc request `{status:?}`",
+                                self.context_id
+                            );
+                            // if failure mode is set to allow, continue with next action
+                            match action_set.runtime_actions[index].get_failure_mode() {
+                                FailureMode::Deny => {
+                                    self.die();
+                                    return Action::Pause;
+                                }
+                                FailureMode::Allow => {
+                                    // increment index to continue with next
+                                    index = index + 1;
+                                }
+                            }
                         }
                     }
                 }
-                Action::Continue
-            }
-            Operation::Die(die_op) => {
-                debug!("handle_operation: Die");
-                self.die(die_op);
-                Action::Continue
-            }
-            Operation::Done() => {
-                debug!("handle_operation: Done");
-                self.add_request_headers();
-                let _ = self.resume_http_request();
-                Action::Continue
+                Err(err) => {
+                    // Building the request failed
+                    // The action failure mode is set to deny, so we log the error and die
+                    debug!("Error while building request: {:?}", err);
+                    self.die();
+                    return Action::Pause;
+                }
             }
         }
     }
 
-    fn die(&mut self, die: GrpcErrResponse) {
+    fn handle_eventual_operation(&mut self, operation: EventualOperation) {
+        match operation {
+            EventualOperation::AddRequestHeaders(headers) => {
+                if let Some(existing_headers) = self.request_headers_to_add.as_mut() {
+                    existing_headers.extend(headers);
+                } else {
+                    warn!("Trying to add request headers after phase has ended!")
+                }
+            }
+            EventualOperation::AddResponseHeaders(headers) => {
+                if let Some(existing_headers) = self.response_headers_to_add.as_mut() {
+                    existing_headers.extend(headers);
+                } else {
+                    warn!("Trying to add response headers after phase has ended!")
+                }
+            }
+        }
+    }
+
+    fn die(&self) {
+        self.send_http_reponse(DirectResponse::new_internal_server_error());
+    }
+
+    fn done(&mut self) {
+        self.add_request_headers();
+        let _ = self.resume_http_request();
+    }
+
+    fn send_http_reponse(&self, direct_response: DirectResponse) {
         let _ = self.send_http_response(
-            die.status_code(),
-            die.headers(),
-            Some(die.body().as_bytes()),
+            direct_response.status_code(),
+            direct_response.headers(),
+            Some(direct_response.body().as_bytes()),
         );
     }
 
@@ -231,6 +316,14 @@ impl KuadrantFilter {
     }
 
     fn send_grpc_request(&self, req: GrpcRequest) -> Result<u32, Status> {
+        debug!(
+            "#{} send_grpc_request: {} {} {} {:?}",
+            self.context_id,
+            req.upstream_name(),
+            req.service_name(),
+            req.method_name(),
+            req.timeout(),
+        );
         let headers = self
             .header_resolver
             .get_with_ctx(self)
@@ -249,7 +342,7 @@ impl KuadrantFilter {
     }
 
     fn add_request_headers(&mut self) {
-        if let Some(request_headers) = mem::take(&mut self.request_headers_to_add) {
+        if let Some(request_headers) = self.request_headers_to_add.take() {
             for (header, value) in request_headers {
                 if let Err(status) = self.add_http_request_header(header.as_str(), value.as_str()) {
                     log::error!(
@@ -271,7 +364,7 @@ impl KuadrantFilter {
             context_id,
             index,
             header_resolver,
-            grpc_message_receiver_operation: None,
+            grpc_message_receiver: None,
             response_headers_to_add: Some(Vec::default()),
             request_headers_to_add: Some(Vec::default()),
         }

--- a/src/filter/kuadrant_filter.rs
+++ b/src/filter/kuadrant_filter.rs
@@ -14,7 +14,7 @@ use std::rc::Rc;
 pub(crate) struct KuadrantFilter {
     context_id: u32,
     index: Rc<ActionSetIndex>,
-    header_resolver: Rc<HeaderResolver>,
+    header_resolver: HeaderResolver,
 
     grpc_message_receiver_operation: Option<GrpcMessageReceiverOperation>,
     response_headers_to_add: Option<Headers>,
@@ -265,7 +265,7 @@ impl KuadrantFilter {
     pub fn new(
         context_id: u32,
         index: Rc<ActionSetIndex>,
-        header_resolver: Rc<HeaderResolver>,
+        header_resolver: HeaderResolver,
     ) -> Self {
         Self {
             context_id,

--- a/src/filter/kuadrant_filter.rs
+++ b/src/filter/kuadrant_filter.rs
@@ -84,17 +84,25 @@ impl HttpContext for KuadrantFilter {
         };
 
         if let Some(action_sets) = self.index.get_longest_match_action_sets(authority.as_ref()) {
-            for action_set in action_sets {
+            let action_set_opt = action_sets.iter().find_map(|action_set| {
+                // returns the first non-None result,
+                // namely when condition apply OR there is an error
                 match action_set.conditions_apply() {
-                    Ok(true) => {
+                    Ok(true) => Some(Ok(action_set)),
+                    Ok(false) => None,
+                    Err(e) => Some(Err(e)),
+                }
+            });
+
+            if let Some(action_set_res) = action_set_opt {
+                match action_set_res {
+                    Ok(action_set) => {
                         debug!(
                             "#{} action_set selected {}",
                             self.context_id, action_set.name
                         );
                         action = self.start_flow(Rc::clone(action_set));
-                        break;
                     }
-                    Ok(false) => continue,
                     Err(e) => {
                         error!(
                             "#{} on_http_request_headers: failed to apply conditions: {:?}",
@@ -107,11 +115,6 @@ impl HttpContext for KuadrantFilter {
             }
         }
 
-        if action == Action::Continue {
-            // the request headers are currently always None, however this is one of two phases
-            // where headers should be added
-            self.add_request_headers()
-        }
         action
     }
 

--- a/src/filter/operations.rs
+++ b/src/filter/operations.rs
@@ -1,107 +1,25 @@
-use crate::configuration::FailureMode;
-use crate::runtime_action_set::{IndexedRequestResult, RuntimeActionSet};
-use crate::service::{GrpcErrResponse, GrpcRequest, HeaderKind, IndexedGrpcRequest};
-use std::rc::Rc;
+use crate::service::{DirectResponse, Headers};
 
+#[derive(Debug)]
 pub enum Operation {
-    SendGrpcRequest(GrpcMessageSenderOperation),
-    AwaitGrpcResponse(GrpcMessageReceiverOperation),
-    AddHeaders(HeaderOperation),
-    Die(GrpcErrResponse),
-    // Done indicates that we have no more operations and can resume the http request flow
-    Done(),
+    EventualOps(Vec<EventualOperation>),
+    DirectResponse(DirectResponse),
 }
 
-pub struct GrpcMessageSenderOperation {
-    runtime_action_set: Rc<RuntimeActionSet>,
-    grpc_request: IndexedGrpcRequest,
-}
-
-impl GrpcMessageSenderOperation {
-    pub fn new(
-        runtime_action_set: Rc<RuntimeActionSet>,
-        indexed_request: IndexedGrpcRequest,
-    ) -> Self {
-        Self {
-            runtime_action_set,
-            grpc_request: indexed_request,
-        }
-    }
-
-    pub fn build_receiver_operation(self) -> (GrpcRequest, GrpcMessageReceiverOperation) {
-        let index = self.grpc_request.index();
-        (
-            self.grpc_request.request(),
-            GrpcMessageReceiverOperation::new(self.runtime_action_set, index),
-        )
+impl From<DirectResponse> for Operation {
+    fn from(e: DirectResponse) -> Self {
+        Operation::DirectResponse(e)
     }
 }
 
-pub struct GrpcMessageReceiverOperation {
-    runtime_action_set: Rc<RuntimeActionSet>,
-    current_index: usize,
-}
-
-impl GrpcMessageReceiverOperation {
-    pub fn new(runtime_action_set: Rc<RuntimeActionSet>, current_index: usize) -> Self {
-        Self {
-            runtime_action_set,
-            current_index,
-        }
-    }
-
-    pub fn digest_grpc_response(self, msg: &[u8]) -> Vec<Operation> {
-        let result = self
-            .runtime_action_set
-            .process_grpc_response(self.current_index, msg);
-
-        match result {
-            Ok((next_msg, headers)) => {
-                let mut operations = Vec::new();
-                if !headers.is_empty() {
-                    operations.push(Operation::AddHeaders(HeaderOperation::new(headers)))
-                }
-                operations.push(self.handle_next(next_msg));
-                operations
-            }
-            Err(grpc_err_resp) => vec![Operation::Die(grpc_err_resp)],
-        }
-    }
-
-    pub fn fail(self) -> Operation {
-        match self.runtime_action_set.runtime_actions[self.current_index].get_failure_mode() {
-            FailureMode::Deny => Operation::Die(GrpcErrResponse::new_internal_server_error()),
-            FailureMode::Allow => {
-                let next = self
-                    .runtime_action_set
-                    .find_next_grpc_request(self.current_index + 1);
-                self.handle_next(next)
-            }
-        }
-    }
-
-    fn handle_next(self, indexed_request_result: IndexedRequestResult) -> Operation {
-        match indexed_request_result {
-            Ok(None) => Operation::Done(),
-            Ok(Some(indexed_req)) => Operation::SendGrpcRequest(GrpcMessageSenderOperation::new(
-                self.runtime_action_set,
-                indexed_req,
-            )),
-            Err(grpc_err_resp) => Operation::Die(grpc_err_resp),
-        }
+impl From<Vec<EventualOperation>> for Operation {
+    fn from(e: Vec<EventualOperation>) -> Self {
+        Operation::EventualOps(e)
     }
 }
 
-pub struct HeaderOperation {
-    headers: HeaderKind,
-}
-
-impl HeaderOperation {
-    pub fn new(headers: HeaderKind) -> Self {
-        Self { headers }
-    }
-
-    pub fn into_inner(self) -> HeaderKind {
-        self.headers
-    }
+#[derive(Debug)]
+pub enum EventualOperation {
+    AddRequestHeaders(Headers),
+    AddResponseHeaders(Headers),
 }

--- a/src/filter/root_context.rs
+++ b/src/filter/root_context.rs
@@ -34,11 +34,10 @@ impl RootContext for FilterRoot {
 
     fn create_http_context(&self, context_id: u32) -> Option<Box<dyn HttpContext>> {
         debug!("#{} create_http_context", context_id);
-        let header_resolver = Rc::new(HeaderResolver::new());
         Some(Box::new(KuadrantFilter::new(
             context_id,
             Rc::clone(&self.action_set_index),
-            header_resolver,
+            HeaderResolver::new(),
         )))
     }
 

--- a/src/runtime_action_set.rs
+++ b/src/runtime_action_set.rs
@@ -2,7 +2,6 @@ use crate::configuration::{ActionSet, Service};
 use crate::data::{Predicate, PredicateResult, PredicateVec};
 use crate::runtime_action::errors::ActionCreationError;
 use crate::runtime_action::RuntimeAction;
-use crate::service::{GrpcErrResponse, HeaderKind, IndexedGrpcRequest};
 use std::collections::HashMap;
 use std::rc::Rc;
 
@@ -12,8 +11,6 @@ pub struct RuntimeActionSet {
     pub route_rule_predicates: Vec<Predicate>,
     pub runtime_actions: Vec<Rc<RuntimeAction>>,
 }
-
-pub type IndexedRequestResult = Result<Option<IndexedGrpcRequest>, GrpcErrResponse>;
 
 impl RuntimeActionSet {
     pub fn new(
@@ -61,36 +58,6 @@ impl RuntimeActionSet {
 
     pub fn conditions_apply(&self) -> PredicateResult {
         self.route_rule_predicates.apply()
-    }
-
-    pub fn find_first_grpc_request(&self) -> IndexedRequestResult {
-        self.find_next_grpc_request(0)
-    }
-
-    pub fn find_next_grpc_request(&self, start: usize) -> IndexedRequestResult {
-        for (index, action) in self.runtime_actions.iter().skip(start).enumerate() {
-            match action.process_request() {
-                Ok(Some(request)) => {
-                    return Ok(Some(IndexedGrpcRequest::new(start + index, request)))
-                }
-                Ok(None) => continue,
-                Err(e) => return Err(e),
-            }
-        }
-        Ok(None)
-    }
-
-    pub fn process_grpc_response(
-        &self,
-        index: usize,
-        msg: &[u8],
-    ) -> Result<(IndexedRequestResult, HeaderKind), GrpcErrResponse> {
-        self.runtime_actions[index]
-            .process_response(msg)
-            .map(|headers| {
-                let next_msg = self.find_next_grpc_request(index + 1);
-                (next_msg, headers)
-            })
     }
 }
 

--- a/src/runtime_action_set.rs
+++ b/src/runtime_action_set.rs
@@ -1,5 +1,5 @@
 use crate::configuration::{ActionSet, Service};
-use crate::data::{Predicate, PredicateResult, PredicateVec};
+use crate::data::{AttributeResolver, Predicate, PredicateResult, PredicateVec};
 use crate::runtime_action::errors::ActionCreationError;
 use crate::runtime_action::RuntimeAction;
 use std::collections::HashMap;
@@ -56,8 +56,11 @@ impl RuntimeActionSet {
         Ok(folded_actions)
     }
 
-    pub fn conditions_apply(&self) -> PredicateResult {
-        self.route_rule_predicates.apply()
+    pub fn conditions_apply<T>(&self, resolver: &mut T) -> PredicateResult
+    where
+        T: AttributeResolver,
+    {
+        self.route_rule_predicates.apply(resolver)
     }
 }
 
@@ -67,6 +70,7 @@ mod test {
     use crate::configuration::{
         Action, ActionSet, FailureMode, RouteRuleConditions, ServiceType, Timeout,
     };
+    use crate::data::PathCache;
 
     #[test]
     fn empty_route_rule_predicates_do_apply() {
@@ -74,7 +78,10 @@ mod test {
 
         let runtime_action_set = RuntimeActionSet::new(&action_set, &HashMap::default())
             .expect("should not happen from an empty set of actions");
-        assert_eq!(runtime_action_set.conditions_apply(), Ok(true));
+        assert_eq!(
+            runtime_action_set.conditions_apply(&mut PathCache::default()),
+            Ok(true)
+        );
     }
 
     #[test]
@@ -90,7 +97,10 @@ mod test {
 
         let runtime_action_set = RuntimeActionSet::new(&action_set, &HashMap::default())
             .expect("should not happen from an empty set of actions");
-        assert_eq!(runtime_action_set.conditions_apply(), Ok(true));
+        assert_eq!(
+            runtime_action_set.conditions_apply(&mut PathCache::default()),
+            Ok(true)
+        );
     }
 
     #[test]
@@ -106,7 +116,10 @@ mod test {
 
         let runtime_action_set = RuntimeActionSet::new(&action_set, &HashMap::default())
             .expect("should not happen from an empty set of actions");
-        assert_eq!(runtime_action_set.conditions_apply(), Ok(false));
+        assert_eq!(
+            runtime_action_set.conditions_apply(&mut PathCache::default()),
+            Ok(false)
+        );
     }
 
     #[test]
@@ -122,7 +135,9 @@ mod test {
 
         let runtime_action_set = RuntimeActionSet::new(&action_set, &HashMap::default())
             .expect("should not happen from an empty set of actions");
-        assert!(runtime_action_set.conditions_apply().is_err());
+        assert!(runtime_action_set
+            .conditions_apply(&mut PathCache::default())
+            .is_err());
     }
 
     fn build_rl_service() -> Service {

--- a/src/service.rs
+++ b/src/service.rs
@@ -245,7 +245,7 @@ impl From<DeniedHttpResponse> for DirectResponse {
         let status_code = resp.get_status().get_code();
         let response_headers = resp
             .get_headers()
-            .into_iter()
+            .iter()
             .map(|header| {
                 let hv = header.get_header();
                 (hv.key.to_owned(), hv.value.to_owned())

--- a/src/service.rs
+++ b/src/service.rs
@@ -2,10 +2,12 @@ pub(crate) mod auth;
 pub(crate) mod rate_limit;
 
 use crate::configuration::{FailureMode, Service, ServiceType};
-use crate::envoy::StatusCode;
+use crate::envoy::DeniedHttpResponse;
+use crate::envoy::{HeaderValue, HeaderValueOption, StatusCode};
 use crate::service::auth::{AUTH_METHOD_NAME, AUTH_SERVICE_NAME};
 use crate::service::rate_limit::{RATELIMIT_METHOD_NAME, RATELIMIT_SERVICE_NAME};
 use crate::service::TracingHeader::{Baggage, Traceparent, Tracestate};
+use protobuf::RepeatedField;
 use proxy_wasm::types::Bytes;
 use std::cell::OnceCell;
 use std::rc::Rc;
@@ -42,6 +44,20 @@ pub(super) mod errors {
                     write!(f, "BuildMessageError::Serialization {{ {e:?} }}")
                 }
             }
+        }
+    }
+
+    #[derive(Debug)]
+    pub enum ProcessGrpcMessageError {
+        Protobuf(ProtobufError),
+        Property(PropertyError),
+        EmptyResponse,
+        UnsupportedField,
+    }
+
+    impl From<ProtobufError> for ProcessGrpcMessageError {
+        fn from(e: ProtobufError) -> Self {
+            ProcessGrpcMessageError::Protobuf(e)
         }
     }
 }
@@ -166,28 +182,32 @@ impl GrpcRequest {
 }
 
 pub type Headers = Vec<(String, String)>;
-#[derive(Debug)]
-pub enum HeaderKind {
-    Response(Headers),
-    Request(Headers),
+
+pub fn from_envoy_rl_headers(headers: RepeatedField<HeaderValue>) -> Headers {
+    headers
+        .into_iter()
+        .map(|header| (header.key, header.value))
+        .collect()
 }
 
-impl HeaderKind {
-    pub fn is_empty(&self) -> bool {
-        match self {
-            HeaderKind::Response(headers) | HeaderKind::Request(headers) => headers.is_empty(),
-        }
-    }
+pub fn from_envoy_headers(headers: &[HeaderValueOption]) -> Headers {
+    headers
+        .iter()
+        .map(|header| {
+            let hv = header.get_header();
+            (hv.key.to_owned(), hv.value.to_owned())
+        })
+        .collect()
 }
 
 #[derive(Debug)]
-pub struct GrpcErrResponse {
+pub struct DirectResponse {
     status_code: u32,
     response_headers: Headers,
     body: String,
 }
 
-impl GrpcErrResponse {
+impl DirectResponse {
     pub fn new(status_code: u32, response_headers: Headers, body: String) -> Self {
         Self {
             status_code,
@@ -217,6 +237,21 @@ impl GrpcErrResponse {
 
     pub fn body(&self) -> &str {
         self.body.as_str()
+    }
+}
+
+impl From<DeniedHttpResponse> for DirectResponse {
+    fn from(resp: DeniedHttpResponse) -> Self {
+        let status_code = resp.get_status().get_code();
+        let response_headers = resp
+            .get_headers()
+            .into_iter()
+            .map(|header| {
+                let hv = header.get_header();
+                (hv.key.to_owned(), hv.value.to_owned())
+            })
+            .collect();
+        Self::new(status_code as u32, response_headers, resp.body)
     }
 }
 

--- a/tests/auth.rs
+++ b/tests/auth.rs
@@ -166,7 +166,7 @@ fn it_auths() {
         .returning(Some(data::source::port::P_45000))
         .expect_log(
             Some(LogLevel::Debug),
-            Some("handle_operation: SendGrpcRequest"),
+            Some("#2 send_grpc_request: authorino-cluster envoy.service.auth.v3.Authorization Check 5s"),
         )
         // retrieving tracing headers
         .expect_get_header_map_value(Some(MapType::HttpRequestHeaders), Some("traceparent"))
@@ -184,10 +184,6 @@ fn it_auths() {
             Some(5000),
         )
         .returning(Ok(42))
-        .expect_log(
-            Some(LogLevel::Debug),
-            Some("handle_operation: AwaitGrpcResponse"),
-        )
         .execute_and_expect(ReturnType::Action(Action::Pause))
         .unwrap();
 
@@ -215,7 +211,6 @@ fn it_auths() {
             Some(LogLevel::Debug),
             Some("process_response(auth): received OkHttpResponse"),
         )
-        .expect_log(Some(LogLevel::Debug), Some("handle_operation: Done"))
         .execute_and_expect(ReturnType::None)
         .unwrap();
 
@@ -358,7 +353,7 @@ fn it_denies() {
         .returning(Some(data::source::port::P_45000))
         .expect_log(
             Some(LogLevel::Debug),
-            Some("handle_operation: SendGrpcRequest"),
+            Some("#2 send_grpc_request: authorino-cluster envoy.service.auth.v3.Authorization Check 5s"),
         )
         // retrieving tracing headers
         .expect_get_header_map_value(Some(MapType::HttpRequestHeaders), Some("traceparent"))
@@ -376,10 +371,6 @@ fn it_denies() {
             Some(5000),
         )
         .returning(Ok(42))
-        .expect_log(
-            Some(LogLevel::Debug),
-            Some("handle_operation: AwaitGrpcResponse"),
-        )
         .execute_and_expect(ReturnType::Action(Action::Pause))
         .unwrap();
 
@@ -407,7 +398,6 @@ fn it_denies() {
             Some(LogLevel::Debug),
             Some("process_response(auth): received DeniedHttpResponse"),
         )
-        .expect_log(Some(LogLevel::Debug), Some("handle_operation: Die"))
         .expect_send_local_response(
             Some(401),
             None,
@@ -568,7 +558,7 @@ fn it_does_not_fold_auth_actions() {
         .returning(Some(data::source::port::P_45000))
         .expect_log(
             Some(LogLevel::Debug),
-            Some("handle_operation: SendGrpcRequest"),
+            Some("#2 send_grpc_request: authorino-cluster envoy.service.auth.v3.Authorization Check 5s"),
         )
         // retrieving tracing headers
         .expect_get_header_map_value(Some(MapType::HttpRequestHeaders), Some("traceparent"))
@@ -586,10 +576,6 @@ fn it_does_not_fold_auth_actions() {
             Some(5000),
         )
         .returning(Ok(42))
-        .expect_log(
-            Some(LogLevel::Debug),
-            Some("handle_operation: AwaitGrpcResponse"),
-        )
         .execute_and_expect(ReturnType::Action(Action::Pause))
         .unwrap();
 
@@ -681,7 +667,7 @@ fn it_does_not_fold_auth_actions() {
         .returning(Some(data::source::port::P_45000))
         .expect_log(
             Some(LogLevel::Debug),
-            Some("handle_operation: SendGrpcRequest"),
+            Some("#2 send_grpc_request: authorino-cluster envoy.service.auth.v3.Authorization Check 5s"),
         )
         .expect_grpc_call(
             Some("authorino-cluster"),
@@ -692,10 +678,6 @@ fn it_does_not_fold_auth_actions() {
             Some(5000),
         )
         .returning(Ok(42))
-        .expect_log(
-            Some(LogLevel::Debug),
-            Some("handle_operation: AwaitGrpcResponse"),
-        )
         .execute_and_expect(ReturnType::None)
         .unwrap();
 
@@ -723,7 +705,6 @@ fn it_does_not_fold_auth_actions() {
             Some(LogLevel::Debug),
             Some("process_response(auth): received OkHttpResponse"),
         )
-        .expect_log(Some(LogLevel::Debug), Some("handle_operation: Done"))
         .execute_and_expect(ReturnType::None)
         .unwrap();
 

--- a/tests/failuremode.rs
+++ b/tests/failuremode.rs
@@ -103,7 +103,7 @@ fn it_runs_next_action_on_failure_when_failuremode_is_allow() {
         )
         .expect_log(
             Some(LogLevel::Debug),
-            Some("handle_operation: SendGrpcRequest"),
+            Some("#2 send_grpc_request: unreachable-cluster envoy.service.ratelimit.v3.RateLimitService ShouldRateLimit 5s"),
         )
         // retrieving tracing headers
         .expect_get_header_map_value(Some(MapType::HttpRequestHeaders), Some("traceparent"))
@@ -121,10 +121,6 @@ fn it_runs_next_action_on_failure_when_failuremode_is_allow() {
             Some(5000),
         )
         .returning(Ok(first_call_token_id))
-        .expect_log(
-            Some(LogLevel::Debug),
-            Some("handle_operation: AwaitGrpcResponse"),
-        )
         .execute_and_expect(ReturnType::Action(Action::Pause))
         .unwrap();
 
@@ -138,7 +134,7 @@ fn it_runs_next_action_on_failure_when_failuremode_is_allow() {
         )
         .expect_log(
             Some(LogLevel::Debug),
-            Some("handle_operation: SendGrpcRequest"),
+            Some("#2 send_grpc_request: limitador-cluster envoy.service.ratelimit.v3.RateLimitService ShouldRateLimit 5s"),
         )
         .expect_grpc_call(
             Some("limitador-cluster"),
@@ -149,10 +145,6 @@ fn it_runs_next_action_on_failure_when_failuremode_is_allow() {
             Some(5000),
         )
         .returning(Ok(second_call_token_id))
-        .expect_log(
-            Some(LogLevel::Debug),
-            Some("handle_operation: AwaitGrpcResponse"),
-        )
         .execute_and_expect(ReturnType::None)
         .unwrap();
 
@@ -172,10 +164,6 @@ fn it_runs_next_action_on_failure_when_failuremode_is_allow() {
         .expect_log(
             Some(LogLevel::Debug),
             Some("process_response(rl): received OK response"),
-        )
-        .expect_log(
-            Some(LogLevel::Debug),
-            Some("handle_operation: Done"),
         )
         .execute_and_expect(ReturnType::None)
         .unwrap();
@@ -284,7 +272,7 @@ fn it_stops_on_failure_when_failuremode_is_deny() {
         )
         .expect_log(
             Some(LogLevel::Debug),
-            Some("handle_operation: SendGrpcRequest"),
+            Some("#2 send_grpc_request: unreachable-cluster envoy.service.ratelimit.v3.RateLimitService ShouldRateLimit 5s"),
         )
         // retrieving tracing headers
         .expect_get_header_map_value(Some(MapType::HttpRequestHeaders), Some("traceparent"))
@@ -302,10 +290,6 @@ fn it_stops_on_failure_when_failuremode_is_deny() {
             Some(5000),
         )
         .returning(Ok(42))
-        .expect_log(
-            Some(LogLevel::Debug),
-            Some("handle_operation: AwaitGrpcResponse"),
-        )
         .execute_and_expect(ReturnType::Action(Action::Pause))
         .unwrap();
 
@@ -315,10 +299,6 @@ fn it_stops_on_failure_when_failuremode_is_deny() {
         .expect_log(
             Some(LogLevel::Debug),
             Some(format!("#2 on_grpc_call_response: received gRPC call response: token: 42, status: {status_code}").as_str()),
-        )
-        .expect_log(
-            Some(LogLevel::Debug),
-            Some("handle_operation: Die"),
         )
         .expect_send_local_response(Some(500), None, None, None)
         .execute_and_expect(ReturnType::None)

--- a/tests/multi.rs
+++ b/tests/multi.rs
@@ -183,7 +183,7 @@ fn it_performs_authenticated_rate_limiting() {
         .returning(Some(data::source::port::P_45000))
         .expect_log(
             Some(LogLevel::Debug),
-            Some("handle_operation: SendGrpcRequest"),
+            Some("#2 send_grpc_request: authorino-cluster envoy.service.auth.v3.Authorization Check 5s"),
         )
         // retrieving tracing headers
         .expect_get_header_map_value(Some(MapType::HttpRequestHeaders), Some("traceparent"))
@@ -201,10 +201,6 @@ fn it_performs_authenticated_rate_limiting() {
             Some(5000),
         )
         .returning(Ok(42))
-        .expect_log(
-            Some(LogLevel::Debug),
-            Some("handle_operation: AwaitGrpcResponse"),
-        )
         .execute_and_expect(ReturnType::Action(Action::Pause))
         .unwrap();
 
@@ -225,10 +221,7 @@ fn it_performs_authenticated_rate_limiting() {
             Some(LogLevel::Debug),
             Some("process_response(auth): received OkHttpResponse"),
         )
-        .expect_log(
-            Some(LogLevel::Debug),
-            Some("handle_operation: SendGrpcRequest"),
-        )
+        .expect_log(Some(LogLevel::Debug), Some("#2 send_grpc_request: limitador-cluster envoy.service.ratelimit.v3.RateLimitService ShouldRateLimit 5s"))
         .expect_grpc_call(
             Some("limitador-cluster"),
             Some("envoy.service.ratelimit.v3.RateLimitService"),
@@ -238,10 +231,6 @@ fn it_performs_authenticated_rate_limiting() {
             Some(5000),
         )
         .returning(Ok(43))
-        .expect_log(
-            Some(LogLevel::Debug),
-            Some("handle_operation: AwaitGrpcResponse"),
-        )
         .execute_and_expect(ReturnType::None)
         .unwrap();
 
@@ -258,7 +247,6 @@ fn it_performs_authenticated_rate_limiting() {
             Some(LogLevel::Debug),
             Some("process_response(rl): received OK response"),
         )
-        .expect_log(Some(LogLevel::Debug), Some("handle_operation: Done"))
         .execute_and_expect(ReturnType::None)
         .unwrap();
 
@@ -401,7 +389,7 @@ fn unauthenticated_does_not_ratelimit() {
         .returning(Some(data::source::port::P_45000))
         .expect_log(
             Some(LogLevel::Debug),
-            Some("handle_operation: SendGrpcRequest"),
+            Some("#2 send_grpc_request: authorino-cluster envoy.service.auth.v3.Authorization Check 5s"),
         )
         // retrieving tracing headers
         .expect_get_header_map_value(Some(MapType::HttpRequestHeaders), Some("traceparent"))
@@ -419,10 +407,6 @@ fn unauthenticated_does_not_ratelimit() {
             Some(5000),
         )
         .returning(Ok(42))
-        .expect_log(
-            Some(LogLevel::Debug),
-            Some("handle_operation: AwaitGrpcResponse"),
-        )
         .execute_and_expect(ReturnType::Action(Action::Pause))
         .unwrap();
 
@@ -450,7 +434,6 @@ fn unauthenticated_does_not_ratelimit() {
             Some(LogLevel::Debug),
             Some("process_response(auth): received DeniedHttpResponse"),
         )
-        .expect_log(Some(LogLevel::Debug), Some("handle_operation: Die"))
         .expect_send_local_response(
             Some(401),
             None,
@@ -670,7 +653,7 @@ fn authenticated_one_ratelimit_action_matches() {
         .returning(Some(data::source::port::P_45000))
         .expect_log(
             Some(LogLevel::Debug),
-            Some("handle_operation: SendGrpcRequest"),
+            Some("#2 send_grpc_request: authorino-cluster envoy.service.auth.v3.Authorization Check 5s"),
         )
         // retrieving tracing headers
         .expect_get_header_map_value(Some(MapType::HttpRequestHeaders), Some("traceparent"))
@@ -688,10 +671,6 @@ fn authenticated_one_ratelimit_action_matches() {
             Some(5000),
         )
         .returning(Ok(42))
-        .expect_log(
-            Some(LogLevel::Debug),
-            Some("handle_operation: AwaitGrpcResponse"),
-        )
         .execute_and_expect(ReturnType::Action(Action::Pause))
         .unwrap();
 
@@ -727,7 +706,7 @@ fn authenticated_one_ratelimit_action_matches() {
         .returning(Some("1.2.3.4:80".as_bytes()))
         .expect_log(
             Some(LogLevel::Debug),
-            Some("handle_operation: SendGrpcRequest"),
+            Some("#2 send_grpc_request: limitador-cluster envoy.service.ratelimit.v3.RateLimitService ShouldRateLimit 5s"),
         )
         .expect_grpc_call(
             Some("limitador-cluster"),
@@ -738,10 +717,6 @@ fn authenticated_one_ratelimit_action_matches() {
             Some(5000),
         )
         .returning(Ok(43))
-        .expect_log(
-            Some(LogLevel::Debug),
-            Some("handle_operation: AwaitGrpcResponse"),
-        )
         .execute_and_expect(ReturnType::None)
         .unwrap();
 
@@ -758,7 +733,6 @@ fn authenticated_one_ratelimit_action_matches() {
             Some(LogLevel::Debug),
             Some("process_response(rl): received OK response"),
         )
-        .expect_log(Some(LogLevel::Debug), Some("handle_operation: Done"))
         .execute_and_expect(ReturnType::None)
         .unwrap();
 

--- a/tests/multi.rs
+++ b/tests/multi.rs
@@ -700,12 +700,6 @@ fn authenticated_one_ratelimit_action_matches() {
         .returning(Some("1.2.3.4:80".as_bytes()))
         .expect_log(
             Some(LogLevel::Debug),
-            Some("get_property: path: [\"source\", \"address\"]"),
-        )
-        .expect_get_property(Some(vec!["source", "address"]))
-        .returning(Some("1.2.3.4:80".as_bytes()))
-        .expect_log(
-            Some(LogLevel::Debug),
             Some("#2 send_grpc_request: limitador-cluster envoy.service.ratelimit.v3.RateLimitService ShouldRateLimit 5s"),
         )
         .expect_grpc_call(

--- a/tests/rate_limited.rs
+++ b/tests/rate_limited.rs
@@ -164,10 +164,7 @@ fn it_limits() {
             Some(LogLevel::Debug),
             Some("#2 action_set selected some-name"),
         )
-        .expect_log(
-            Some(LogLevel::Debug),
-            Some("handle_operation: SendGrpcRequest"),
-        )
+        .expect_log(Some(LogLevel::Debug), Some("#2 send_grpc_request: limitador-cluster envoy.service.ratelimit.v3.RateLimitService ShouldRateLimit 5s"))
         // retrieving tracing headers
         .expect_get_header_map_value(Some(MapType::HttpRequestHeaders), Some("traceparent"))
         .returning(None)
@@ -184,10 +181,6 @@ fn it_limits() {
             Some(5000),
         )
         .returning(Ok(42))
-        .expect_log(
-            Some(LogLevel::Debug),
-            Some("handle_operation: AwaitGrpcResponse"),
-        )
         .execute_and_expect(ReturnType::Action(Action::Pause))
         .unwrap();
 
@@ -204,7 +197,6 @@ fn it_limits() {
             Some(LogLevel::Debug),
             Some("process_response(rl): received OK response"),
         )
-        .expect_log(Some(LogLevel::Debug), Some("handle_operation: Done"))
         .execute_and_expect(ReturnType::None)
         .unwrap();
 
@@ -318,7 +310,7 @@ fn it_passes_additional_headers() {
         )
         .expect_log(
             Some(LogLevel::Debug),
-            Some("handle_operation: SendGrpcRequest"),
+            Some("#2 send_grpc_request: limitador-cluster envoy.service.ratelimit.v3.RateLimitService ShouldRateLimit 5s"),
         )
         // retrieving tracing headers
         .expect_get_header_map_value(Some(MapType::HttpRequestHeaders), Some("traceparent"))
@@ -336,10 +328,6 @@ fn it_passes_additional_headers() {
             Some(5000),
         )
         .returning(Ok(42))
-        .expect_log(
-            Some(LogLevel::Debug),
-            Some("handle_operation: AwaitGrpcResponse"),
-        )
         .execute_and_expect(ReturnType::Action(Action::Pause))
         .unwrap();
 
@@ -360,8 +348,6 @@ fn it_passes_additional_headers() {
             Some(LogLevel::Debug),
             Some("process_response(rl): received OK response"),
         )
-        .expect_log(Some(LogLevel::Debug), Some("handle_operation: AddHeaders"))
-        .expect_log(Some(LogLevel::Debug), Some("handle_operation: Done"))
         .execute_and_expect(ReturnType::None)
         .unwrap();
 
@@ -461,7 +447,7 @@ fn it_rate_limits_with_empty_predicates() {
         )
         .expect_log(
             Some(LogLevel::Debug),
-            Some("handle_operation: SendGrpcRequest"),
+            Some("#2 send_grpc_request: limitador-cluster envoy.service.ratelimit.v3.RateLimitService ShouldRateLimit 5s"),
         )
         // retrieving tracing headers
         .expect_get_header_map_value(Some(MapType::HttpRequestHeaders), Some("traceparent"))
@@ -479,10 +465,6 @@ fn it_rate_limits_with_empty_predicates() {
             Some(5000),
         )
         .returning(Ok(42))
-        .expect_log(
-            Some(LogLevel::Debug),
-            Some("handle_operation: AwaitGrpcResponse"),
-        )
         .execute_and_expect(ReturnType::Action(Action::Pause))
         .unwrap();
 
@@ -499,7 +481,6 @@ fn it_rate_limits_with_empty_predicates() {
             Some(LogLevel::Debug),
             Some("process_response(rl): received OK response"),
         )
-        .expect_log(Some(LogLevel::Debug), Some("handle_operation: Done"))
         .execute_and_expect(ReturnType::None)
         .unwrap();
 
@@ -594,7 +575,6 @@ fn it_does_not_rate_limits_when_predicates_does_not_match() {
             Some(LogLevel::Debug),
             Some("build_message(rl): empty descriptors"),
         )
-        .expect_log(Some(LogLevel::Debug), Some("handle_operation: Done"))
         .execute_and_expect(ReturnType::Action(Action::Continue))
         .unwrap();
 
@@ -709,7 +689,7 @@ fn it_folds_subsequent_actions_to_limitador_into_a_single_one() {
         )
         .expect_log(
             Some(LogLevel::Debug),
-            Some("handle_operation: SendGrpcRequest"),
+            Some("#2 send_grpc_request: limitador-cluster envoy.service.ratelimit.v3.RateLimitService ShouldRateLimit 5s"),
         )
         // retrieving tracing headers
         .expect_get_header_map_value(Some(MapType::HttpRequestHeaders), Some("traceparent"))
@@ -727,10 +707,6 @@ fn it_folds_subsequent_actions_to_limitador_into_a_single_one() {
             Some(5000),
         )
         .returning(Ok(42))
-        .expect_log(
-            Some(LogLevel::Debug),
-            Some("handle_operation: AwaitGrpcResponse"),
-        )
         .execute_and_expect(ReturnType::Action(Action::Pause))
         .unwrap();
 
@@ -747,7 +723,6 @@ fn it_folds_subsequent_actions_to_limitador_into_a_single_one() {
             Some(LogLevel::Debug),
             Some("process_response(rl): received OK response"),
         )
-        .expect_log(Some(LogLevel::Debug), Some("handle_operation: Done"))
         .execute_and_expect(ReturnType::None)
         .unwrap();
 

--- a/tests/remote_address.rs
+++ b/tests/remote_address.rs
@@ -104,7 +104,7 @@ fn it_limits_based_on_source_address() {
         .returning(Some(data::source::ADDRESS))
         .expect_log(
             Some(LogLevel::Debug),
-            Some("handle_operation: SendGrpcRequest"),
+            Some("#2 send_grpc_request: limitador-cluster envoy.service.ratelimit.v3.RateLimitService ShouldRateLimit 5s"),
         )
         // retrieving tracing headers
         .expect_get_header_map_value(Some(MapType::HttpRequestHeaders), Some("traceparent"))
@@ -126,10 +126,6 @@ fn it_limits_based_on_source_address() {
             Some(5000),
         )
         .returning(Ok(42))
-        .expect_log(
-            Some(LogLevel::Debug),
-            Some("handle_operation: AwaitGrpcResponse"),
-        )
         .execute_and_expect(ReturnType::Action(Action::Pause))
         .unwrap();
 
@@ -146,7 +142,6 @@ fn it_limits_based_on_source_address() {
             Some(LogLevel::Debug),
             Some("process_response(rl): received OK response"),
         )
-        .expect_log(Some(LogLevel::Debug), Some("handle_operation: Done"))
         .execute_and_expect(ReturnType::None)
         .unwrap();
 

--- a/tests/remote_address.rs
+++ b/tests/remote_address.rs
@@ -98,12 +98,6 @@ fn it_limits_based_on_source_address() {
         // retrieving properties for data
         .expect_log(
             Some(LogLevel::Debug),
-            Some("get_property: path: [\"source\", \"address\"]"),
-        )
-        .expect_get_property(Some(vec!["source", "address"]))
-        .returning(Some(data::source::ADDRESS))
-        .expect_log(
-            Some(LogLevel::Debug),
             Some("#2 send_grpc_request: limitador-cluster envoy.service.ratelimit.v3.RateLimitService ShouldRateLimit 5s"),
         )
         // retrieving tracing headers


### PR DESCRIPTION
### What

Sharing the "request context" with the CEL evaluation context, ensuring the relevant data is accessible when expressions are evaluated. This means that before evaluating a CEL expression, the Kuadrant filter will prepare and inject any necessary context. If the expression depends on the request or response body, the filter will read it and include it in the context accordingly.

This PR lays the groundwork for making the request and response bodies available during CEL evaluation.

A shared request context is introduced, represented as a `HashMap<Path, Value>`. Its scope is limited to a single request, so it resides within the Kuadrant filter struct. This context must be passed to CEL expression instances as a mutable reference, since it stores resolved paths for reuse in future evaluations.

Additionally, the Kuadrant filter has been refactored to take ownership of running the action workflow. This simplifies sharing the request context with CEL expressions and also resolves some inconsistencies, such as the following:

```rust
Operation::Done() => {
    debug!("handle_operation: Done");
    self.add_request_headers();
    let _ = self.resume_http_request();
    Action::Continue
}
```

This code is problematic, as a filter must either return an Action variant or call `resume_http_request()`, doing both simultaneously is incorrect.

Another issue being fixed is that denied responses are not handled as errors.

In summary: “Easy changes to make the change easy.”

Related PR: https://github.com/Kuadrant/wasm-shim/pull/190