### PR TITLE
Fix resume/pause logic

### DIFF
--- a/src/filter/kuadrant_filter.rs
+++ b/src/filter/kuadrant_filter.rs
@@ -4,13 +4,14 @@ use proxy_wasm::traits::{Context, HttpContext};
 use proxy_wasm::types::Action;
 use std::ops::Not;
 use std::rc::Rc;
-use tracing::{debug, error};
+use tracing::{debug, error, trace, warn};
 
 pub struct KuadrantFilter {
     context_id: u32,
     factory: Rc<PipelineFactory>,
     pipeline: Option<Pipeline>,
     in_response_phase: bool,
+    force_resume: bool,
 }
 
 impl KuadrantFilter {
@@ -20,11 +21,22 @@ impl KuadrantFilter {
             factory,
             pipeline: None,
             in_response_phase: false,
+            force_resume: false,
         }
     }
 
     fn should_pause(&self) -> bool {
         self.pipeline.as_ref().is_some_and(|p| p.requires_pause())
+    }
+
+    #[allow(clippy::expect_used)]
+    fn should_resume(&self) -> bool {
+        self.pipeline
+            .as_ref()
+            .expect("pipeline must be present")
+            .is_terminated()
+            .not()
+            && self.should_pause().not()
     }
 }
 
@@ -38,18 +50,25 @@ impl Context for KuadrantFilter {
             let should_resume = match pipeline.digest(token_id, status_code, response_size) {
                 PipelineState::InProgress(p) => {
                     self.pipeline = Some(*p);
-                    self.should_pause().not()
+                    self.should_resume()
                 }
                 PipelineState::Completed { should_resume } => {
                     self.pipeline = None;
-                    should_resume
+                    trace!(
+                        "#{} PipelineState::Completed: should_resume={}",
+                        self.context_id,
+                        should_resume
+                    );
+                    should_resume || self.force_resume
                 }
             };
 
             if should_resume {
                 let result = if self.in_response_phase {
+                    trace!("on_grpc_call_response: resume_http_response");
                     self.resume_http_response()
                 } else {
+                    trace!("on_grpc_call_response: resume_http_request");
                     self.resume_http_request()
                 };
 
@@ -60,6 +79,8 @@ impl Context for KuadrantFilter {
                     );
                 }
             }
+        } else {
+            warn!("#{} received response without a pipeline", self.context_id);
         }
     }
 }
@@ -86,8 +107,10 @@ impl HttpContext for KuadrantFilter {
                     }
                 }
                 if self.should_pause() {
+                    trace!("on_http_request_headers: pause");
                     Action::Pause
                 } else {
+                    trace!("on_http_request_headers: continue");
                     Action::Continue
                 }
             }
@@ -118,8 +141,10 @@ impl HttpContext for KuadrantFilter {
             }
         }
         if self.should_pause() {
+            trace!("on_http_request_body: pause");
             Action::Pause
         } else {
+            trace!("on_http_request_body: continue");
             Action::Continue
         }
     }
@@ -139,8 +164,10 @@ impl HttpContext for KuadrantFilter {
             }
         }
         if self.should_pause() {
+            trace!("on_http_response_headers: pause");
             Action::Pause
         } else {
+            trace!("on_http_response_headers: continue");
             Action::Continue
         }
     }
@@ -161,9 +188,17 @@ impl HttpContext for KuadrantFilter {
             }
         }
         if self.should_pause() {
+            trace!("on_http_response_body: pause");
             Action::Pause
         } else {
-            Action::Continue
+            if self.pipeline.is_some() && end_of_stream {
+                trace!("on_http_response_body: pipeline is some, pause");
+                self.force_resume = true;
+                Action::Pause
+            } else {
+                trace!("on_http_response_body: continue");
+                Action::Continue
+            }
         }
     }
 }

