### PR TITLE
Run example envoy containers as root

### DIFF
--- a/e2e/basic/docker-compose.yaml
+++ b/e2e/basic/docker-compose.yaml
@@ -2,6 +2,9 @@
 services:
   envoy:
     image: envoyproxy/envoy:v1.35-latest
+    user: root
+    environment:
+      - ENVOY_UID=0
     depends_on:
       - limitador
       - upstream

--- a/e2e/remote-address/docker-compose.yaml
+++ b/e2e/remote-address/docker-compose.yaml
@@ -2,6 +2,9 @@
 services:
   envoy:
     image: envoyproxy/envoy:v1.35-latest
+    user: root
+    environment:
+      - ENVOY_UID=0
     depends_on:
       - limitador
       - upstream

--- a/examples/ratelimit/docker-compose.yaml
+++ b/examples/ratelimit/docker-compose.yaml
@@ -2,6 +2,9 @@
 services:
   envoy:
     image: envoyproxy/envoy:v1.35-latest
+    user: root
+    environment:
+      - ENVOY_UID=0
     depends_on:
       - limitador
       - upstream

--- a/examples/ratelimit_check_report/docker-compose.yaml
+++ b/examples/ratelimit_check_report/docker-compose.yaml
@@ -3,6 +3,9 @@ services:
   envoy:
     image: envoyproxy/envoy:v1.35-latest
     container_name: envoy
+    user: root
+    environment:
+      - ENVOY_UID=0
     depends_on:
       - limitador
       - upstream


### PR DESCRIPTION
On macOS get a permission denied error on the envoy containers when starting which causes the examples to fail

Can see more info here https://github.com/envoyproxy/envoy/issues/11551