### PR TITLE
Replace protobuf v2 with prost

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -76,7 +76,7 @@ checksum = "721cae7de5c34fbb2acd27e21e6d2cf7b886dce0c27388d46c4e6c47ea4318dd"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -164,6 +164,12 @@ name = "byteorder"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
+
+[[package]]
+name = "bytes"
+version = "1.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
 
 [[package]]
 name = "cc"
@@ -1043,6 +1049,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7843ec2de400bcbc6a6328c958dc38e5359da6e93e72e37bc5246bf1ae776389"
 
 [[package]]
+name = "multimap"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d87ecb2933e8aeadb3e3a02b828fed80a7528047e68b4f424523a0981a3a084"
+
+[[package]]
 name = "new_debug_unreachable"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1197,6 +1209,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "925383efa346730478fb4838dbe9137d2a47675ad789c546d150a6e1dd4ab31c"
 
 [[package]]
+name = "prettyplease"
+version = "0.2.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64d1ec885c64d0457d564db4ec299b2dae3f9c02808b8ad9c3a089c591b18033"
+dependencies = [
+ "proc-macro2",
+ "syn 2.0.87",
+]
+
+[[package]]
 name = "proc-macro-error"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1230,44 +1252,55 @@ dependencies = [
 ]
 
 [[package]]
-name = "protobuf"
-version = "2.28.0"
+name = "prost"
+version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "106dd99e98437432fed6519dedecfade6a06a73bb7b2a1e019fdd2bee5778d94"
+checksum = "7231bd9b3d3d33c86b58adbac74b5ec0ad9f496b19d22801d773636feaa95f3d"
 dependencies = [
- "serde",
- "serde_derive",
+ "bytes",
+ "prost-derive",
 ]
 
 [[package]]
-name = "protobuf-codegen"
-version = "2.28.0"
+name = "prost-build"
+version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "033460afb75cf755fcfc16dfaed20b86468082a2ea24e05ac35ab4a099a017d6"
+checksum = "ac6c3320f9abac597dcbc668774ef006702672474aad53c6d596b62e487b40b1"
 dependencies = [
- "protobuf",
-]
-
-[[package]]
-name = "protoc"
-version = "2.28.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0218039c514f9e14a5060742ecd50427f8ac4f85a6dc58f2ddb806e318c55ee"
-dependencies = [
+ "heck 0.4.1",
+ "itertools 0.13.0",
  "log",
- "which",
+ "multimap",
+ "once_cell",
+ "petgraph",
+ "prettyplease",
+ "prost",
+ "prost-types",
+ "regex",
+ "syn 2.0.87",
+ "tempfile",
 ]
 
 [[package]]
-name = "protoc-rust"
-version = "2.28.0"
+name = "prost-derive"
+version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22f8a182bb17c485f20bdc4274a8c39000a61024cfe461c799b50fec77267838"
+checksum = "9120690fafc389a67ba3803df527d0ec9cbbc9cc45e4cc20b332996dfb672425"
 dependencies = [
- "protobuf",
- "protobuf-codegen",
- "protoc",
- "tempfile",
+ "anyhow",
+ "itertools 0.13.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.87",
+]
+
+[[package]]
+name = "prost-types"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9b4db3d6da204ed77bb26ba83b6122a73aeb2e87e25fbf7ad2e84c4ccbf8f72"
+dependencies = [
+ "prost",
 ]
 
 [[package]]
