### PR TITLE
Use token in workflows to avoid ratelimit

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -3,11 +3,11 @@ name: e2e tests
 
 on:
   push:
-    branches: ['main']
+    branches: ["main"]
   pull_request:
-    branches: ['*']
+    branches: ["*"]
   merge_group:
-    types: [ checks_requested ]
+    types: [checks_requested]
   workflow_dispatch:
 
 jobs:
@@ -15,56 +15,58 @@ jobs:
     name: Basic integration test
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
-    - uses: actions-rs/toolchain@v1
-      with:
-        profile: minimal
-        toolchain: stable
-        override: true
-        target: wasm32-unknown-unknown
-    - uses: arduino/setup-protoc@v1
-      with:
-        version: '3.x'
-    - uses: actions-rs/cargo@v1
-      with:
-        command: build
-        args: --target wasm32-unknown-unknown
-    - name: Run docker compose
-      run: |
-        docker compose -f ./e2e/basic/docker-compose.yaml run start_services
-    - name: Execute tests in the running services
-      run: |
-        make -f ./e2e/basic/Makefile test
+      - uses: actions/checkout@v4
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+          target: wasm32-unknown-unknown
+      - uses: arduino/setup-protoc@v3
+        with:
+          version: "3.x"
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+      - uses: actions-rs/cargo@v1
+        with:
+          command: build
+          args: --target wasm32-unknown-unknown
+      - name: Run docker compose
+        run: |
+          docker compose -f ./e2e/basic/docker-compose.yaml run start_services
+      - name: Execute tests in the running services
+        run: |
+          make -f ./e2e/basic/Makefile test
   remote_address:
     name: Remote address integration test
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
-    - uses: actions-rs/toolchain@v1
-      with:
-        profile: minimal
-        toolchain: stable
-        override: true
-        target: wasm32-unknown-unknown
-    - uses: arduino/setup-protoc@v1
-      with:
-        version: '3.x'
-    - uses: actions-rs/cargo@v1
-      with:
-        command: build
-        args: --target wasm32-unknown-unknown
-    - name: Run docker compose
-      run: |
-        docker compose -f ./e2e/remote-address/docker-compose.yaml run start_services
-    - name: Execute tests in the running services
-      run: |
-        make -f ./e2e/remote-address/Makefile test
+      - uses: actions/checkout@v4
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+          target: wasm32-unknown-unknown
+      - uses: arduino/setup-protoc@v3
+        with:
+          version: "3.x"
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+      - uses: actions-rs/cargo@v1
+        with:
+          command: build
+          args: --target wasm32-unknown-unknown
+      - name: Run docker compose
+        run: |
+          docker compose -f ./e2e/remote-address/docker-compose.yaml run start_services
+      - name: Execute tests in the running services
+        run: |
+          make -f ./e2e/remote-address/Makefile test
   required-checks:
     name: E2E Tests Required Checks
     # This check adds a list of checks to one job to simplify adding settings to the repo.
     # If a new check is added in this file, and it should be retested on entry to the merge queue,
     # it needs to be added to the list below aka needs: [ existing check 1, existing check 2, new check ].
-    needs: [ basic, remote_address ]
+    needs: [basic, remote_address]
     if: always()
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,5 +1,4 @@
 ---
-
 name: Release
 
 on:
@@ -21,9 +20,10 @@ jobs:
           toolchain: stable
           override: true
           target: wasm32-unknown-unknown
-      - uses: arduino/setup-protoc@v1
+      - uses: arduino/setup-protoc@v3
         with:
-          version: '3.x'
+          version: "3.x"
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
       - uses: actions-rs/cargo@v1
         with:
           command: build

--- a/.github/workflows/rust.yaml
+++ b/.github/workflows/rust.yaml
@@ -3,14 +3,14 @@ name: Rust
 
 on:
   push:
-    branches: ['main']
+    branches: ["main"]
   pull_request:
-    branches: ['*']
+    branches: ["*"]
   merge_group:
-    types: [ checks_requested ]
+    types: [checks_requested]
   workflow_dispatch:
   schedule:
-    - cron: '5 4 * * *'
+    - cron: "5 4 * * *"
 
 jobs:
   check:
@@ -24,9 +24,10 @@ jobs:
           toolchain: stable
           override: true
           target: wasm32-unknown-unknown
-      - uses: arduino/setup-protoc@v1
+      - uses: arduino/setup-protoc@v3
         with:
-          version: '3.x'
+          version: "3.x"
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
       - uses: actions-rs/cargo@v1
         with:
           command: check
@@ -44,7 +45,7 @@ jobs:
           target: wasm32-unknown-unknown
       - uses: arduino/setup-protoc@v1
         with:
-          version: '3.x'
+          version: "3.x"
       - uses: actions-rs/cargo@v1
         with:
           command: build
@@ -67,7 +68,7 @@ jobs:
           target: wasm32-unknown-unknown
       - uses: arduino/setup-protoc@v1
         with:
-          version: '3.x'
+          version: "3.x"
       - run: rustup component add clippy
       - uses: actions-rs/cargo@v1
         with:
@@ -78,7 +79,7 @@ jobs:
     # This check adds a list of checks to one job to simplify adding settings to the repo.
     # If a new check is added in this file, and it should be retested on entry to the merge queue,
     # it needs to be added to the list below aka needs: [ existing check 1, existing check 2, new check ].
-    needs: [ check, fmt, clippy ]
+    needs: [check, fmt, clippy]
     if: always()
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -3,11 +3,11 @@ name: Tests
 
 on:
   push:
-    branches: ['main']
+    branches: ["main"]
   pull_request:
-    branches: ['*']
+    branches: ["*"]
   merge_group:
-    types: [ checks_requested ]
+    types: [checks_requested]
   workflow_dispatch:
 
 jobs:
@@ -22,9 +22,10 @@ jobs:
           toolchain: stable
           override: true
           target: wasm32-unknown-unknown
-      - uses: arduino/setup-protoc@v1
+      - uses: arduino/setup-protoc@v3
         with:
-          version: '3.x'
+          version: "3.x"
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
       - uses: actions-rs/cargo@v1
         with:
           command: build
@@ -37,7 +38,7 @@ jobs:
     # This check adds a list of checks to one job to simplify adding settings to the repo.
     # If a new check is added in this file, and it should be retested on entry to the merge queue,
     # it needs to be added to the list below aka needs: [ existing check 1, existing check 2, new check ].
-    needs: [ test ]
+    needs: [test]
     if: always()
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
The protoc action is often being rate limited; trying to fix this using the repo token as [listed here](https://github.com/arduino/setup-protoc?tab=readme-ov-file#usage)

Also updated the action to v3