--- a/src/kuadrant/pipeline/executor.rs
+++ b/src/kuadrant/pipeline/executor.rs
@@ -1,4 +1,4 @@
-use tracing::error;
+use tracing::{error, trace};
 
 use crate::kuadrant::{
     pipeline::tasks::{
@@ -57,6 +57,10 @@ impl Pipeline {
         self
     }
 
+    pub fn is_terminated(&self) -> bool {
+        self.terminated
+    }
+
     fn replace_deferred_with_noop(&mut self) {
         // map existing deferred tasks to no-op consumers
         let deferred = std::mem::take(&mut self.deferred_tasks);
@@ -64,7 +68,7 @@ impl Pipeline {
             .into_iter()
             .map(|(token_id, task)| {
                 // Create a new PendingTask with no-op processor
-                let pending = Box::new(PendingTask::new(
+                let pending = Box::new(PendingTask::background(
                     task.id().unwrap_or_default(),
                     Box::new(noop_response_processor(token_id)),
                 )) as Box<dyn Task>;
@@ -80,7 +84,7 @@ impl Pipeline {
                 TeardownOutcome::Done => {}
                 TeardownOutcome::Deferred(token_id) => {
                     // Create a no-op PendingTask for this deferred teardown action
-                    let pending = Box::new(PendingTask::new(
+                    let pending = Box::new(PendingTask::background(
                         format!("teardown_{}", token_id),
                         Box::new(noop_response_processor(token_id)),
                     ));
@@ -195,7 +199,10 @@ impl Pipeline {
     }
 
     pub fn requires_pause(&self) -> bool {
-        let has_deferred = !self.deferred_tasks.is_empty();
+        let has_blocking_deferred = self
+            .deferred_tasks
+            .iter()
+            .any(|(_, task)| task.pauses_filter());
         let has_blocking = self.task_queue.iter().any(|task| {
             // Only consider tasks whose dependencies are met.
             // Tasks with unmet deps shouldn't block the filter since they're
@@ -206,8 +213,12 @@ impl Pipeline {
                 .all(|dep| self.completed_tasks.contains(dep));
             deps_met && task.pauses_filter()
         });
-
-        has_deferred || has_blocking
+        trace!(
+            "requires_pause: has_blocking_deferred={} || has_blocking={}",
+            has_blocking_deferred,
+            has_blocking
+        );
+        has_blocking_deferred || has_blocking
     }
 }
 
@@ -291,20 +302,38 @@ mod tests {
     }
 
     #[test]
-    fn requires_pause_returns_true_for_deferred_tasks() {
-        // Even with blocking task that has unmet deps, deferred tasks cause pause
+    fn requires_pause_returns_true_for_blocking_deferred_tasks() {
+        // Even with blocking task that has unmet deps, blocking deferred tasks cause pause
         let blocking_task = TestTask::new("blocker", vec!["auth"], true);
-        let deferred_task = TestTask::new("auth", vec![], false);
+        let deferred_task = TestTask::new("auth", vec![], true);
 
         let ctx = create_test_context();
         let mut pipeline = Pipeline::new(ctx);
         pipeline.task_queue.push(Box::new(blocking_task));
         pipeline.deferred_tasks.insert(42, Box::new(deferred_task));
 
-        // requires_pause should return TRUE because there's a deferred task
+        // requires_pause should return TRUE because there's a blocking deferred task
         assert!(
             pipeline.requires_pause(),
-            "requires_pause() should return true when deferred tasks exist"
+            "requires_pause() should return true when blocking deferred tasks exist"
+        );
+    }
+
+    #[test]
+    fn requires_pause_ignores_background_deferred_tasks() {
+        // Background deferred tasks (pauses_filter=false) should not cause pause
+        let background_task = TestTask::new("background", vec![], false);
+
+        let ctx = create_test_context();
+        let mut pipeline = Pipeline::new(ctx);
+        pipeline
+            .deferred_tasks
+            .insert(42, Box::new(background_task));
+
+        // requires_pause should return FALSE because background tasks don't pause
+        assert!(
+            !pipeline.requires_pause(),
+            "requires_pause() should ignore background deferred tasks"
         );
     }
 

--- a/src/kuadrant/pipeline/tasks/mod.rs
+++ b/src/kuadrant/pipeline/tasks/mod.rs
@@ -43,6 +43,7 @@ pub trait Task {
 pub struct PendingTask {
     task_id: String,
     process_response: Box<ResponseProcessor>,
+    pause: bool,
 }
 
 impl PendingTask {
@@ -50,6 +51,15 @@ impl PendingTask {
         Self {
             task_id,
             process_response,
+            pause: true,
+        }
+    }
+
+    pub fn background(task_id: String, process_response: Box<ResponseProcessor>) -> Self {
+        Self {
+            task_id,
+            process_response,
+            pause: false,
         }
     }
 }
@@ -62,7 +72,7 @@ impl Task for PendingTask {
         Some(self.task_id.clone())
     }
     fn pauses_filter(&self) -> bool {
-        true
+        self.pause
     }
 }
 

--- a/src/kuadrant/pipeline/tasks/ratelimit.rs
+++ b/src/kuadrant/pipeline/tasks/ratelimit.rs
@@ -245,7 +245,13 @@ impl RateLimitTask {
 impl Task for RateLimitTask {
     fn apply(self: Box<Self>, ctx: &mut ReqRespCtx) -> TaskOutcome {
         match self.predicates.apply(ctx) {
-            Ok(AttributeState::Pending) => return TaskOutcome::Requeued(vec![self]),
+            Ok(AttributeState::Pending) => {
+                return if ctx.is_end_of_stream() {
+                    TaskOutcome::Failed
+                } else {
+                    TaskOutcome::Requeued(vec![self])
+                };
+            }
             Ok(AttributeState::Available(false)) => return TaskOutcome::Done,
             Ok(AttributeState::Available(true)) => {}
             Err(e) => {
@@ -259,7 +265,11 @@ impl Task for RateLimitTask {
             Ok(AttributeState::Available(descriptors)) => descriptors,
             Ok(AttributeState::Pending) => {
                 // Need to wait for attributes, requeue
-                return TaskOutcome::Requeued(vec![self]);
+                return if ctx.is_end_of_stream() {
+                    TaskOutcome::Failed
+                } else {
+                    TaskOutcome::Requeued(vec![self])
+                };
             }
             Err(e) => {
                 error!("Failed to build descriptors: {e:?}");

--- a/tests/response_body.rs
+++ b/tests/response_body.rs
@@ -510,6 +510,7 @@ fn it_handles_errors_on_response_body() {
             Some(LogLevel::Warn),
             Some("Missing json property: /usage/total_tokens"),
         )
+        .expect_log(Some(LogLevel::Error), Some("Task failed: Some(\"0\")"))
         // on response headers/body, expected action is Continue
         .execute_and_expect(ReturnType::Action(Action::Continue))
         .unwrap();


### PR DESCRIPTION
Follows #321, #322

Fixes a bug in the pause/resume logic. Any deferred tasks now no longer pause the pipeline at the response headers phase but can continue into the last possible moment in the response body phase.