@@ -1567,7 +1600,7 @@ checksum = "243902eda00fad750862fc144cea25caca5e20d615af0a81bee94ca738f1df1f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -1604,7 +1637,7 @@ checksum = "91d129178576168c589c9ec973feedf7d3126c01ac2bf08795109aa35b69fb8f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -1723,9 +1756,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.79"
+version = "2.0.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89132cd0bf050864e1d38dc3bbc07a0eb8e7530af26344d3d2bbbef83499f590"
+checksum = "25aa4ce346d03a6dcd68dd8b4010bcb74e54e62c90c573f394c46eae99aba32d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1796,7 +1829,7 @@ checksum = "08904e7672f5eb876eaaf87e0ce17857500934f4981c4a0ab2b4aa98baac7fc3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -1944,8 +1977,9 @@ dependencies = [
  "const_format",
  "lazy_static",
  "log",
- "protobuf",
- "protoc-rust",
+ "prost",
+ "prost-build",
+ "prost-types",
  "proxy-wasm",
  "proxy-wasm-test-framework",
  "radix_trie",
@@ -2216,18 +2250,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "which"
-version = "4.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87ba24419a2078cd2b0f2ede2691b6c66d8e47836da3b6db8265ebad47afbfc7"
-dependencies = [
- "either",
- "home",
- "once_cell",
- "rustix 0.38.37",
-]
-
-[[package]]
 name = "winapi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2439,7 +2461,7 @@ checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.87",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,8 +16,7 @@ readme = "README.md"
 crate-type = ["cdylib"]
 
 [features]
-default = ["with-serde"]
-with-serde = ["protobuf/with-serde"]
+default = []
 debug-host-behaviour = []
 
 [dependencies]
@@ -25,7 +24,8 @@ proxy-wasm = { git = "https://github.com/Kuadrant/proxy-wasm-rust-sdk.git", bran
 serde_json = "1.0"
 log = "0.4"
 serde = { version = "1.0", features = ["derive"] }
-protobuf = { version = "2.27", features = ["with-serde"] }
+prost = "0.14"
+prost-types = "0.14"
 radix_trie = "0.2.1"
 const_format = "0.2.31"
 chrono = { version = "0.4.38", default-features = false, features = ["alloc", "std"] }
@@ -39,7 +39,7 @@ proxy-wasm-test-framework = { git = "https://github.com/Kuadrant/wasm-test-frame
 serial_test = "2.0.0"
 
 [build-dependencies]
-protoc-rust = "2.27"
+prost-build = "0.14"
 
 [lints.clippy]
 panic = "deny"

--- a/src/envoy/mod.rs
+++ b/src/envoy/mod.rs
@@ -1,49 +1,115 @@
-mod address;
-mod attribute_context;
-mod authority;
-mod backoff;
-mod base;
-mod config_source;
-mod context_params;
-mod custom_tag;
-mod extension;
-mod external_auth;
-mod grpc_service;
-mod http_status;
-mod http_uri;
-mod matcher;
-mod metadata;
-mod number;
-mod percent;
-mod proxy_protocol;
-mod range;
-mod ratelimit;
-mod ratelimit_unit;
-mod regex;
-mod rls;
-mod route_components;
-mod semantic_version;
-mod socket_option;
-mod status;
-mod string;
-mod timestamp;
-mod token_bucket;
-mod value;
+// Generated protobuf modules
+pub mod envoy {
+    pub mod config {
+        pub mod common {
+            pub mod matcher {
+                pub mod v3 {
+                    include!("envoy.config.common.matcher.v3.rs");
+                }
+            }
+        }
+        pub mod core {
+            pub mod v3 {
+                include!("envoy.config.core.v3.rs");
+            }
+        }
+        pub mod route {
+            pub mod v3 {
+                include!("envoy.config.route.v3.rs");
+            }
+        }
+    }
+    pub mod extensions {
+        pub mod common {
+            pub mod ratelimit {
+                pub mod v3 {
+                    include!("envoy.extensions.common.ratelimit.v3.rs");
+                }
+            }
+        }
+    }
+    pub mod service {
+        pub mod auth {
+            pub mod v3 {
+                include!("envoy.service.auth.v3.rs");
+            }
+        }
+        pub mod ratelimit {
+            pub mod v3 {
+                include!("envoy.service.ratelimit.v3.rs");
+            }
+        }
+    }
+    pub mod r#type {
+        pub mod matcher {
+            pub mod v3 {
+                include!("envoy.r#type.matcher.v3.rs");
+            }
+        }
+        pub mod metadata {
+            pub mod v3 {
+                include!("envoy.r#type.metadata.v3.rs");
+            }
+        }
+        pub mod tracing {
+            pub mod v3 {
+                include!("envoy.r#type.tracing.v3.rs");
+            }
+        }
+        pub mod v3 {
+            include!("envoy.r#type.v3.rs");
+        }
+    }
+}
 
-pub use {
-    address::{Address, SocketAddress},
-    attribute_context::{
-        AttributeContext, AttributeContext_HttpRequest, AttributeContext_Peer,
-        AttributeContext_Request,
-    },
-    base::{HeaderValue, HeaderValueOption, Metadata},
-    external_auth::{
-        CheckRequest, CheckResponse, CheckResponse_oneof_http_response, DeniedHttpResponse,
-    },
-    http_status::StatusCode,
-    ratelimit::{RateLimitDescriptor, RateLimitDescriptor_Entry},
-    rls::{RateLimitRequest, RateLimitResponse, RateLimitResponse_Code},
+pub mod google {
+    pub mod rpc {
+        include!("google.rpc.rs");
+    }
+}
+
+pub mod udpa {
+    pub mod annotations {
+        include!("udpa.annotations.rs");
+    }
+}
+
+pub mod xds {
+    pub mod annotations {
+        pub mod v3 {
+            include!("xds.annotations.v3.rs");
+        }
+    }
+    pub mod core {
+        pub mod v3 {
+            include!("xds.core.v3.rs");
+        }
+    }
+    pub mod r#type {
+        pub mod matcher {
+            pub mod v3 {
+                include!("xds.r#type.matcher.v3.rs");
+            }
+        }
+    }
+}
+
+pub mod validate {
+    include!("validate.rs");
+}
+
+pub use envoy::config::core::v3::{
+    address, socket_address, Address, HeaderValue, HeaderValueOption, Metadata, SocketAddress,
 };
+pub use envoy::extensions::common::ratelimit::v3::{rate_limit_descriptor, RateLimitDescriptor};
+pub use envoy::r#type::v3::StatusCode;
+pub use envoy::service::auth::v3::{
+    attribute_context, check_response, AttributeContext, CheckRequest, CheckResponse,
+    DeniedHttpResponse,
+};
+pub use envoy::service::ratelimit::v3::{rate_limit_response, RateLimitRequest, RateLimitResponse};
 
 #[cfg(test)]
-pub use {external_auth::OkHttpResponse, http_status::HttpStatus};
+pub use envoy::r#type::v3::HttpStatus;
+#[cfg(test)]
+pub use envoy::service::auth::v3::OkHttpResponse;

--- a/src/envoy/mod.rs
+++ b/src/envoy/mod.rs
@@ -1,4 +1,12 @@
 // Generated protobuf modules
+#[allow(
+    dead_code,
+    clippy::module_inception,
+    clippy::enum_variant_names,
+    clippy::doc_overindented_list_items,
+    clippy::doc_lazy_continuation,
+    clippy::large_enum_variant
+)]
 pub mod envoy {
     pub mod config {
         pub mod common {
@@ -62,18 +70,21 @@ pub mod envoy {
     }
 }
 
+#[allow(dead_code)]
 pub mod google {
     pub mod rpc {
         include!("google.rpc.rs");
     }
 }
 
+#[allow(dead_code)]
 pub mod udpa {
     pub mod annotations {
         include!("udpa.annotations.rs");
     }
 }
 
+#[allow(dead_code)]
 pub mod xds {
     pub mod annotations {
         pub mod v3 {
@@ -94,6 +105,7 @@ pub mod xds {
     }
 }
 
+#[allow(dead_code, clippy::enum_variant_names)]
 pub mod validate {
     include!("validate.rs");
 }

--- a/src/filter/kuadrant_filter.rs
+++ b/src/filter/kuadrant_filter.rs
@@ -95,10 +95,10 @@ impl Context for KuadrantFilter {
                                         self.send_direct_response(direct_response);
                                     }
                                 }
-                                Err(ProcessGrpcMessageError::Protobuf(e)) => {
+                                Err(ProcessGrpcMessageError::Decode(e)) => {
                                     // processing the response failed
                                     // The action failure mode is set to deny, so we log the error and die
-                                    debug!("ProtobufError while processing grpc response: {e:?}");
+                                    debug!("DecodeError while processing grpc response: {e:?}");
                                     self.die();
                                 }
                                 Err(ProcessGrpcMessageError::Property(e)) => {

--- a/src/runtime_action.rs
+++ b/src/runtime_action.rs
@@ -3,6 +3,7 @@ use crate::configuration::{Action, FailureMode, Service, ServiceType};
 use crate::data::{
     Attribute, AttributeOwner, AttributeResolver, Expression, Predicate, PredicateResult,
 };
+use crate::envoy::{CheckResponse, RateLimitResponse};
 use crate::filter::operations::{
     EventualOperation, ProcessGrpcMessageOperation, ProcessNextRequestOperation,
 };
@@ -12,7 +13,7 @@ use crate::service::auth::AuthService;
 use crate::service::errors::{BuildMessageError, ProcessGrpcMessageError};
 use crate::service::{GrpcRequest, GrpcService};
 use log::debug;
-use protobuf::Message;
+use prost::Message;
 use std::collections::HashMap;
 use std::rc::Rc;
 
@@ -135,11 +136,11 @@ impl RuntimeAction {
     pub fn process_response(&self, msg: &[u8]) -> ResponseResult {
         let res = match self {
             Self::Auth(auth_action) => {
-                let check_response = Message::parse_from_bytes(msg)?;
+                let check_response = CheckResponse::decode(msg)?;
                 auth_action.process_response(check_response)
             }
             Self::RateLimit(rl_action) => {
-                let rate_limit_response = Message::parse_from_bytes(msg)?;
+                let rate_limit_response = RateLimitResponse::decode(msg)?;
                 rl_action.process_response(rate_limit_response)
             }
         };

--- a/src/service/auth.rs
+++ b/src/service/auth.rs
@@ -1,15 +1,15 @@
 use crate::data::{get_attribute, AttributeResolver, Expression, PropError, PropertyError};
 use crate::envoy::{
-    Address, AttributeContext, AttributeContext_HttpRequest, AttributeContext_Peer,
-    AttributeContext_Request, CheckRequest, DeniedHttpResponse, Metadata, SocketAddress,
+    address, attribute_context, socket_address, Address, AttributeContext, CheckRequest,
+    DeniedHttpResponse, Metadata, SocketAddress, StatusCode,
 };
 use crate::service::errors::BuildMessageError;
 use crate::service::DirectResponse;
 use cel_interpreter::Value;
 use chrono::{DateTime, FixedOffset};
 use log::{debug, log_enabled};
-use protobuf::well_known_types::{Struct, Timestamp};
-use protobuf::Message;
+use prost::Message;
+use prost_types::{Struct, Timestamp};
 use proxy_wasm::hostcalls;
 use proxy_wasm::types::MapType;
 use std::collections::HashMap;
@@ -20,13 +20,19 @@ pub const AUTH_METHOD_NAME: &str = "Check";
 
 impl From<DeniedHttpResponse> for DirectResponse {
     fn from(resp: DeniedHttpResponse) -> Self {
-        let status_code = resp.get_status().get_code();
+        let status_code = resp
+            .status
+            .as_ref()
+            .map(|s| s.code)
+            .unwrap_or(StatusCode::Forbidden as i32);
         let response_headers = resp
-            .get_headers()
+            .headers
             .iter()
-            .map(|header| {
-                let hv = header.get_header();
-                (hv.key.to_owned(), hv.value.to_owned())
+            .filter_map(|header| {
+                header
+                    .header
+                    .as_ref()
+                    .map(|hv| (hv.key.to_owned(), hv.value.to_owned()))
             })
             .collect();
         Self::new(status_code as u32, response_headers, resp.body)
@@ -57,10 +63,9 @@ impl AuthService {
     where
         T: AttributeResolver,
     {
-        Self::request_message(ce_host, request_data, resolver)
+        Ok(Self::request_message(ce_host, request_data, resolver)
             .map_err(BuildMessageError::Property)?
-            .write_to_bytes()
-            .map_err(BuildMessageError::Serialization)
+            .encode_to_vec())
     }
 
     fn build_check_req<T>(
@@ -71,20 +76,18 @@ impl AuthService {
     where
         T: AttributeResolver,
     {
-        let mut auth_req = CheckRequest::default();
-        let mut attr = AttributeContext::default();
-        attr.set_request(AuthService::build_request()?);
-        attr.set_destination(AuthService::build_peer(
+        let request = AuthService::build_request()?;
+        let destination = AuthService::build_peer(
             get_attribute::<String>(&"destination.address".into())?.unwrap_or_default(),
             get_attribute::<i64>(&"destination.port".into())?.unwrap_or_default() as u32,
-        ));
-        attr.set_source(AuthService::build_peer(
+        );
+        let source = AuthService::build_peer(
             get_attribute::<String>(&"source.address".into())?.unwrap_or_default(),
             get_attribute::<i64>(&"source.port".into())?.unwrap_or_default() as u32,
-        ));
+        );
         // the ce_host is the identifier for authorino to determine which authconfig to use
         let context_extensions = HashMap::from([("host".to_string(), ce_host)]);
-        attr.set_context_extensions(context_extensions);
+
         let mut metadata = Metadata::default();
         if !request_data.is_empty() {
             let mut by_domain = HashMap::new();
@@ -101,43 +104,36 @@ impl AuthService {
                     .into_iter()
                     .for_each(|(field, expr)| match expr.eval(resolver) {
                         Ok(Value::Null) | Err(_) => {
-                            let mut value = protobuf::well_known_types::Value::default();
-                            let mut cel_expr_struct = Struct::default();
-                            let mut cel_expr_field_value =
-                                protobuf::well_known_types::Value::default();
-                            cel_expr_field_value.set_string_value(expr.source().to_string());
-                            cel_expr_struct
-                                .mut_fields()
-                                .insert("cel_expr".to_string(), cel_expr_field_value);
-                            value.set_struct_value(cel_expr_struct);
-                            fields.mut_fields().insert(field.clone(), value);
+                            let cel_expr_field_value = prost_types::Value {
+                                kind: Some(prost_types::value::Kind::StringValue(
+                                    expr.source().to_string(),
+                                )),
+                            };
+                            let cel_expr_struct = Struct {
+                                fields: [("cel_expr".to_string(), cel_expr_field_value)].into(),
+                            };
+                            let value = prost_types::Value {
+                                kind: Some(prost_types::value::Kind::StructValue(cel_expr_struct)),
+                            };
+                            fields.fields.insert(field.clone(), value);
                         }
                         Ok(value) => {
-                            let mut f_value = protobuf::well_known_types::Value::default();
-                            if match value {
+                            if let Some(kind) = match value {
                                 Value::Int(i) => {
-                                    f_value.set_number_value(i as f64);
-                                    true
+                                    Some(prost_types::value::Kind::NumberValue(i as f64))
                                 }
                                 Value::UInt(u) => {
-                                    f_value.set_number_value(u as f64);
-                                    true
+                                    Some(prost_types::value::Kind::NumberValue(u as f64))
                                 }
-                                Value::Float(f) => {
-                                    f_value.set_number_value(f);
-                                    true
-                                }
+                                Value::Float(f) => Some(prost_types::value::Kind::NumberValue(f)),
                                 Value::String(s) => {
-                                    f_value.set_string_value(s.deref().clone());
-                                    true
+                                    Some(prost_types::value::Kind::StringValue(s.deref().clone()))
                                 }
-                                Value::Bool(b) => {
-                                    f_value.set_bool_value(b);
-                                    true
-                                }
-                                _ => false,
+                                Value::Bool(b) => Some(prost_types::value::Kind::BoolValue(b)),
+                                _ => None,
                             } {
-                                fields.mut_fields().insert(field.clone(), f_value);
+                                let f_value = prost_types::Value { kind: Some(kind) };
+                                fields.fields.insert(field.clone(), f_value);
                             }
                         }
                     });
@@ -147,21 +143,26 @@ impl AuthService {
                     format!("{KUADRANT_METADATA_PREFIX}.{domain}")
                 };
                 if log_enabled!(log::Level::Debug) {
-                    let mut fields = fields.get_fields().keys().collect::<Vec<_>>();
+                    let mut fields = fields.fields.keys().collect::<Vec<_>>();
                     fields.sort();
                     debug!("Adding data: `{data_key}` with entries: {fields:?}",);
                 }
                 metadata.filter_metadata.insert(data_key, fields);
             }
         }
-        attr.set_metadata_context(metadata);
-        auth_req.set_attributes(attr);
-        Ok(auth_req)
+
+        Ok(CheckRequest {
+            attributes: Some(AttributeContext {
+                request: Some(request),
+                destination: Some(destination),
+                source: Some(source),
+                context_extensions,
+                metadata_context: Some(metadata),
+            }),
+        })
     }
 
-    fn build_request() -> Result<AttributeContext_Request, PropertyError> {
-        let mut request = AttributeContext_Request::default();
-        let mut http = AttributeContext_HttpRequest::default();
+    fn build_request() -> Result<attribute_context::Request, PropertyError> {
         let headers: HashMap<String, String> = match hostcalls::get_map(MapType::HttpRequestHeaders)
         {
             Ok(header_map) => header_map.into_iter().collect(),
@@ -172,47 +173,55 @@ impl AuthService {
             }
         };
 
-        http.set_host(get_attribute::<String>(&"request.host".into())?.ok_or(
-            PropertyError::Get(PropError::new("request.host not set".to_string())),
-        )?);
-        http.set_method(get_attribute::<String>(&"request.method".into())?.ok_or(
+        let host = get_attribute::<String>(&"request.host".into())?.ok_or(PropertyError::Get(
+            PropError::new("request.host not set".to_string()),
+        ))?;
+        let method = get_attribute::<String>(&"request.method".into())?.ok_or(
             PropertyError::Get(PropError::new("request.method not set".to_string())),
-        )?);
-        http.set_scheme(get_attribute::<String>(&"request.scheme".into())?.ok_or(
+        )?;
+        let scheme = get_attribute::<String>(&"request.scheme".into())?.ok_or(
             PropertyError::Get(PropError::new("request.scheme not set".to_string())),
-        )?);
-        http.set_path(get_attribute::<String>(&"request.path".into())?.ok_or(
-            PropertyError::Get(PropError::new("request.path not set".to_string())),
-        )?);
-        http.set_protocol(get_attribute::<String>(&"request.protocol".into())?.ok_or(
+        )?;
+        let path = get_attribute::<String>(&"request.path".into())?.ok_or(PropertyError::Get(
+            PropError::new("request.path not set".to_string()),
+        ))?;
+        let protocol = get_attribute::<String>(&"request.protocol".into())?.ok_or(
             PropertyError::Get(PropError::new("request.protocol not set".to_string())),
-        )?);
+        )?;
 
-        http.set_headers(headers);
-        request.set_time(
-            get_attribute(&"request.time".into())?
-                .map(|date_time: DateTime<FixedOffset>| Timestamp {
-                    nanos: date_time.timestamp_subsec_nanos() as i32,
-                    seconds: date_time.timestamp(),
-                    unknown_fields: Default::default(),
-                    cached_size: Default::default(),
-                })
-                .ok_or(PropertyError::Get(PropError::new(
-                    "request.time not set".to_string(),
-                )))?,
-        );
-        request.set_http(http);
-        Ok(request)
+        let time = get_attribute(&"request.time".into())?
+            .map(|date_time: DateTime<FixedOffset>| Timestamp {
+                nanos: date_time.timestamp_subsec_nanos() as i32,
+                seconds: date_time.timestamp(),
+            })
+            .ok_or(PropertyError::Get(PropError::new(
+                "request.time not set".to_string(),
+            )))?;
+
+        Ok(attribute_context::Request {
+            time: Some(time),
+            http: Some(attribute_context::HttpRequest {
+                host,
+                method,
+                scheme,
+                path,
+                protocol,
+                headers,
+                ..Default::default()
+            }),
+        })
     }
 
-    fn build_peer(host: String, port: u32) -> AttributeContext_Peer {
-        let mut peer = AttributeContext_Peer::default();
-        let mut address = Address::default();
-        let mut socket_address = SocketAddress::default();
-        socket_address.set_address(host);
-        socket_address.set_port_value(port);
-        address.set_socket_address(socket_address);
-        peer.set_address(address);
-        peer
+    fn build_peer(host: String, port: u32) -> attribute_context::Peer {
+        attribute_context::Peer {
+            address: Some(Address {
+                address: Some(address::Address::SocketAddress(SocketAddress {
+                    address: host,
+                    port_specifier: Some(socket_address::PortSpecifier::PortValue(port)),
+                    ..Default::default()
+                })),
+            }),
+            ..Default::default()
+        }
     }
 }

--- a/src/service/rate_limit.rs
+++ b/src/service/rate_limit.rs
@@ -1,6 +1,6 @@
 use crate::envoy::{RateLimitDescriptor, RateLimitRequest};
 use crate::service::errors::BuildMessageError;
-use protobuf::{Message, RepeatedField};
+use prost::Message;
 
 pub const RATELIMIT_SERVICE_NAME: &str = "envoy.service.ratelimit.v3.RateLimitService";
 pub const RATELIMIT_METHOD_NAME: &str = "ShouldRateLimit";
@@ -14,46 +14,41 @@ pub struct RateLimitService;
 impl RateLimitService {
     pub fn request_message(
         domain: String,
-        descriptors: RepeatedField<RateLimitDescriptor>,
+        descriptors: Vec<RateLimitDescriptor>,
         hits_addend: u32,
     ) -> RateLimitRequest {
         RateLimitRequest {
             domain,
             descriptors,
             hits_addend,
-            unknown_fields: Default::default(),
-            cached_size: Default::default(),
         }
     }
 
     pub fn request_message_as_bytes(
         domain: String,
-        descriptors: RepeatedField<RateLimitDescriptor>,
+        descriptors: Vec<RateLimitDescriptor>,
         hits_addend: u32,
     ) -> Result<Vec<u8>, BuildMessageError> {
-        Self::request_message(domain, descriptors, hits_addend)
-            .write_to_bytes()
-            .map_err(BuildMessageError::Serialization)
+        Ok(Self::request_message(domain, descriptors, hits_addend).encode_to_vec())
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use crate::envoy::{RateLimitDescriptor, RateLimitDescriptor_Entry, RateLimitRequest};
+    use crate::envoy::{rate_limit_descriptor, RateLimitDescriptor, RateLimitRequest};
     use crate::service::rate_limit::RateLimitService;
-    //use crate::service::Service;
-    use protobuf::{CachedSize, RepeatedField, UnknownFields};
 
     fn build_message() -> RateLimitRequest {
         let domain = "rlp1";
-        let mut field = RateLimitDescriptor::new();
-        let mut entry = RateLimitDescriptor_Entry::new();
-        entry.set_key("key1".to_string());
-        entry.set_value("value1".to_string());
-        field.set_entries(RepeatedField::from_vec(vec![entry]));
-        let descriptors = RepeatedField::from_vec(vec![field]);
+        let mut field = RateLimitDescriptor::default();
+        let entry = rate_limit_descriptor::Entry {
+            key: "key1".to_string(),
+            value: "value1".to_string(),
+        };
+        field.entries = vec![entry];
+        let descriptors = vec![field];
 
-        RateLimitService::request_message(domain.to_string(), descriptors.clone(), 1)
+        RateLimitService::request_message(domain.to_string(), descriptors, 1)
     }
     #[test]
     fn builds_correct_message() {
@@ -77,7 +72,5 @@ mod tests {
                 .value,
             "value1"
         );
-        assert_eq!(msg.unknown_fields, UnknownFields::default());
-        assert_eq!(msg.cached_size, CachedSize::default());
     }
 }


### PR DESCRIPTION
Replaces the existing outdated protobuf v2 library with [prost](https://github.com/tokio-rs/prost), a different protobuf implementation that still leverages protoc but provides more idiomatic rust types