### PR TITLE
Add Sector release workflow for WASM Shim

### DIFF
--- a/.github/actions/prepare-release/action.yaml
+++ b/.github/actions/prepare-release/action.yaml
@@ -1,0 +1,70 @@
+name: 'Prepare WASM Shim Release'
+description: 'Validate version, update Cargo files, create release branch, and set up Rust environment'
+
+inputs:
+  version:
+    description: 'WASM Shim version (semver, e.g., 0.12.1)'
+    required: true
+  push-branch:
+    description: 'Whether to push the base branch immediately if it does not exist'
+    required: false
+    default: 'false'
+  github-token:
+    description: 'GitHub token for protoc setup'
+    required: true
+
+outputs:
+  wasm-shim-version:
+    description: 'The validated WASM Shim version'
+    value: ${{ steps.validate.outputs.version }}
+  base-branch:
+    description: 'The base release branch name'
+    value: ${{ steps.create-branch.outputs.base-branch }}
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Validate and set version
+      id: validate
+      shell: bash
+      run: |
+        VERSION="${{ inputs.version }}"
+        if ! echo "$VERSION" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?(\+[0-9A-Za-z.-]+)?$'; then
+          echo "Error: wasmShimVersion must be valid semver format (e.g., 0.12.1, 0.13.0-rc1)"
+          exit 1
+        fi
+        echo "WASM_SHIM_VERSION=$VERSION" >> $GITHUB_ENV
+        echo "version=$VERSION" >> $GITHUB_OUTPUT
+
+    - name: Create release branch
+      id: create-branch
+      shell: bash
+      run: |
+        base_branch=release-v$(echo "$WASM_SHIM_VERSION" | sed 's/[+-].*//; s/\.[0-9]*$//')
+        echo "BASE_BRANCH=$base_branch" >> $GITHUB_ENV
+        echo "base-branch=$base_branch" >> $GITHUB_OUTPUT
+
+        if git ls-remote --exit-code --heads origin "$base_branch" ; then
+          echo "Base branch $base_branch already exists"
+        else
+          echo "Creating branch $base_branch"
+          git checkout -b "$base_branch"
+          if [ "${{ inputs.push-branch }}" = "true" ]; then
+            echo "Pushing branch $base_branch to origin"
+            git push --set-upstream origin "$base_branch"
+          fi
+        fi
+
+    - name: Update Cargo.toml version
+      shell: bash
+      run: |
+        sed -i '0,/^version = ".*"/s//version = "'"$WASM_SHIM_VERSION"'"/' Cargo.toml
+
+    - name: Set up Rust and WASM environment
+      uses: ./.github/actions/setup-rust-wasm
+      with:
+        github-token: ${{ inputs.github-token }}
+
+    - name: Update Cargo.lock
+      shell: bash
+      run: cargo check --target wasm32-wasip1

--- a/.github/actions/setup-rust-wasm/action.yaml
+++ b/.github/actions/setup-rust-wasm/action.yaml
@@ -1,0 +1,29 @@
+name: 'Setup Rust WASM Environment'
+description: 'Set up Rust toolchain with wasm32-wasip1 target, cache, and protoc'
+
+inputs:
+  rust-components:
+    description: 'Additional Rust components (e.g., rustfmt, clippy)'
+    required: false
+    default: ''
+  github-token:
+    description: 'GitHub token for protoc setup'
+    required: true
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Set up Rust toolchain
+      uses: dtolnay/rust-toolchain@stable
+      with:
+        targets: wasm32-wasip1
+        components: ${{ inputs.rust-components }}
+
+    - name: Set up Rust cache
+      uses: Swatinem/rust-cache@v2
+
+    - name: Set up protoc
+      uses: arduino/setup-protoc@v3
+      with:
+        version: "3.x"
+        repo-token: ${{ inputs.github-token }}

--- a/.github/workflows/automated-release.yaml
+++ b/.github/workflows/automated-release.yaml
@@ -25,49 +25,12 @@ jobs:
           ref: ${{ github.event.inputs.gitRef }}
           token: ${{ secrets.KUADRANT_WORKFLOWS_PAT }}
 
