### PR TITLE
Fix host setting and lookup in cache

### DIFF
--- a/src/kuadrant/pipeline/tasks/auth.rs
+++ b/src/kuadrant/pipeline/tasks/auth.rs
@@ -239,7 +239,7 @@ fn process_metadata(s: &prost_types::Struct, prefix: String) -> Vec<(String, Vec
     let mut result = Vec::new();
 
     for (key, value) in &s.fields {
-        let current_path = format!("{}\\.{}", prefix, key);
+        let current_path = format!("{}.{}", prefix, key);
 
         match &value.kind {
             Some(Kind::StructValue(nested_struct)) => {


### PR DESCRIPTION
There was a couple bugs in the way we store and read from the cache; in particular with the way things are namespaced as well as the escaping. I've tried to make it consistent so that all props are stored at the location that you'd expect in the cache; BUT are escaped and namespaced when we hit the host

This makes it so:
- auth creates unescaped path `['auth', 'identity', 'userid']`
- we store it in the cache as the path `auth.identity.userid`
- we store it in the host, escaped and prefixed as `kuadrant\.auth\.identity\.userid` (envoy then _actually_ stores it under `filter_state.wasm\.{entry}`
- we lookup from the cache as `auth.identity.userid`
- If cache miss, we lookup from the host with escaped prefixed key `filter_state.wasm\.kuadrant\.auth\.identity\.userid`

This is fixing the authenticated rate limiting guide _and_ ensuring stored props are retrieved from the cache correctly and do not go to the host.