### PR TITLE
Use log::error for those prior to configuring tracing

### DIFF
--- a/src/filter/root_context.rs
+++ b/src/filter/root_context.rs
@@ -65,7 +65,7 @@ impl RootContext for FilterRoot {
                 None => return false,
             },
             Err(status) => {
-                error!("#{} on_configure: {:?}", self.context_id, status);
+                log::error!("#{} on_configure: {:?}", self.context_id, status);
                 return false;
             }
         };
@@ -89,7 +89,7 @@ impl RootContext for FilterRoot {
                 }
             }
             Err(e) => {
-                error!("failed to parse plugin config: {}", e);
+                log::error!("failed to parse plugin config: {}", e);
                 return false;
             }
         }

--- a/src/tracing/mod.rs
+++ b/src/tracing/mod.rs
@@ -65,6 +65,7 @@ pub fn init_observability(use_tracing: bool, log_level: Option<&str>) {
         if let Err(e) = otel_handle.reload(otel_filter) {
             log::error!("Failed to reload OpenTelemetry filter: {:?}", e);
         }
+        update_log_level();
     } else {
         // Initialise global tracing subscriber and store handles to the filters
         let processor_handle = processor::SpanProcessorHandle;


### PR DESCRIPTION
These two error messages are prior to the tracing configuration / occur if we fail to parse the configuration - they should use `log::`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Standardised internal error logging to use a consistent logging provider.
  * Ensured log-level updates occur after observability initialisation so runtime logging reflects the current settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->