-      - name: Validate and set version
-        run: |
-          VERSION="${{ github.event.inputs.wasmShimVersion }}"
-          if ! echo "$VERSION" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?(\+[0-9A-Za-z.-]+)?$'; then
-            echo "Error: wasmShimVersion must be valid semver format (e.g., 0.12.1, 0.13.0-rc1)"
-            exit 1
-          fi
-          echo "WASM_SHIM_VERSION=$VERSION" >> $GITHUB_ENV
-
-      - name: Create release branch
-        id: create-release-branch
-        shell: bash
-        run: |
-          base_branch=release-v$(echo "$WASM_SHIM_VERSION" | sed 's/[+-].*//; s/\.[0-9]*$//')
-          echo "BASE_BRANCH=$base_branch" >> $GITHUB_ENV
-
-          if git ls-remote --exit-code --heads origin "$base_branch" ; then
-            echo "Base branch $base_branch already exists"
-          else
-            echo "Creating branch $base_branch"
-            git checkout -b "$base_branch"
-            git push --set-upstream origin "$base_branch"
-          fi
-
-      - name: Update Cargo.toml version
-        run: |
-          sed -i '0,/^version = ".*"/s//version = "'"$WASM_SHIM_VERSION"'"/' Cargo.toml
-
-      - name: Set up Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+      - name: Prepare release
+        uses: ./.github/actions/prepare-release
         with:
-          targets: wasm32-wasip1
-
-      - uses: Swatinem/rust-cache@v2
-
-      - name: Set up protoc
-        uses: arduino/setup-protoc@v3
-        with:
-          version: "3.x"
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Update Cargo.lock
-        run: cargo check --target wasm32-wasip1
+          version: ${{ github.event.inputs.wasmShimVersion }}
+          push-branch: 'true'
+          github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Create Pull Request
         id: cpr

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -16,14 +16,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: dtolnay/rust-toolchain@stable
+      - name: Set up Rust and WASM environment
+        uses: ./.github/actions/setup-rust-wasm
         with:
-          targets: wasm32-wasip1
-      - uses: Swatinem/rust-cache@v2
-      - uses: arduino/setup-protoc@v3
-        with:
-          version: "3.x"
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
       - run: cargo build --target wasm32-wasip1
       - name: Run docker compose
         run: |
@@ -36,14 +32,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: dtolnay/rust-toolchain@stable
+      - name: Set up Rust and WASM environment
+        uses: ./.github/actions/setup-rust-wasm
         with:
-          targets: wasm32-wasip1
-      - uses: Swatinem/rust-cache@v2
-      - uses: arduino/setup-protoc@v3
-        with:
-          version: "3.x"
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
       - run: cargo build --target wasm32-wasip1
       - name: Run docker compose
         run: |

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -45,18 +45,10 @@ jobs:
             echo "Tag ${{ env.TAG }} does not exist - proceeding with release"
           fi
 
-      - name: Set up Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+      - name: Set up Rust and WASM environment
+        uses: ./.github/actions/setup-rust-wasm
         with:
-          targets: wasm32-wasip1
-
-      - uses: Swatinem/rust-cache@v2
-
-      - name: Set up protoc
-        uses: arduino/setup-protoc@v3
-        with:
-          version: "3.x"
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build WASM binary
         run: cargo build --release --target wasm32-wasip1

--- a/.github/workflows/rust.yaml
+++ b/.github/workflows/rust.yaml
@@ -18,29 +18,21 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: dtolnay/rust-toolchain@stable
+      - name: Set up Rust and WASM environment
+        uses: ./.github/actions/setup-rust-wasm
         with:
-          targets: wasm32-wasip1
-      - uses: Swatinem/rust-cache@v2
-      - uses: arduino/setup-protoc@v3
-        with:
-          version: "3.x"
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
       - run: cargo check --release --target wasm32-wasip1
   fmt:
     name: Rustfmt
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: dtolnay/rust-toolchain@stable
+      - name: Set up Rust and WASM environment
+        uses: ./.github/actions/setup-rust-wasm
         with:
