### PR TITLE
Default request/response headers to replace

### DIFF
--- a/src/filter/kuadrant_filter.rs
+++ b/src/filter/kuadrant_filter.rs
@@ -290,7 +290,8 @@ impl HttpContext for KuadrantFilter {
         // too late
         if let Some(response_headers) = self.response_headers_to_add.take() {
             for (header, value) in response_headers {
-                if let Err(status) = self.add_http_response_header(header.as_str(), value.as_str())
+                if let Err(status) =
+                    self.set_http_response_header(header.as_str(), Some(value.as_str()))
                 {
                     log::error!(
                         "#{} on_http_response_headers: failed to add headers: {:?}",
@@ -615,7 +616,9 @@ impl KuadrantFilter {
     fn add_request_headers(&mut self) {
         if let Some(request_headers) = self.request_headers_to_add.take() {
             for (header, value) in request_headers {
-                if let Err(status) = self.add_http_request_header(header.as_str(), value.as_str()) {
+                if let Err(status) =
+                    self.set_http_request_header(header.as_str(), Some(value.as_str()))
+                {
                     log::error!(
                         "add_http_request_headers failed for {}: {:?}",
                         &header,


### PR DESCRIPTION
Updates the default behaviour to replace existing headers rather than append (see [`proxy_replace_header_map_value`](https://github.com/proxy-wasm/spec/tree/main/abi-versions/v0.2.1#proxy_replace_header_map_value))

The issue below describes the defaults for `ext_authz`, and from what I can tell this is also the default for the ratelimit [implementation](https://github.com/envoyproxy/envoy/blob/main/source/extensions/filters/common/ratelimit/ratelimit_impl.cc#L107-L119).

When working on the refactor we'll have an easier time conditionally appending based on the request that we receive, but for now this default is for every message.

Resolves #231