-          targets: wasm32-wasip1
-          components: rustfmt
-      - uses: Swatinem/rust-cache@v2
-      - uses: arduino/setup-protoc@v3
-        with:
-          version: "3.x"
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          rust-components: rustfmt
+          github-token: ${{ secrets.GITHUB_TOKEN }}
       - run: cargo build --target=wasm32-wasip1 --release
       - run: cargo fmt --all -- --check
   clippy:
@@ -48,15 +40,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: dtolnay/rust-toolchain@stable
+      - name: Set up Rust and WASM environment
+        uses: ./.github/actions/setup-rust-wasm
         with:
-          targets: wasm32-wasip1
-          components: clippy
-      - uses: Swatinem/rust-cache@v2
-      - uses: arduino/setup-protoc@v3
-        with:
-          version: "3.x"
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          rust-components: clippy
+          github-token: ${{ secrets.GITHUB_TOKEN }}
       - run: cargo clippy --all-targets --all-features -- -D warnings
   required-checks:
     name: Rust Required Checks

--- a/.github/workflows/sector-release.yaml
+++ b/.github/workflows/sector-release.yaml
@@ -1,0 +1,79 @@
+name: Sector Release WASM Shim
+
+on:
+  workflow_dispatch:
+    inputs:
+      gitRef:
+        description: Commit SHA, tag or branch name (usually main branch)
+        required: true
+        default: "main"
+        type: string
+      wasmShimVersion:
+        description: WASM Shim version (semver, e.g., 0.12.1)
+        required: true
+        default: "0.0.0"
+        type: string
+
+jobs:
+  sector-release:
+    name: Prepare Release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code at git ref
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.inputs.gitRef }}
+          token: ${{ secrets.KUADRANT_WORKFLOWS_PAT }}
+
+      - name: Validate and set version
+        run: |
+          VERSION="${{ github.event.inputs.wasmShimVersion }}"
+          if ! echo "$VERSION" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?(\+[0-9A-Za-z.-]+)?$'; then
+            echo "Error: wasmShimVersion must be valid semver format (e.g., 0.12.1, 0.13.0-rc1)"
+            exit 1
+          fi
+          echo "WASM_SHIM_VERSION=$VERSION" >> $GITHUB_ENV
+
+      - name: Create release branch
+        id: create-release-branch
+        shell: bash
+        run: |
+          base_branch=release-v$(echo "$WASM_SHIM_VERSION" | sed 's/[+-].*//; s/\.[0-9]*$//')
+          echo "BASE_BRANCH=$base_branch" >> $GITHUB_ENV
+
+          if git ls-remote --exit-code --heads origin "$base_branch" ; then
+            echo "Base branch $base_branch already exists"
+          else
+            echo "Creating branch $base_branch"
+            git checkout -b "$base_branch"
+          fi
+
+      - name: Update Cargo.toml version
+        run: |
+          sed -i '0,/^version = ".*"/s//version = "'"$WASM_SHIM_VERSION"'"/' Cargo.toml
+
+      - name: Set up Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: wasm32-wasip1
+
+      - uses: Swatinem/rust-cache@v2
+
+      - name: Set up protoc
+        uses: arduino/setup-protoc@v3
+        with:
+          version: "3.x"
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Update Cargo.lock
+        run: cargo check --target wasm32-wasip1
+
+      - name: Commit and push changes
+        id: commit-and-push-changes
+        shell: bash
+        run: | 
+          git config --global user.email "${{ github.actor_id }}+${{ github.actor }}@users.noreply.github.com"
+          git config --global user.name "${{ github.actor}}"
+
+          git commit . -s -m "Prepare release ${{ github.event.inputs.wasmShimVersion }}"
+          git push --set-upstream origin "$BASE_BRANCH"

--- a/.github/workflows/sector-release.yaml
+++ b/.github/workflows/sector-release.yaml
@@ -25,48 +25,12 @@ jobs:
           ref: ${{ github.event.inputs.gitRef }}
           token: ${{ secrets.KUADRANT_WORKFLOWS_PAT }}
 
-      - name: Validate and set version
-        run: |
-          VERSION="${{ github.event.inputs.wasmShimVersion }}"
-          if ! echo "$VERSION" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?(\+[0-9A-Za-z.-]+)?$'; then
-            echo "Error: wasmShimVersion must be valid semver format (e.g., 0.12.1, 0.13.0-rc1)"
-            exit 1
-          fi
-          echo "WASM_SHIM_VERSION=$VERSION" >> $GITHUB_ENV
-
-      - name: Create release branch
-        id: create-release-branch
-        shell: bash
-        run: |
-          base_branch=release-v$(echo "$WASM_SHIM_VERSION" | sed 's/[+-].*//; s/\.[0-9]*$//')
-          echo "BASE_BRANCH=$base_branch" >> $GITHUB_ENV
-
-          if git ls-remote --exit-code --heads origin "$base_branch" ; then
-            echo "Base branch $base_branch already exists"
-          else
-            echo "Creating branch $base_branch"
-            git checkout -b "$base_branch"
-          fi
-
-      - name: Update Cargo.toml version
-        run: |
-          sed -i '0,/^version = ".*"/s//version = "'"$WASM_SHIM_VERSION"'"/' Cargo.toml
-
-      - name: Set up Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+      - name: Prepare release
+        uses: ./.github/actions/prepare-release
         with:
-          targets: wasm32-wasip1
-
-      - uses: Swatinem/rust-cache@v2
-
-      - name: Set up protoc
-        uses: arduino/setup-protoc@v3
-        with:
-          version: "3.x"
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Update Cargo.lock
-        run: cargo check --target wasm32-wasip1
+          version: ${{ github.event.inputs.wasmShimVersion }}
+          push-branch: 'false'
+          github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Commit and push changes
         id: commit-and-push-changes

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -16,14 +16,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: dtolnay/rust-toolchain@stable
+      - name: Set up Rust and WASM environment
+        uses: ./.github/actions/setup-rust-wasm
         with:
-          targets: wasm32-wasip1
-      - uses: Swatinem/rust-cache@v2
-      - uses: arduino/setup-protoc@v3
-        with:
-          version: "3.x"
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
       - run: cargo build --release --target wasm32-wasip1
       - run: cargo test
   required-checks:


### PR DESCRIPTION
## Summary
- Adds a new GitHub Actions workflow for preparing WASM Shim releases via the Sector release process
- The workflow is manually triggered via `workflow_dispatch` and automates version bumping and release branch creation

## Details

This workflow (`sector-release.yaml`) allows maintainers to prepare a release by:

1. Checking out code at a specified git ref (commit SHA, tag, or branch)
2. Validating the provided version follows semver format
3. Creating or using an existing release branch (e.g., `release-v0.12`)
4. Updating `Cargo.toml` with the new version
5. Running `cargo check` to update `Cargo.lock`
6. Committing and pushing the changes to the release branch

### Inputs
- `gitRef`: Commit SHA, tag, or branch name (default: `main`)
- `wasmShimVersion`: Semver version string (e.g., `0.12.1`, `0.13.0-rc1`)

## References
- Related issue: https://github.com/Kuadrant/sector/issues/45
- Example workflow runs: https://github.com/kuadrant-labs/wasm-shim/actions/workflows/sector-release.yaml

## Test plan
- [ ] Trigger the workflow manually with a test version
- [ ] Verify release branch is created correctly
- [ ] Verify `Cargo.toml` and `Cargo.lock` are updated with the new version
- [ ] Verify commit is signed and pushed to the release branch


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added a manual "Sector Release WASM Shim" release workflow with version input.
  * Added a reusable release-preparation action to validate versions, derive base branches and update package metadata.
  * Added a reusable Rust/WASM setup action to centralise toolchain, caching and protobuf setup.
  * Updated CI workflows to use the new reusable actions for release and build setup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->