### PR TITLE
Build messages dynamically using CEL and prost-reflect

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -39,6 +39,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "ansi_term"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -208,15 +217,14 @@ dependencies = [
 
 [[package]]
 name = "cel"
-version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca1e5eda1b0f8476181bed1bfc9232a91d62ff0b9f1bc0e48afff3cbcb5b0b5c"
+version = "0.13.0"
+source = "git+https://github.com/cel-rust/cel-rust.git?branch=master#212f441dbf3fa41289bfdb9f0a8c234e6db7125a"
 dependencies = [
  "antlr4rust",
  "chrono",
  "lazy_static",
  "nom 7.1.3",
- "paste",
+ "pastey",
  "regex",
  "serde",
  "thiserror 1.0.69",
@@ -234,8 +242,10 @@ version = "0.4.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "145052bdd345b87320e369255277e3fb5152762ad123a901ef5c262dd38fe8d2"
 dependencies = [
+ "iana-time-zone",
  "num-traits",
  "serde",
+ "windows-link",
 ]
 
 [[package]]
@@ -272,6 +282,12 @@ dependencies = [
  "quote",
  "unicode-xid",
 ]
+
+[[package]]
+name = "core-foundation-sys"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "cpp_demangle"
@@ -883,6 +899,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "135b12329e5e3ce057a9f972339ea52bc954fe1e9358ef27f95e89716fbc5424"
 
 [[package]]
+name = "iana-time-zone"
+version = "0.1.65"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e31bc9ad994ba00e440a8aa5c9ef0ec67d5cb5e5cb0cc7f8b744a35b389cc470"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "log",
+ "wasm-bindgen",
+ "windows-core",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "icu_collections"
 version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1364,6 +1404,12 @@ name = "paste"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
+
+[[package]]
+name = "pastey"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b867cad97c0791bbd3aaa6472142568c6c9e8f71937e98379f584cfb0cf35bec"
 
 [[package]]
 name = "percent-encoding"
@@ -2787,10 +2833,63 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
+name = "windows-core"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
+dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-link",
+ "windows-result",
+ "windows-strings",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.110",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.59.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.110",
+]
+
+[[package]]
 name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-result"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
+dependencies = [
+ "windows-link",
+]
 
 [[package]]
 name = "windows-sys"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ prost-reflect = { version = "0.16", features = ["serde"] }
 radix_trie = "0.2.1"
 const_format = "0.2.31"
 chrono = { version = "0.4.38", default-features = false, features = ["alloc", "std"] }
-cel = "0.12.0"
+cel = {git = "https://github.com/cel-rust/cel-rust.git", branch = "master", features = ["structs"] }
 urlencoding = "2.1.3"
 lazy_static = "1.5.0"
 nom = { version = "8", default-features = false }

--- a/build.rs
+++ b/build.rs
@@ -57,6 +57,9 @@ fn set_git_hash(env: &str) {
 fn generate_protobuf() -> Result<(), Box<dyn Error>> {
     println!("Starting protobuf generation...");
 
+    let out_dir = std::env::var("OUT_DIR")?;
+
+    // Generate Rust code for all protos
     let mut prost_build = prost_build::Config::new();
     prost_build.out_dir("src/envoy");
 
@@ -112,5 +115,42 @@ fn generate_protobuf() -> Result<(), Box<dyn Error>> {
     }
 
     result?;
+
+    // Generate separate FileDescriptorSets for embedded services
+    println!("Generating embedded descriptors...");
+
+    // RateLimit service descriptors (both envoy and kuadrant services, same messages)
+    let mut ratelimit_config = prost_build::Config::new();
+    ratelimit_config.file_descriptor_set_path(format!("{}/ratelimit_descriptors.bin", out_dir));
+    ratelimit_config.compile_protos(
+        &[
+            "vendor-protobufs/data-plane-api/envoy/service/ratelimit/v3/rls.proto",
+            "vendor-protobufs/kuadrant/service/ratelimit/v1/ratelimit.proto",
+        ],
+        &[
+            "vendor-protobufs/data-plane-api/",
+            "vendor-protobufs/protoc-gen-validate/",
+            "vendor-protobufs/udpa/",
+            "vendor-protobufs/xds/",
+            "vendor-protobufs/googleapis/",
+            "vendor-protobufs/kuadrant/",
+        ],
+    )?;
+
+    // Auth service descriptors (don't generate Rust code, just descriptor set)
+    let mut auth_config = prost_build::Config::new();
+    auth_config.file_descriptor_set_path(format!("{}/auth_descriptors.bin", out_dir));
+    auth_config.compile_protos(
+        &["vendor-protobufs/data-plane-api/envoy/service/auth/v3/external_auth.proto"],
+        &[
+            "vendor-protobufs/data-plane-api/",
+            "vendor-protobufs/protoc-gen-validate/",
+            "vendor-protobufs/udpa/",
+            "vendor-protobufs/xds/",
+            "vendor-protobufs/googleapis/",
+        ],
+    )?;
+
+    println!("Embedded descriptor generation completed!");
     Ok(())
 }

--- a/src/data/cel.rs
+++ b/src/data/cel.rs
@@ -2,8 +2,7 @@ use crate::data::attribute::{AttributeError, AttributeState, Path};
 use crate::data::cel::errors::{CelError, EvaluationError};
 use crate::data::Headers;
 use crate::kuadrant::ReqRespCtx;
-use cel::common::ast::{EntryExpr, Expr, IdedExpr};
-use cel::common::value::CelVal;
+use cel::common::ast::{EntryExpr, Expr, IdedExpr, LiteralValue};
 use cel::extractors::{Arguments, This};
 use cel::objects::{Key, Map, ValueType};
 use cel::parser::{Expression as CelExpression, ParseErrors, Parser};
@@ -194,10 +193,8 @@ impl Expression {
         };
 
         for binding in ["request", "metadata", "source", "destination", "auth"] {
-            ctx.add_variable_from_value(
-                binding,
-                map.get(&binding.into()).cloned().unwrap_or(Value::Null),
-            );
+            let key: Key = binding.into();
+            ctx.add_variable_from_value(binding, map.get(&key).cloned().unwrap_or(Value::Null));
         }
 
         let mut response_json_map = HashMap::new();
@@ -240,14 +237,23 @@ pub fn response_body_json(ftx: &FunctionContext, arg: Value) -> ResolveResult {
     let key: Result<Key, Value> = arg.try_into();
     match key {
         Ok(key) => match ftx.ptx.get_variable(RESPONSE_BODY_JSON_DATA) {
-            Ok(Value::Map(map)) => match map.get(&key) {
-                None => Ok(Value::Null),
-                Some(value) => Ok(value.clone()),
+            Some(var) => match Value::try_from(var.as_ref()) {
+                Ok(Value::Map(map)) => match map.get(&key) {
+                    None => Ok(Value::Null),
+                    Some(value) => Ok(value.clone()),
+                },
+                Ok(_) => Err(ExecutionError::FunctionError {
+                    function: RESPONSE_BODY_JSON_FN.to_string(),
+                    message: "Bad internal state!".to_string(),
+                }),
+                Err(_) => Err(ExecutionError::FunctionError {
+                    function: RESPONSE_BODY_JSON_FN.to_string(),
+                    message: "Failed to convert variable to Value".to_string(),
+                }),
             },
-            Err(e) => Err(e),
-            _ => Err(ExecutionError::FunctionError {
+            None => Err(ExecutionError::FunctionError {
                 function: RESPONSE_BODY_JSON_FN.to_string(),
-                message: "Bad internal state!".to_string(),
+                message: format!("Variable {} not found", RESPONSE_BODY_JSON_DATA),
             }),
         },
         Err(e) => Err(ExecutionError::UnexpectedType {
@@ -560,6 +566,7 @@ fn copy(value_type: &ValueType) -> ValueType {
         ValueType::Timestamp => ValueType::Timestamp,
         ValueType::Null => ValueType::Null,
         ValueType::Opaque => ValueType::Opaque,
+        ValueType::Struct => ValueType::Struct,
     }
 }
 
@@ -643,7 +650,7 @@ fn properties<'e>(
         Expr::Call(call) => {
             if call.target.is_none() && call.func_name == "responseBodyJSON" && call.args.len() == 1
             {
-                if let Expr::Literal(CelVal::String(prop)) = &call.args[0].expr {
+                if let Expr::Literal(LiteralValue::String(prop)) = &call.args[0].expr {
                     response_props.push(prop.to_string());
                 }
             }

--- a/src/filter/descriptor_manager.rs
+++ b/src/filter/descriptor_manager.rs
@@ -63,6 +63,7 @@ enum DescriptorState {
 #[derive(Default)]
 pub struct DescriptorManager {
     pools: RefCell<HashMap<u64, Rc<DescriptorPool>>>,
+    embedded: RefCell<HashMap<String, u64>>,
     descriptors: RefCell<HashMap<DescriptorKey, DescriptorState>>,
     descriptor_service: RefCell<Option<String>>,
 }
@@ -104,10 +105,27 @@ impl DescriptorManager {
                 DescriptorState::Resolved(hash) => self.pools.borrow().get(hash).map(Rc::clone),
                 _ => None,
             })
+            .or_else(|| {
+                self.embedded
+                    .borrow()
+                    .get(service)
+                    .and_then(|hash| self.pools.borrow().get(hash).map(Rc::clone))
+            })
             .ok_or_else(|| DescriptorError::NotAvailable {
                 cluster: cluster.to_string(),
                 service: service.to_string(),
             })
+    }
+
+    pub fn register_embedded(&self, service: String, fds_bytes: &[u8], pool: DescriptorPool) {
+        let content_hash = hash_bytes(fds_bytes);
+
+        self.pools
+            .borrow_mut()
+            .entry(content_hash)
+            .or_insert_with(|| Rc::new(pool));
+
+        self.embedded.borrow_mut().insert(service, content_hash);
     }
 
     #[cfg(test)]
@@ -414,6 +432,187 @@ mod tests {
         let result2 = manager.get_pool("cluster-b", "test.TestService").unwrap();
 
         assert!(Rc::ptr_eq(&result1, &result2));
+
+        assert_eq!(manager.pools.borrow().len(), 1);
+    }
+
+    #[test]
+    fn test_embedded_descriptors() {
+        let manager = DescriptorManager::default();
+
+        let file_descriptor = FileDescriptorProto {
+            name: Some("test.proto".to_string()),
+            package: Some("test".to_string()),
+            service: vec![ServiceDescriptorProto {
+                name: Some("TestService".to_string()),
+                ..Default::default()
+            }],
+            ..Default::default()
+        };
+
+        let fds = FileDescriptorSet {
+            file: vec![file_descriptor],
+        };
+
+        let mut fds_bytes = Vec::new();
+        fds.encode(&mut fds_bytes).unwrap();
+
+        let pool = DescriptorPool::from_file_descriptor_set(
+            FileDescriptorSet::decode(fds_bytes.as_slice()).unwrap(),
+        )
+        .unwrap();
+
+        manager.register_embedded("test.TestService".to_string(), &fds_bytes, pool);
+
+        let result = manager.get_pool("any-cluster", "test.TestService");
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_remote_overrides_embedded() {
+        let manager = DescriptorManager::default();
+
+        let embedded_fd = FileDescriptorProto {
+            name: Some("embedded.proto".to_string()),
+            package: Some("test".to_string()),
+            service: vec![ServiceDescriptorProto {
+                name: Some("TestService".to_string()),
+                ..Default::default()
+            }],
+            ..Default::default()
+        };
+
+        let remote_fd = FileDescriptorProto {
+            name: Some("remote.proto".to_string()),
+            package: Some("test".to_string()),
+            service: vec![ServiceDescriptorProto {
+                name: Some("TestService".to_string()),
+                ..Default::default()
+            }],
+            ..Default::default()
+        };
+
+        let embedded_fds = FileDescriptorSet {
+            file: vec![embedded_fd],
+        };
+        let remote_fds = FileDescriptorSet {
+            file: vec![remote_fd],
+        };
+
+        let mut embedded_bytes = Vec::new();
+        embedded_fds.encode(&mut embedded_bytes).unwrap();
+        let mut remote_bytes = Vec::new();
+        remote_fds.encode(&mut remote_bytes).unwrap();
+
+        let embedded_pool = DescriptorPool::from_file_descriptor_set(
+            FileDescriptorSet::decode(embedded_bytes.as_slice()).unwrap(),
+        )
+        .unwrap();
+        let remote_pool = DescriptorPool::from_file_descriptor_set(
+            FileDescriptorSet::decode(remote_bytes.as_slice()).unwrap(),
+        )
+        .unwrap();
+
+        manager.register_embedded(
+            "test.TestService".to_string(),
+            &embedded_bytes,
+            embedded_pool,
+        );
+
+        let key = DescriptorKey::new("test-cluster".to_string(), "test.TestService".to_string());
+        manager.insert_pool_from_bytes(key, &remote_bytes, remote_pool);
+
+        let result = manager
+            .get_pool("test-cluster", "test.TestService")
+            .unwrap();
+
+        assert_eq!(
+            result.services().next().unwrap().parent_file().name(),
+            "remote.proto"
+        );
+    }
+
+    #[test]
+    fn test_embedded_used_when_no_cluster_config() {
+        let manager = DescriptorManager::default();
+
+        let embedded_fd = FileDescriptorProto {
+            name: Some("embedded.proto".to_string()),
+            package: Some("test".to_string()),
+            service: vec![ServiceDescriptorProto {
+                name: Some("TestService".to_string()),
+                ..Default::default()
+            }],
+            ..Default::default()
+        };
+
+        let embedded_fds = FileDescriptorSet {
+            file: vec![embedded_fd],
+        };
+
+        let mut embedded_bytes = Vec::new();
+        embedded_fds.encode(&mut embedded_bytes).unwrap();
+
+        let embedded_pool = DescriptorPool::from_file_descriptor_set(
+            FileDescriptorSet::decode(embedded_bytes.as_slice()).unwrap(),
+        )
+        .unwrap();
+
+        manager.register_embedded(
+            "test.TestService".to_string(),
+            &embedded_bytes,
+            embedded_pool,
+        );
+
+        let result = manager.get_pool("any-cluster", "test.TestService").unwrap();
+
+        assert_eq!(
+            result.services().next().unwrap().parent_file().name(),
+            "embedded.proto"
+        );
+    }
+
+    #[test]
+    fn test_embedded_and_remote_deduplicate_when_identical() {
+        let manager = DescriptorManager::default();
+
+        let file_descriptor = FileDescriptorProto {
+            name: Some("test.proto".to_string()),
+            package: Some("test".to_string()),
+            service: vec![ServiceDescriptorProto {
+                name: Some("TestService".to_string()),
+                ..Default::default()
+            }],
+            ..Default::default()
+        };
+
+        let fds = FileDescriptorSet {
+            file: vec![file_descriptor],
+        };
+
+        let mut fds_bytes = Vec::new();
+        fds.encode(&mut fds_bytes).unwrap();
+
+        let embedded_pool = DescriptorPool::from_file_descriptor_set(
+            FileDescriptorSet::decode(fds_bytes.as_slice()).unwrap(),
+        )
+        .unwrap();
+        let remote_pool = DescriptorPool::from_file_descriptor_set(
+            FileDescriptorSet::decode(fds_bytes.as_slice()).unwrap(),
+        )
+        .unwrap();
+
+        manager.register_embedded("test.TestService".to_string(), &fds_bytes, embedded_pool);
+
+        let key = DescriptorKey::new("test-cluster".to_string(), "test.TestService".to_string());
+        manager.insert_pool_from_bytes(key, &fds_bytes, remote_pool);
+
+        let embedded_result = manager.get_pool("any-cluster", "test.TestService").unwrap();
+        let remote_result = manager
+            .get_pool("test-cluster", "test.TestService")
+            .unwrap();
+
+        assert!(Rc::ptr_eq(&embedded_result, &remote_result));
 
         assert_eq!(manager.pools.borrow().len(), 1);
     }

--- a/src/filter/descriptor_manager.rs
+++ b/src/filter/descriptor_manager.rs
@@ -6,8 +6,9 @@ use prost_reflect::DescriptorPool;
 use prost_types::FileDescriptorSet;
 use proxy_wasm::traits::Context;
 use std::cell::RefCell;
+use std::collections::hash_map::DefaultHasher;
 use std::collections::HashMap;
-use std::hash::Hash;
+use std::hash::{Hash, Hasher};
 use std::rc::Rc;
 use std::time::Duration;
 use tracing::{debug, error};
@@ -47,14 +48,21 @@ impl std::fmt::Display for DescriptorError {
 
 impl std::error::Error for DescriptorError {}
 
+fn hash_bytes(bytes: &[u8]) -> u64 {
+    let mut hasher = DefaultHasher::new();
+    bytes.hash(&mut hasher);
+    hasher.finish()
+}
+
 enum DescriptorState {
     Missing,
     Pending(u32),
-    Resolved(Rc<DescriptorPool>),
+    Resolved(u64),
 }
 
 #[derive(Default)]
 pub struct DescriptorManager {
+    pools: RefCell<HashMap<u64, Rc<DescriptorPool>>>,
     descriptors: RefCell<HashMap<DescriptorKey, DescriptorState>>,
     descriptor_service: RefCell<Option<String>>,
 }
@@ -88,29 +96,42 @@ impl DescriptorManager {
         service: &str,
     ) -> Result<Rc<DescriptorPool>, DescriptorError> {
         let key = DescriptorKey::new(cluster.to_string(), service.to_string());
-        let descriptors = self.descriptors.borrow();
 
-        match descriptors.get(&key) {
-            Some(DescriptorState::Resolved(pool)) => Ok(Rc::clone(pool)),
-            _ => Err(DescriptorError::NotAvailable {
+        self.descriptors
+            .borrow()
+            .get(&key)
+            .and_then(|state| match state {
+                DescriptorState::Resolved(hash) => self.pools.borrow().get(hash).map(Rc::clone),
+                _ => None,
+            })
+            .ok_or_else(|| DescriptorError::NotAvailable {
                 cluster: cluster.to_string(),
                 service: service.to_string(),
-            }),
-        }
+            })
     }
 
     #[cfg(test)]
     pub fn insert_pool(&self, key: DescriptorKey, pool: DescriptorPool) {
+        let mut hasher = DefaultHasher::new();
+        key.hash(&mut hasher);
+        let hash = hasher.finish();
+        self.pools.borrow_mut().insert(hash, Rc::new(pool));
         self.descriptors
             .borrow_mut()
-            .insert(key, DescriptorState::Resolved(Rc::new(pool)));
+            .insert(key, DescriptorState::Resolved(hash));
     }
 
-    #[cfg(not(test))]
-    fn insert_pool(&self, key: DescriptorKey, pool: DescriptorPool) {
+    fn insert_pool_from_bytes(&self, key: DescriptorKey, fds_bytes: &[u8], pool: DescriptorPool) {
+        let content_hash = hash_bytes(fds_bytes);
+
+        self.pools
+            .borrow_mut()
+            .entry(content_hash)
+            .or_insert_with(|| Rc::new(pool));
+
         self.descriptors
             .borrow_mut()
-            .insert(key, DescriptorState::Resolved(Rc::new(pool)));
+            .insert(key, DescriptorState::Resolved(content_hash));
     }
 
     fn get_missing(&self) -> Vec<DescriptorKey> {
@@ -225,8 +246,9 @@ impl DescriptorManager {
             .into_iter()
             .filter_map(|descriptor| {
                 let key = DescriptorKey::new(descriptor.cluster_name, descriptor.service);
+                let fds_bytes = descriptor.file_descriptor_set;
 
-                let result = FileDescriptorSet::decode(descriptor.file_descriptor_set.as_slice())
+                let result = FileDescriptorSet::decode(fds_bytes.as_slice())
                     .map_err(|e| format!("could not decode FileDescriptorSet for {:?}: {}", key, e))
                     .and_then(|fds| {
                         DescriptorPool::from_file_descriptor_set(fds).map_err(|e| {
@@ -247,7 +269,7 @@ impl DescriptorManager {
                 match result {
                     Ok(pool) => {
                         debug!("Cached descriptor for {:?}", key);
-                        self.insert_pool(key, pool);
+                        self.insert_pool_from_bytes(key, &fds_bytes, pool);
                         None
                     }
                     Err(e) => {
@@ -346,5 +368,53 @@ mod tests {
         let retrieved_pool = result.unwrap();
         let service = retrieved_pool.get_service_by_name("test.TestService");
         assert!(service.is_some());
+    }
+
+    #[test]
+    fn test_deduplication_same_descriptor_bytes() {
+        let manager = DescriptorManager::default();
+
+        let file_descriptor = FileDescriptorProto {
+            name: Some("test.proto".to_string()),
+            package: Some("test".to_string()),
+            message_type: vec![DescriptorProto {
+                name: Some("TestMessage".to_string()),
+                ..Default::default()
+            }],
+            service: vec![ServiceDescriptorProto {
+                name: Some("TestService".to_string()),
+                ..Default::default()
+            }],
+            ..Default::default()
+        };
+
+        let fds = FileDescriptorSet {
+            file: vec![file_descriptor],
+        };
+
+        let mut fds_bytes = Vec::new();
+        fds.encode(&mut fds_bytes).unwrap();
+
+        let pool1 = DescriptorPool::from_file_descriptor_set(
+            FileDescriptorSet::decode(fds_bytes.as_slice()).unwrap(),
+        )
+        .unwrap();
+        let pool2 = DescriptorPool::from_file_descriptor_set(
+            FileDescriptorSet::decode(fds_bytes.as_slice()).unwrap(),
+        )
+        .unwrap();
+
+        let key1 = DescriptorKey::new("cluster-a".to_string(), "test.TestService".to_string());
+        let key2 = DescriptorKey::new("cluster-b".to_string(), "test.TestService".to_string());
+
+        manager.insert_pool_from_bytes(key1, &fds_bytes, pool1);
+        manager.insert_pool_from_bytes(key2, &fds_bytes, pool2);
+
+        let result1 = manager.get_pool("cluster-a", "test.TestService").unwrap();
+        let result2 = manager.get_pool("cluster-b", "test.TestService").unwrap();
+
+        assert!(Rc::ptr_eq(&result1, &result2));
+
+        assert_eq!(manager.pools.borrow().len(), 1);
     }
 }

--- a/src/filter/descriptor_manager.rs
+++ b/src/filter/descriptor_manager.rs
@@ -60,12 +60,51 @@ enum DescriptorState {
     Resolved(u64),
 }
 
-#[derive(Default)]
 pub struct DescriptorManager {
     pools: RefCell<HashMap<u64, Rc<DescriptorPool>>>,
     embedded: RefCell<HashMap<String, u64>>,
     descriptors: RefCell<HashMap<DescriptorKey, DescriptorState>>,
     descriptor_service: RefCell<Option<String>>,
+}
+
+impl Default for DescriptorManager {
+    fn default() -> Self {
+        let manager = Self {
+            pools: Default::default(),
+            embedded: Default::default(),
+            descriptors: Default::default(),
+            descriptor_service: Default::default(),
+        };
+
+        match embedded_descriptors::get_ratelimit_pool() {
+            Ok((pool, bytes)) => {
+                manager.register_embedded(
+                    embedded_descriptors::RATELIMIT_SERVICE.to_string(),
+                    bytes,
+                    &pool,
+                );
+                manager.register_embedded(
+                    embedded_descriptors::KUADRANT_RATELIMIT_SERVICE.to_string(),
+                    bytes,
+                    &pool,
+                );
+            }
+            Err(e) => error!("failed to load embedded ratelimit descriptors: {}", e),
+        }
+
+        match embedded_descriptors::get_auth_pool() {
+            Ok((pool, bytes)) => {
+                manager.register_embedded(
+                    embedded_descriptors::AUTH_SERVICE.to_string(),
+                    bytes,
+                    &pool,
+                );
+            }
+            Err(e) => error!("failed to load embedded auth descriptors: {}", e),
+        }
+
+        manager
+    }
 }
 
 impl DescriptorManager {
@@ -117,13 +156,13 @@ impl DescriptorManager {
             })
     }
 
-    pub fn register_embedded(&self, service: String, fds_bytes: &[u8], pool: DescriptorPool) {
+    pub fn register_embedded(&self, service: String, fds_bytes: &[u8], pool: &DescriptorPool) {
         let content_hash = hash_bytes(fds_bytes);
 
         self.pools
             .borrow_mut()
             .entry(content_hash)
-            .or_insert_with(|| Rc::new(pool));
+            .or_insert_with(|| Rc::new(pool.clone()));
 
         self.embedded.borrow_mut().insert(service, content_hash);
     }
@@ -306,6 +345,41 @@ impl DescriptorManager {
     }
 }
 
+mod embedded_descriptors {
+    use prost::Message;
+    use prost_reflect::DescriptorPool;
+    use prost_types::FileDescriptorSet;
+
+    const RATELIMIT_DESCRIPTORS: &[u8] =
+        include_bytes!(concat!(env!("OUT_DIR"), "/ratelimit_descriptors.bin"));
+    const AUTH_DESCRIPTORS: &[u8] =
+        include_bytes!(concat!(env!("OUT_DIR"), "/auth_descriptors.bin"));
+
+    pub const RATELIMIT_SERVICE: &str = "envoy.service.ratelimit.v3.RateLimitService";
+    pub const KUADRANT_RATELIMIT_SERVICE: &str = "kuadrant.service.ratelimit.v1.RateLimitService";
+    pub const AUTH_SERVICE: &str = "envoy.service.auth.v3.Authorization";
+
+    pub fn get_ratelimit_pool() -> Result<(DescriptorPool, &'static [u8]), String> {
+        let fds = FileDescriptorSet::decode(RATELIMIT_DESCRIPTORS)
+            .map_err(|e| format!("Failed to decode ratelimit descriptors: {}", e))?;
+
+        let pool = DescriptorPool::from_file_descriptor_set(fds)
+            .map_err(|e| format!("Failed to create ratelimit descriptor pool: {}", e))?;
+
+        Ok((pool, RATELIMIT_DESCRIPTORS))
+    }
+
+    pub fn get_auth_pool() -> Result<(DescriptorPool, &'static [u8]), String> {
+        let fds = FileDescriptorSet::decode(AUTH_DESCRIPTORS)
+            .map_err(|e| format!("Failed to decode auth descriptors: {}", e))?;
+
+        let pool = DescriptorPool::from_file_descriptor_set(fds)
+            .map_err(|e| format!("Failed to create auth descriptor pool: {}", e))?;
+
+        Ok((pool, AUTH_DESCRIPTORS))
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -391,6 +465,7 @@ mod tests {
     #[test]
     fn test_deduplication_same_descriptor_bytes() {
         let manager = DescriptorManager::default();
+        let initial_pool_count = manager.pools.borrow().len();
 
         let file_descriptor = FileDescriptorProto {
             name: Some("test.proto".to_string()),
@@ -433,7 +508,7 @@ mod tests {
 
         assert!(Rc::ptr_eq(&result1, &result2));
 
-        assert_eq!(manager.pools.borrow().len(), 1);
+        assert_eq!(manager.pools.borrow().len(), initial_pool_count + 1);
     }
 
     #[test]
@@ -462,7 +537,7 @@ mod tests {
         )
         .unwrap();
 
-        manager.register_embedded("test.TestService".to_string(), &fds_bytes, pool);
+        manager.register_embedded("test.TestService".to_string(), &fds_bytes, &pool);
 
         let result = manager.get_pool("any-cluster", "test.TestService");
         assert!(result.is_ok());
@@ -516,7 +591,7 @@ mod tests {
         manager.register_embedded(
             "test.TestService".to_string(),
             &embedded_bytes,
-            embedded_pool,
+            &embedded_pool,
         );
 
         let key = DescriptorKey::new("test-cluster".to_string(), "test.TestService".to_string());
@@ -561,7 +636,7 @@ mod tests {
         manager.register_embedded(
             "test.TestService".to_string(),
             &embedded_bytes,
-            embedded_pool,
+            &embedded_pool,
         );
 
         let result = manager.get_pool("any-cluster", "test.TestService").unwrap();
@@ -575,6 +650,7 @@ mod tests {
     #[test]
     fn test_embedded_and_remote_deduplicate_when_identical() {
         let manager = DescriptorManager::default();
+        let initial_pool_count = manager.pools.borrow().len();
 
         let file_descriptor = FileDescriptorProto {
             name: Some("test.proto".to_string()),
@@ -602,7 +678,7 @@ mod tests {
         )
         .unwrap();
 
-        manager.register_embedded("test.TestService".to_string(), &fds_bytes, embedded_pool);
+        manager.register_embedded("test.TestService".to_string(), &fds_bytes, &embedded_pool);
 
         let key = DescriptorKey::new("test-cluster".to_string(), "test.TestService".to_string());
         manager.insert_pool_from_bytes(key, &fds_bytes, remote_pool);
@@ -614,6 +690,6 @@ mod tests {
 
         assert!(Rc::ptr_eq(&embedded_result, &remote_result));
 
-        assert_eq!(manager.pools.borrow().len(), 1);
+        assert_eq!(manager.pools.borrow().len(), initial_pool_count + 1);
     }
 }

--- a/src/kuadrant/pipeline/blueprint.rs
+++ b/src/kuadrant/pipeline/blueprint.rs
@@ -187,13 +187,13 @@ impl Blueprint {
                         tasks.push(task);
                     }
                 }
-                ServiceInstance::RateLimit(ratelimit_service)
-                | ServiceInstance::RateLimitCheck(ratelimit_service) => {
+                ServiceInstance::RateLimit(dynamic_service)
+                | ServiceInstance::RateLimitCheck(dynamic_service) => {
                     let task = Box::new(RateLimitTask::new_with_attributes(
                         ctx,
                         action.id.clone(),
                         action.dependencies.clone(),
-                        Rc::clone(ratelimit_service),
+                        Rc::clone(dynamic_service),
                         action.scope.clone(),
                         action.predicates.clone(),
                         action.conditional_data.clone(),
@@ -210,13 +210,13 @@ impl Blueprint {
                         tasks.push(task);
                     }
                 }
-                ServiceInstance::RateLimitReport(ratelimit_service) => {
+                ServiceInstance::RateLimitReport(dynamic_service) => {
                     // parse token usage from response
                     let task = Box::new(RateLimitTask::new_with_attributes(
                         ctx,
                         action.id.clone(),
                         action.dependencies.clone(),
-                        Rc::clone(ratelimit_service),
+                        Rc::clone(dynamic_service),
                         action.scope.clone(),
                         action.predicates.clone(),
                         action.conditional_data.clone(),

--- a/src/kuadrant/pipeline/tasks/ratelimit.rs
+++ b/src/kuadrant/pipeline/tasks/ratelimit.rs
@@ -1,9 +1,8 @@
 use crate::data::attribute::{AttributeError, AttributeState};
 use crate::data::cel::errors::EvaluationError;
 use crate::data::cel::{Expression, Predicate, PredicateVec};
-use crate::data::Headers;
 use crate::envoy::rate_limit_descriptor::Entry;
-use crate::envoy::{rate_limit_response, HeaderValue, RateLimitDescriptor, RateLimitResponse};
+use crate::envoy::{rate_limit_response, RateLimitDescriptor};
 use crate::kuadrant::pipeline::blueprint::ConditionalData;
 use crate::kuadrant::pipeline::tasks::{
     HeaderOperation, HeadersType, ModifyHeadersTask, SendReplyTask,
@@ -11,8 +10,10 @@ use crate::kuadrant::pipeline::tasks::{
 use crate::kuadrant::pipeline::tasks::{PendingTask, Task, TaskOutcome};
 use crate::kuadrant::ReqRespCtx;
 use crate::record_error;
-use crate::services::{RateLimitService, Service};
+use crate::services::{DynamicService, Service};
 use cel::Value;
+use prost_reflect::DynamicMessage;
+use prost_reflect::Value as ProtoValue;
 use std::rc::Rc;
 use tracing::{debug, error};
 
@@ -71,7 +72,7 @@ pub struct RateLimitTask {
 
     // Rate limit configuration
     scope: String,
-    service: Rc<RateLimitService>,
+    service: Rc<DynamicService>,
 
     // Conditional data for building descriptors
     conditional_data_sets: Vec<ConditionalData>,
@@ -80,33 +81,13 @@ pub struct RateLimitTask {
 
 /// Creates a new RL task
 impl RateLimitTask {
-    pub fn new(
-        task_id: String,
-        dependencies: Vec<String>,
-        service: Rc<RateLimitService>,
-        scope: String,
-        predicates: Vec<Predicate>,
-        conditional_data_sets: Vec<ConditionalData>,
-        pauses_filter: bool,
-    ) -> Self {
-        Self {
-            task_id,
-            dependencies,
-            pauses_filter,
-            scope,
-            service,
-            predicates,
-            conditional_data_sets,
-        }
-    }
-
     /// Creates a new RL task prior caching its needed attributes
     #[allow(clippy::too_many_arguments)]
     pub fn new_with_attributes(
         ctx: &ReqRespCtx,
         task_id: String,
         dependencies: Vec<String>,
-        service: Rc<RateLimitService>,
+        service: Rc<DynamicService>,
         scope: String,
         predicates: Vec<Predicate>,
         conditional_data_sets: Vec<ConditionalData>,
@@ -122,15 +103,50 @@ impl RateLimitTask {
                 .map(|data| data.value.eval(ctx))
         });
 
-        Self::new(
+        Self {
             task_id,
             dependencies,
-            service,
-            scope,
-            predicates,
-            conditional_data_sets,
             pauses_filter,
-        )
+            scope,
+            service,
+            conditional_data_sets,
+            predicates,
+        }
+    }
+
+    fn add_request_data_entries(
+        &self,
+        ctx: &mut ReqRespCtx,
+        mut descriptors: Vec<RateLimitDescriptor>,
+    ) -> Vec<RateLimitDescriptor> {
+        let request_data = ctx.eval_request_data();
+        if !request_data.is_empty() {
+            let entries: Vec<_> = request_data
+                .iter()
+                .filter_map(|entry| match &entry.result {
+                    Ok(AttributeState::Available(Value::String(value))) => {
+                        let key = if entry.domain.is_empty() || entry.domain == "metrics.labels" {
+                            entry.field.clone()
+                        } else {
+                            format!("{}.{}", entry.domain, entry.field)
+                        };
+                        Some(Entry {
+                            key,
+                            value: value.to_string(),
+                        })
+                    }
+                    _ => None,
+                })
+                .collect();
+
+            if !entries.is_empty() {
+                descriptors.push(RateLimitDescriptor {
+                    entries,
+                    limit: None,
+                });
+            }
+        }
+        descriptors
     }
 
     /// Builds the rate limit descriptors from the context
@@ -298,15 +314,15 @@ impl Task for RateLimitTask {
             domain_override
         };
 
+        let descriptors = self.add_request_data_entries(ctx, descriptors);
+        let cel_expr = generate_ratelimit_request_cel(&domain, hits_addend, &descriptors);
+
         // Dispatch the rate limit service message
         let token_id = {
             let _span =
                 tracing::debug_span!("ratelimit_request", task_id = self.task_id, scope = domain)
                     .entered();
-            match self
-                .service
-                .dispatch_ratelimit(ctx, &domain, descriptors, hits_addend)
-            {
+            match self.service.dispatch_dynamic(ctx, &cel_expr) {
                 Ok(id) => id,
                 Err(e) => {
                     error!("Failed to dispatch rate limit: {}", e);
@@ -373,45 +389,123 @@ impl Task for RateLimitTask {
     }
 }
 
-fn process_rl_response(response: RateLimitResponse) -> TaskOutcome {
-    // Process based on response code
-    match response.overall_code {
-        code if code == rate_limit_response::Code::Ok as i32 => {
-            // Rate limit check passed
-            if !response.response_headers_to_add.is_empty() {
-                let headers = from_envoy_header_value(&response.response_headers_to_add);
-                return TaskOutcome::Requeued(vec![Box::new(ModifyHeadersTask::new(
-                    HeaderOperation::Set(headers),
-                    HeadersType::HttpResponseHeaders,
-                ))]);
+fn process_rl_response(response: DynamicMessage) -> TaskOutcome {
+    // Extract overall_code
+    let overall_code = match response.get_field_by_name("overall_code") {
+        Some(field) => match field.as_ref() {
+            ProtoValue::I32(code) => *code,
+            ProtoValue::EnumNumber(code) => *code,
+            _ => {
+                error!("overall_code is not an integer");
+                return TaskOutcome::Failed;
             }
-            TaskOutcome::Done
+        },
+        None => {
+            error!("overall_code field not found");
+            return TaskOutcome::Failed;
         }
-        code if code == rate_limit_response::Code::OverLimit as i32 => {
-            // Rate limit exceeded - return 429
-            let headers = from_envoy_header_value(&response.response_headers_to_add);
-            let status_code = crate::envoy::StatusCode::TooManyRequests as u32;
-            let body = Some("Too Many Requests\n".to_string());
+    };
 
-            TaskOutcome::Terminate(Box::new(SendReplyTask::new(
-                status_code,
-                headers.into_inner(),
-                body,
-            )))
+    // Extract response headers
+    let response_headers = match response.get_field_by_name("response_headers_to_add") {
+        Some(field) => match field.as_ref() {
+            ProtoValue::List(headers_list) => {
+                let mut headers = Vec::new();
+                for header_item in headers_list {
+                    if let ProtoValue::Message(header_msg) = header_item {
+                        let key = match header_msg.get_field_by_name("key") {
+                            Some(k) => match k.as_ref() {
+                                ProtoValue::String(s) => s.to_string(),
+                                _ => continue,
+                            },
+                            None => continue,
+                        };
+                        let value = match header_msg.get_field_by_name("value") {
+                            Some(v) => match v.as_ref() {
+                                ProtoValue::String(s) => s.to_string(),
+                                _ => continue,
+                            },
+                            None => continue,
+                        };
+                        headers.push((key, value));
+                    }
+                }
+                headers
+            }
+            _ => Vec::new(),
+        },
+        None => Vec::new(),
+    };
+
+    // Process based on response code
+    if overall_code == rate_limit_response::Code::Ok as i32 {
+        if !response_headers.is_empty() {
+            return TaskOutcome::Requeued(vec![Box::new(ModifyHeadersTask::new(
+                HeaderOperation::Set(response_headers.into()),
+                HeadersType::HttpResponseHeaders,
+            ))]);
         }
-        i32::MIN..=i32::MAX => {
-            // Unknown code or error response
-            TaskOutcome::Failed
-        }
+        TaskOutcome::Done
+    } else if overall_code == rate_limit_response::Code::OverLimit as i32 {
+        let status_code = crate::envoy::StatusCode::TooManyRequests as u32;
+        let body = Some("Too Many Requests\n".to_string());
+
+        TaskOutcome::Terminate(Box::new(SendReplyTask::new(
+            status_code,
+            response_headers,
+            body,
+        )))
+    } else {
+        // Unknown code or error response
+        TaskOutcome::Failed
     }
 }
 
-pub fn from_envoy_header_value(headers: &[HeaderValue]) -> Headers {
-    let vec: Vec<(String, String)> = headers
+fn generate_ratelimit_request_cel(
+    domain: &str,
+    hits_addend: u32,
+    descriptors: &[RateLimitDescriptor],
+) -> String {
+    fn escape_string(s: &str) -> String {
+        s.replace('\\', "\\\\")
+            .replace('"', "\\\"")
+            .replace('\n', "\\n")
+            .replace('\r', "\\r")
+            .replace('\t', "\\t")
+    }
+
+    let descriptors_cel: Vec<String> = descriptors
         .iter()
-        .map(|hv| (hv.key.to_owned(), hv.value.to_owned()))
+        .map(|descriptor| {
+            let entries_cel: Vec<String> = descriptor
+                .entries
+                .iter()
+                .map(|entry| {
+                    format!(
+                        "envoy.extensions.common.ratelimit.v3.RateLimitDescriptor.Entry {{ key: \"{}\", value: \"{}\" }}",
+                        escape_string(&entry.key),
+                        escape_string(&entry.value)
+                    )
+                })
+                .collect();
+
+            format!(
+                "envoy.extensions.common.ratelimit.v3.RateLimitDescriptor {{ entries: [{}] }}",
+                entries_cel.join(", ")
+            )
+        })
         .collect();
-    vec.into()
+
+    format!(
+        r#"envoy.service.ratelimit.v3.RateLimitRequest {{
+    domain: "{}",
+    hits_addend: {}u,
+    descriptors: [{}]
+}}"#,
+        escape_string(domain),
+        hits_addend,
+        descriptors_cel.join(", ")
+    )
 }
 
 #[cfg(test)]
@@ -430,13 +524,16 @@ mod tests {
         ReqRespCtx::new(Arc::new(mock_host))
     }
 
-    fn create_test_service() -> RateLimitService {
-        RateLimitService::new(
+    fn create_test_service() -> DynamicService {
+        use crate::filter::DescriptorManager;
+
+        DynamicService::new(
             "test".to_string(),
+            "envoy.service.ratelimit.v3.RateLimitService".to_string(),
+            "ShouldRateLimit".to_string(),
             std::time::Duration::from_secs(1),
-            "test",
-            "POST",
             FailureMode::Deny,
+            Rc::new(DescriptorManager::default()),
         )
     }
 

--- a/src/services/dynamic.rs
+++ b/src/services/dynamic.rs
@@ -10,6 +10,8 @@ use crate::configuration::FailureMode;
 use crate::filter::{DescriptorKey, DescriptorManager};
 use crate::kuadrant::ReqRespCtx;
 
+pub mod converters;
+
 pub struct DynamicService {
     upstream_name: String,
     service_name: String,

--- a/src/services/dynamic.rs
+++ b/src/services/dynamic.rs
@@ -36,8 +36,6 @@ impl DynamicService {
         failure_mode: FailureMode,
         descriptor_manager: Rc<DescriptorManager>,
     ) -> Self {
-        descriptor_manager.add_expected(DescriptorKey::new(endpoint.clone(), grpc_service.clone()));
-
         Self {
             upstream_name: endpoint,
             service_name: grpc_service,
@@ -49,11 +47,17 @@ impl DynamicService {
         }
     }
 
+    pub fn register_for_fetch(&self) {
+        self.descriptor_manager.add_expected(DescriptorKey::new(
+            self.upstream_name.clone(),
+            self.service_name.clone(),
+        ));
+    }
+
     pub fn failure_mode(&self) -> FailureMode {
         self.failure_mode
     }
 
-    #[allow(dead_code)]
     pub fn dispatch_dynamic(
         &self,
         ctx: &mut ReqRespCtx,
@@ -158,6 +162,7 @@ impl Service for DynamicService {
         let output_descriptor = method_descriptor.output();
         let response = DynamicMessage::decode(output_descriptor, message.as_slice())
             .map_err(|e| ServiceError::Decode(format!("Failed to decode response: {}", e)))?;
+
         Ok(response)
     }
 }

--- a/src/services/dynamic.rs
+++ b/src/services/dynamic.rs
@@ -1,6 +1,9 @@
+use std::cell::OnceCell;
 use std::rc::Rc;
+use std::sync::Arc;
 use std::time::Duration;
 
+use cel::{Context, Env, Program};
 use prost::Message;
 use prost_reflect::DynamicMessage;
 use tracing::debug;
@@ -12,6 +15,8 @@ use crate::kuadrant::ReqRespCtx;
 
 pub mod converters;
 
+use converters::{DescriptorConverter, MessageConverter};
+
 pub struct DynamicService {
     upstream_name: String,
     service_name: String,
@@ -19,6 +24,7 @@ pub struct DynamicService {
     timeout: Duration,
     failure_mode: FailureMode,
     descriptor_manager: Rc<DescriptorManager>,
+    cel_env: OnceCell<Arc<Env>>,
 }
 
 impl DynamicService {
@@ -39,6 +45,7 @@ impl DynamicService {
             timeout,
             failure_mode,
             descriptor_manager,
+            cel_env: Default::default(),
         }
     }
 
@@ -50,7 +57,7 @@ impl DynamicService {
     pub fn dispatch_dynamic(
         &self,
         ctx: &mut ReqRespCtx,
-        json_message: &str,
+        message_expression: &str,
     ) -> Result<u32, ServiceError> {
         let pool = self
             .descriptor_manager
@@ -75,18 +82,42 @@ impl DynamicService {
                 ))
             })?;
         let input_descriptor = method_descriptor.input();
-        // todo(@adam-cattermole): To be replaced with CEL construction
-        debug!("Deserializing JSON into dynamic message");
-        let mut deserializer = serde_json::Deserializer::from_str(json_message);
-        let request_message = DynamicMessage::deserialize(input_descriptor, &mut deserializer)
-            .map_err(|e| ServiceError::Dispatch(format!("Failed to deserialize JSON: {}", e)))?;
-        deserializer
-            .end()
-            .map_err(|e| ServiceError::Dispatch(format!("JSON deserializer error: {}", e)))?;
+
+        debug!("Building message from CEL expression");
+        let env = match self.cel_env.get() {
+            Some(env) => Arc::clone(env),
+            None => {
+                let mut new_env = Env::stdlib();
+                DescriptorConverter::register_message_types(&mut new_env, &input_descriptor)
+                    .map_err(|e| {
+                        ServiceError::Dispatch(format!("Failed to register message types: {}", e))
+                    })?;
+                let env_arc = Arc::new(new_env);
+                let _ = self.cel_env.set(Arc::clone(&env_arc));
+                env_arc
+            }
+        };
+
+        let cel_ctx = Context::with_env(env);
+
+        let program = Program::compile(message_expression).map_err(|e| {
+            ServiceError::Dispatch(format!("Failed to compile CEL expression: {}", e))
+        })?;
+
+        let cel_value = program.execute(&cel_ctx).map_err(|e| {
+            ServiceError::Dispatch(format!("Failed to execute CEL expression: {}", e))
+        })?;
+
+        let request_message =
+            MessageConverter::cel_to_dynamic_message(&cel_value, &input_descriptor).map_err(
+                |e| ServiceError::Dispatch(format!("Failed to convert CEL to message: {}", e)),
+            )?;
+
         let mut message_bytes = Vec::new();
         request_message
             .encode(&mut message_bytes)
             .map_err(|e| ServiceError::Dispatch(format!("Failed to encode message: {}", e)))?;
+
         self.dispatch(
             ctx,
             &self.upstream_name,
@@ -195,7 +226,7 @@ mod tests {
     }
 
     #[test]
-    fn test_dynamic_service_message_building() {
+    fn test_dynamic_service_cel_message_building() {
         let manager = create_test_descriptor_manager();
         let service = DynamicService::new(
             "test-cluster".to_string(),
@@ -206,7 +237,7 @@ mod tests {
             manager.clone(),
         );
 
-        let json_request = r#"{ "message": "hello" }"#;
+        let cel_expression = r#"test.TestRequest { message: "hello" }"#;
 
         let pool = manager
             .get_pool("test-cluster", "test.TestService")
@@ -220,14 +251,28 @@ mod tests {
             .expect("Method not found");
         let input_desc = method_desc.input();
 
-        let mut deserializer = serde_json::Deserializer::from_str(json_request);
-        let message = DynamicMessage::deserialize(input_desc, &mut deserializer)
-            .expect("Failed to deserialize");
-        deserializer.end().expect("Deserializer should end cleanly");
+        let mut env = Env::stdlib();
+        DescriptorConverter::register_message_types(&mut env, &input_desc)
+            .expect("Failed to register types");
+
+        let cel_ctx = Context::with_env(Arc::new(env));
+        let program = Program::compile(cel_expression).expect("Failed to compile");
+        let cel_value = program.execute(&cel_ctx).expect("Failed to execute");
+
+        let message = MessageConverter::cel_to_dynamic_message(&cel_value, &input_desc)
+            .expect("Failed to convert");
 
         let mut bytes = Vec::new();
         message.encode(&mut bytes).expect("Failed to encode");
         assert!(!bytes.is_empty());
+
+        let field_value = message
+            .get_field_by_name("message")
+            .expect("message field not found");
+        assert_eq!(
+            field_value.as_ref(),
+            &prost_reflect::Value::String("hello".to_string())
+        );
     }
 
     #[test]

--- a/src/services/dynamic/converters.rs
+++ b/src/services/dynamic/converters.rs
@@ -1,0 +1,567 @@
+use cel::common::types::{CelBool, CelBytes, CelDouble, CelInt, CelString, CelStruct, CelUInt};
+use cel::{Env, StructDef, Value};
+use prost_reflect::{
+    DynamicMessage, FieldDescriptor, Kind as ProtoKind, MessageDescriptor, Value as ProtoValue,
+};
+use std::collections::HashSet;
+use std::fmt;
+use std::sync::Arc;
+
+#[derive(Debug)]
+pub enum ConversionError {
+    TypeMismatch {
+        field: String,
+        expected: String,
+        got: String,
+    },
+    UnsupportedFieldType {
+        field: String,
+        kind: String,
+    },
+    NotAStruct,
+}
+
+impl fmt::Display for ConversionError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            ConversionError::TypeMismatch {
+                field,
+                expected,
+                got,
+            } => write!(
+                f,
+                "Type mismatch for field '{}': expected {}, got {}",
+                field, expected, got
+            ),
+            ConversionError::UnsupportedFieldType { field, kind } => {
+                write!(f, "Unsupported field type for '{}': {}", field, kind)
+            }
+            ConversionError::NotAStruct => write!(f, "CEL value is not a struct"),
+        }
+    }
+}
+
+impl std::error::Error for ConversionError {}
+
+/// Converts protobuf MessageDescriptors to CEL StructDefs
+pub struct DescriptorConverter;
+
+impl DescriptorConverter {
+    /// Register a message descriptor and all its nested message types with the CEL environment
+    /// This must be called before evaluating CEL expressions that construct these messages
+    pub fn register_message_types(
+        env: &mut Env,
+        descriptor: &MessageDescriptor,
+    ) -> Result<(), ConversionError> {
+        let mut to_register = vec![descriptor.clone()];
+        let mut visited = HashSet::new();
+
+        while let Some(desc) = to_register.pop() {
+            if !visited.insert(desc.full_name().to_string()) {
+                continue;
+            }
+
+            for field in desc.fields() {
+                if let ProtoKind::Message(nested_desc) = field.kind() {
+                    to_register.push(nested_desc);
+                }
+            }
+
+            let struct_def = Self::to_struct_def(&desc)?;
+            env.add_struct(struct_def);
+        }
+
+        Ok(())
+    }
+
+    /// Convert a protobuf MessageDescriptor to a CEL StructDef
+    /// Supports nested messages - they will be referenced by name
+    pub fn to_struct_def(descriptor: &MessageDescriptor) -> Result<StructDef, ConversionError> {
+        let mut struct_def = StructDef::new(descriptor.full_name().to_string());
+
+        for field in descriptor.fields() {
+            let cel_type = Self::protobuf_kind_to_cel_type(field.kind())?;
+            struct_def = struct_def.add_field(field.name().to_string(), cel_type);
+        }
+
+        Ok(struct_def)
+    }
+
+    fn protobuf_kind_to_cel_type(
+        kind: ProtoKind,
+    ) -> Result<cel::common::types::Type, ConversionError> {
+        use cel::common::types::*;
+
+        match kind {
+            ProtoKind::Bool => Ok(BOOL_TYPE),
+            ProtoKind::Int32
+            | ProtoKind::Int64
+            | ProtoKind::Sint32
+            | ProtoKind::Sint64
+            | ProtoKind::Sfixed32
+            | ProtoKind::Sfixed64 => Ok(INT_TYPE),
+            ProtoKind::Uint32 | ProtoKind::Uint64 | ProtoKind::Fixed32 | ProtoKind::Fixed64 => {
+                Ok(UINT_TYPE)
+            }
+            ProtoKind::Float | ProtoKind::Double => Ok(DOUBLE_TYPE),
+            ProtoKind::String => Ok(STRING_TYPE),
+            ProtoKind::Bytes => Ok(BYTES_TYPE),
+            ProtoKind::Message(desc) => Ok(Type::new_struct(desc.full_name().to_string())),
+            ProtoKind::Enum(_) => {
+                // Enums are represented as INT in CEL
+                Ok(INT_TYPE)
+            }
+        }
+    }
+}
+
+pub struct MessageConverter;
+
+impl MessageConverter {
+    pub fn cel_to_dynamic_message(
+        cel_value: &Value,
+        descriptor: &MessageDescriptor,
+    ) -> Result<DynamicMessage, ConversionError> {
+        match cel_value {
+            Value::Struct(cel_struct) => Self::struct_to_dynamic_message(cel_struct, descriptor),
+            _ => Err(ConversionError::NotAStruct),
+        }
+    }
+
+    fn struct_to_dynamic_message(
+        cel_struct: &Arc<CelStruct>,
+        descriptor: &MessageDescriptor,
+    ) -> Result<DynamicMessage, ConversionError> {
+        let mut message = DynamicMessage::new(descriptor.clone());
+
+        for field in descriptor.fields() {
+            if let Some(val) = cel_struct.field_value(field.name()) {
+                let proto_value = Self::cel_val_to_proto_value(val, &field)?;
+                message.set_field(&field, proto_value);
+            }
+        }
+
+        Ok(message)
+    }
+
+    fn cel_val_to_proto_value(
+        cel_val: &dyn cel::common::value::Val,
+        field: &FieldDescriptor,
+    ) -> Result<ProtoValue, ConversionError> {
+        let field_name = field.name();
+
+        match field.kind() {
+            ProtoKind::Bool => {
+                let b = cel_val.downcast_ref::<CelBool>().ok_or_else(|| {
+                    ConversionError::TypeMismatch {
+                        field: field_name.to_string(),
+                        expected: "bool".to_string(),
+                        got: format!("{:?}", cel_val),
+                    }
+                })?;
+                Ok(ProtoValue::Bool(*b.inner()))
+            }
+            ProtoKind::Int32 | ProtoKind::Sint32 | ProtoKind::Sfixed32 => {
+                let i = cel_val.downcast_ref::<CelInt>().ok_or_else(|| {
+                    ConversionError::TypeMismatch {
+                        field: field_name.to_string(),
+                        expected: "int".to_string(),
+                        got: format!("{:?}", cel_val),
+                    }
+                })?;
+                Ok(ProtoValue::I32(*i.inner() as i32))
+            }
+            ProtoKind::Int64 | ProtoKind::Sint64 | ProtoKind::Sfixed64 => {
+                let i = cel_val.downcast_ref::<CelInt>().ok_or_else(|| {
+                    ConversionError::TypeMismatch {
+                        field: field_name.to_string(),
+                        expected: "int".to_string(),
+                        got: format!("{:?}", cel_val),
+                    }
+                })?;
+                Ok(ProtoValue::I64(*i.inner()))
+            }
+            ProtoKind::Uint32 | ProtoKind::Fixed32 => {
+                let u = cel_val.downcast_ref::<CelUInt>().ok_or_else(|| {
+                    ConversionError::TypeMismatch {
+                        field: field_name.to_string(),
+                        expected: "uint".to_string(),
+                        got: format!("{:?}", cel_val),
+                    }
+                })?;
+                Ok(ProtoValue::U32(*u.inner() as u32))
+            }
+            ProtoKind::Uint64 | ProtoKind::Fixed64 => {
+                let u = cel_val.downcast_ref::<CelUInt>().ok_or_else(|| {
+                    ConversionError::TypeMismatch {
+                        field: field_name.to_string(),
+                        expected: "uint".to_string(),
+                        got: format!("{:?}", cel_val),
+                    }
+                })?;
+                Ok(ProtoValue::U64(*u.inner()))
+            }
+            ProtoKind::Float => {
+                let f = cel_val.downcast_ref::<CelDouble>().ok_or_else(|| {
+                    ConversionError::TypeMismatch {
+                        field: field_name.to_string(),
+                        expected: "float".to_string(),
+                        got: format!("{:?}", cel_val),
+                    }
+                })?;
+                let f64_value = *f.inner();
+                if !f64_value.is_finite()
+                    || f64_value < f32::MIN as f64
+                    || f64_value > f32::MAX as f64
+                {
+                    return Err(ConversionError::TypeMismatch {
+                        field: field_name.to_string(),
+                        expected: "float value within f32 range".to_string(),
+                        got: format!("{}", f64_value),
+                    });
+                }
+                Ok(ProtoValue::F32(f64_value as f32))
+            }
+            ProtoKind::Double => {
+                let f = cel_val.downcast_ref::<CelDouble>().ok_or_else(|| {
+                    ConversionError::TypeMismatch {
+                        field: field_name.to_string(),
+                        expected: "double".to_string(),
+                        got: format!("{:?}", cel_val),
+                    }
+                })?;
+                Ok(ProtoValue::F64(*f.inner()))
+            }
+            ProtoKind::String => {
+                let s = cel_val.downcast_ref::<CelString>().ok_or_else(|| {
+                    ConversionError::TypeMismatch {
+                        field: field_name.to_string(),
+                        expected: "string".to_string(),
+                        got: format!("{:?}", cel_val),
+                    }
+                })?;
+                Ok(ProtoValue::String(s.inner().to_string()))
+            }
+            ProtoKind::Bytes => {
+                let b = cel_val.downcast_ref::<CelBytes>().ok_or_else(|| {
+                    ConversionError::TypeMismatch {
+                        field: field_name.to_string(),
+                        expected: "bytes".to_string(),
+                        got: format!("{:?}", cel_val),
+                    }
+                })?;
+                Ok(ProtoValue::Bytes(b.inner().to_vec().into()))
+            }
+            ProtoKind::Enum(enum_desc) => {
+                // CEL represents enums as integers
+                let i = cel_val.downcast_ref::<CelInt>().ok_or_else(|| {
+                    ConversionError::TypeMismatch {
+                        field: field_name.to_string(),
+                        expected: "int (enum)".to_string(),
+                        got: format!("{:?}", cel_val),
+                    }
+                })?;
+                let i64_value = *i.inner();
+                if i64_value < i32::MIN as i64 || i64_value > i32::MAX as i64 {
+                    return Err(ConversionError::TypeMismatch {
+                        field: field_name.to_string(),
+                        expected: "int32 value for enum".to_string(),
+                        got: format!("{}", i64_value),
+                    });
+                }
+                let value = enum_desc.get_value(i64_value as i32).ok_or_else(|| {
+                    ConversionError::TypeMismatch {
+                        field: field_name.to_string(),
+                        expected: format!("valid enum value for {}", enum_desc.name()),
+                        got: format!("{}", i64_value),
+                    }
+                })?;
+                Ok(ProtoValue::EnumNumber(value.number()))
+            }
+            ProtoKind::Message(nested_desc) => {
+                // Nested message - recurse
+                let nested_message =
+                    Self::struct_from_val_to_message(cel_val, &nested_desc, &field_name)?;
+                Ok(ProtoValue::Message(nested_message))
+            }
+        }
+    }
+
+    fn struct_from_val_to_message(
+        cel_val: &dyn cel::common::value::Val,
+        descriptor: &MessageDescriptor,
+        field_name: &str,
+    ) -> Result<DynamicMessage, ConversionError> {
+        let nested_struct =
+            cel_val
+                .downcast_ref::<CelStruct>()
+                .ok_or_else(|| ConversionError::TypeMismatch {
+                    field: field_name.to_string(),
+                    expected: "struct (nested message)".to_string(),
+                    got: format!("{:?}", cel_val),
+                })?;
+
+        let mut message = DynamicMessage::new(descriptor.clone());
+
+        for field in descriptor.fields() {
+            if let Some(val) = nested_struct.field_value(field.name()) {
+                let proto_value = Self::cel_val_to_proto_value(val, &field)?;
+                message.set_field(&field, proto_value);
+            }
+        }
+
+        Ok(message)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use cel::{Context, Program};
+    use prost::Message;
+    use prost_types::{field_descriptor_proto, DescriptorProto, FieldDescriptorProto};
+    use prost_types::{FileDescriptorProto, FileDescriptorSet};
+    use std::sync::Arc;
+
+    fn create_test_message_descriptor() -> MessageDescriptor {
+        let file_descriptor = FileDescriptorProto {
+            name: Some("test.proto".to_string()),
+            package: Some("test".to_string()),
+            message_type: vec![DescriptorProto {
+                name: Some("TestMessage".to_string()),
+                field: vec![
+                    FieldDescriptorProto {
+                        name: Some("string_field".to_string()),
+                        number: Some(1),
+                        r#type: Some(field_descriptor_proto::Type::String.into()),
+                        ..Default::default()
+                    },
+                    FieldDescriptorProto {
+                        name: Some("int32_field".to_string()),
+                        number: Some(2),
+                        r#type: Some(field_descriptor_proto::Type::Int32.into()),
+                        ..Default::default()
+                    },
+                    FieldDescriptorProto {
+                        name: Some("bool_field".to_string()),
+                        number: Some(3),
+                        r#type: Some(field_descriptor_proto::Type::Bool.into()),
+                        ..Default::default()
+                    },
+                ],
+                ..Default::default()
+            }],
+            ..Default::default()
+        };
+
+        let fds = FileDescriptorSet {
+            file: vec![file_descriptor],
+        };
+
+        let pool = prost_reflect::DescriptorPool::from_file_descriptor_set(fds)
+            .expect("Failed to create descriptor pool");
+
+        pool.get_message_by_name("test.TestMessage")
+            .expect("Message not found")
+    }
+
+    #[test]
+    fn test_descriptor_to_struct_def() {
+        let descriptor = create_test_message_descriptor();
+        let struct_def = DescriptorConverter::to_struct_def(&descriptor);
+
+        assert!(struct_def.is_ok());
+        let struct_def = struct_def.unwrap();
+
+        // Verify we can register it with CEL
+        let mut env = cel::Env::stdlib();
+        env.add_struct(struct_def);
+
+        // Should be able to compile an expression using the struct
+        let result = Program::compile(
+            "test.TestMessage { string_field: 'hello', int32_field: 42, bool_field: true }",
+        );
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_cel_to_dynamic_message() {
+        let descriptor = create_test_message_descriptor();
+        let struct_def =
+            DescriptorConverter::to_struct_def(&descriptor).expect("Failed to convert descriptor");
+
+        let mut env = cel::Env::stdlib();
+        env.add_struct(struct_def);
+
+        let ctx = Context::with_env(Arc::new(env));
+
+        let program = Program::compile(
+            "test.TestMessage { string_field: 'hello', int32_field: 42, bool_field: true }",
+        )
+        .expect("Failed to compile");
+
+        let cel_value = program.execute(&ctx).expect("Failed to execute");
+
+        let message = MessageConverter::cel_to_dynamic_message(&cel_value, &descriptor)
+            .expect("Failed to convert");
+
+        // Verify fields
+        let string_field = message
+            .get_field_by_name("string_field")
+            .expect("string_field not found");
+        assert_eq!(
+            string_field.as_ref(),
+            &ProtoValue::String("hello".to_string())
+        );
+
+        let int_field = message
+            .get_field_by_name("int32_field")
+            .expect("int32_field not found");
+        assert_eq!(int_field.as_ref(), &ProtoValue::I32(42));
+
+        let bool_field = message
+            .get_field_by_name("bool_field")
+            .expect("bool_field not found");
+        assert_eq!(bool_field.as_ref(), &ProtoValue::Bool(true));
+    }
+
+    #[test]
+    fn test_nested_messages() {
+        // Create a descriptor with nested messages
+        let file_descriptor = FileDescriptorProto {
+            name: Some("test.proto".to_string()),
+            package: Some("test".to_string()),
+            message_type: vec![
+                DescriptorProto {
+                    name: Some("Inner".to_string()),
+                    field: vec![FieldDescriptorProto {
+                        name: Some("value".to_string()),
+                        number: Some(1),
+                        r#type: Some(field_descriptor_proto::Type::String.into()),
+                        ..Default::default()
+                    }],
+                    ..Default::default()
+                },
+                DescriptorProto {
+                    name: Some("Outer".to_string()),
+                    field: vec![
+                        FieldDescriptorProto {
+                            name: Some("name".to_string()),
+                            number: Some(1),
+                            r#type: Some(field_descriptor_proto::Type::String.into()),
+                            ..Default::default()
+                        },
+                        FieldDescriptorProto {
+                            name: Some("inner".to_string()),
+                            number: Some(2),
+                            r#type: Some(field_descriptor_proto::Type::Message.into()),
+                            type_name: Some(".test.Inner".to_string()),
+                            ..Default::default()
+                        },
+                    ],
+                    ..Default::default()
+                },
+            ],
+            ..Default::default()
+        };
+
+        let fds = FileDescriptorSet {
+            file: vec![file_descriptor],
+        };
+
+        let pool = prost_reflect::DescriptorPool::from_file_descriptor_set(fds)
+            .expect("Failed to create descriptor pool");
+
+        let outer_descriptor = pool
+            .get_message_by_name("test.Outer")
+            .expect("Outer message not found");
+
+        // Register all message types
+        let mut env = cel::Env::stdlib();
+        DescriptorConverter::register_message_types(&mut env, &outer_descriptor)
+            .expect("Failed to register types");
+
+        let ctx = Context::with_env(Arc::new(env));
+
+        // Build a CEL expression with nested message
+        let program = Program::compile(
+            r#"test.Outer { name: "parent", inner: test.Inner { value: "child" } }"#,
+        )
+        .expect("Failed to compile");
+
+        let cel_value = program.execute(&ctx).expect("Failed to execute");
+
+        // Convert to DynamicMessage
+        let message = MessageConverter::cel_to_dynamic_message(&cel_value, &outer_descriptor)
+            .expect("Failed to convert");
+
+        // Verify outer fields
+        let name_field = message
+            .get_field_by_name("name")
+            .expect("name field not found");
+        assert_eq!(
+            name_field.as_ref(),
+            &ProtoValue::String("parent".to_string())
+        );
+
+        // Verify nested message
+        let inner_field = message
+            .get_field_by_name("inner")
+            .expect("inner field not found");
+        if let ProtoValue::Message(inner_msg) = inner_field.as_ref() {
+            let value_field = inner_msg
+                .get_field_by_name("value")
+                .expect("value field not found");
+            assert_eq!(
+                value_field.as_ref(),
+                &ProtoValue::String("child".to_string())
+            );
+        } else {
+            panic!("inner field is not a message");
+        }
+    }
+
+    #[test]
+    fn test_encode_decode_roundtrip() {
+        let descriptor = create_test_message_descriptor();
+        let struct_def =
+            DescriptorConverter::to_struct_def(&descriptor).expect("Failed to convert descriptor");
+
+        let mut env = cel::Env::stdlib();
+        env.add_struct(struct_def);
+
+        let ctx = Context::with_env(Arc::new(env));
+
+        let program = Program::compile(
+            "test.TestMessage { string_field: 'test', int32_field: 123, bool_field: false }",
+        )
+        .expect("Failed to compile");
+
+        let cel_value = program.execute(&ctx).expect("Failed to execute");
+
+        let message = MessageConverter::cel_to_dynamic_message(&cel_value, &descriptor)
+            .expect("Failed to convert");
+
+        // Encode to protobuf bytes
+        let mut bytes = Vec::new();
+        message.encode(&mut bytes).expect("Failed to encode");
+
+        // Decode back
+        let decoded =
+            DynamicMessage::decode(descriptor, bytes.as_slice()).expect("Failed to decode");
+
+        // Verify fields match
+        assert_eq!(
+            message.get_field_by_name("string_field"),
+            decoded.get_field_by_name("string_field")
+        );
+        assert_eq!(
+            message.get_field_by_name("int32_field"),
+            decoded.get_field_by_name("int32_field")
+        );
+        assert_eq!(
+            message.get_field_by_name("bool_field"),
+            decoded.get_field_by_name("bool_field")
+        );
+    }
+}

--- a/src/services/dynamic/converters.rs
+++ b/src/services/dynamic/converters.rs
@@ -1,8 +1,12 @@
-use cel::common::types::{CelBool, CelBytes, CelDouble, CelInt, CelString, CelStruct, CelUInt};
+use cel::common::types::*;
 use cel::{Env, StructDef, Value};
+use prost_reflect::Cardinality;
 use prost_reflect::{
-    DynamicMessage, FieldDescriptor, Kind as ProtoKind, MessageDescriptor, Value as ProtoValue,
+    DynamicMessage, FieldDescriptor, Kind as ProtoKind, MapKey, MessageDescriptor, ReflectMessage,
+    Value as ProtoValue,
 };
+use std::borrow::Cow;
+use std::collections::HashMap;
 use std::collections::HashSet;
 use std::fmt;
 use std::sync::Arc;
@@ -43,6 +47,17 @@ impl fmt::Display for ConversionError {
 
 impl std::error::Error for ConversionError {}
 
+fn is_map_field(field: &FieldDescriptor) -> bool {
+    if field.cardinality() != Cardinality::Repeated {
+        return false;
+    }
+    if let ProtoKind::Message(msg_desc) = field.kind() {
+        msg_desc.is_map_entry()
+    } else {
+        false
+    }
+}
+
 /// Converts protobuf MessageDescriptors to CEL StructDefs
 pub struct DescriptorConverter;
 
@@ -61,9 +76,15 @@ impl DescriptorConverter {
                 continue;
             }
 
+            if desc.is_map_entry() {
+                continue;
+            }
+
             for field in desc.fields() {
                 if let ProtoKind::Message(nested_desc) = field.kind() {
-                    to_register.push(nested_desc);
+                    if !nested_desc.is_map_entry() {
+                        to_register.push(nested_desc);
+                    }
                 }
             }
 
@@ -75,15 +96,13 @@ impl DescriptorConverter {
     }
 
     /// Convert a protobuf MessageDescriptor to a CEL StructDef
-    /// Supports nested messages - they will be referenced by name
     pub fn to_struct_def(descriptor: &MessageDescriptor) -> Result<StructDef, ConversionError> {
-        use cel::common::types::*;
-        use prost_reflect::Cardinality;
-
         let mut struct_def = StructDef::new(descriptor.full_name().to_string());
 
         for field in descriptor.fields() {
-            let cel_type = if field.cardinality() == Cardinality::Repeated {
+            let cel_type = if is_map_field(&field) {
+                MAP_TYPE
+            } else if field.cardinality() == Cardinality::Repeated {
                 LIST_TYPE
             } else {
                 Self::protobuf_kind_to_cel_type(field.kind())?
@@ -98,8 +117,6 @@ impl DescriptorConverter {
     fn protobuf_kind_to_cel_type(
         kind: ProtoKind,
     ) -> Result<cel::common::types::Type, ConversionError> {
-        use cel::common::types::*;
-
         match kind {
             ProtoKind::Bool => Ok(BOOL_TYPE),
             ProtoKind::Int32
@@ -136,6 +153,74 @@ impl MessageConverter {
         }
     }
 
+    #[allow(dead_code)]
+    pub fn dynamic_message_to_cel(message: &DynamicMessage) -> Value {
+        let descriptor = message.descriptor();
+        let mut cel_struct = CelStruct::new(descriptor.full_name().to_string());
+
+        for field in descriptor.fields() {
+            let field_value = message.get_field(&field);
+            let cel_value = Self::proto_value_to_cel_val(field_value.as_ref());
+            cel_struct.add_field_value(field.name().to_string(), Cow::Owned(cel_value));
+        }
+
+        Value::Struct(Arc::new(cel_struct))
+    }
+
+    fn proto_value_to_cel_val(proto_value: &ProtoValue) -> Box<dyn cel::common::value::Val> {
+        match proto_value {
+            ProtoValue::Bool(b) => Box::new(CelBool::from(*b)),
+            ProtoValue::I32(i) => Box::new(CelInt::from(*i as i64)),
+            ProtoValue::I64(i) => Box::new(CelInt::from(*i)),
+            ProtoValue::U32(u) => Box::new(CelUInt::from(*u as u64)),
+            ProtoValue::U64(u) => Box::new(CelUInt::from(*u)),
+            ProtoValue::F32(f) => Box::new(CelDouble::from(*f as f64)),
+            ProtoValue::F64(f) => Box::new(CelDouble::from(*f)),
+            ProtoValue::String(s) => Box::new(CelString::from(s.clone())),
+            ProtoValue::Bytes(b) => Box::new(CelBytes::from(b.to_vec())),
+            ProtoValue::EnumNumber(n) => Box::new(CelInt::from(*n as i64)),
+            ProtoValue::Message(m) => {
+                let descriptor = m.descriptor();
+                let mut cel_struct = CelStruct::new(descriptor.full_name().to_string());
+
+                for field in descriptor.fields() {
+                    let field_value = m.get_field(&field);
+                    let cel_value = Self::proto_value_to_cel_val(field_value.as_ref());
+                    cel_struct.add_field_value(field.name().to_string(), Cow::Owned(cel_value));
+                }
+
+                Box::new(cel_struct)
+            }
+            ProtoValue::List(items) => {
+                let cel_items: Vec<Box<dyn cel::common::value::Val>> = items
+                    .iter()
+                    .map(|item| Self::proto_value_to_cel_val(item))
+                    .collect();
+                Box::new(CelList::from(cel_items))
+            }
+            ProtoValue::Map(entries) => {
+                let mut map = HashMap::new();
+                for (key, value) in entries.iter() {
+                    let cel_key = Self::map_key_to_cel(key);
+                    let cel_value = Self::proto_value_to_cel_val(value);
+                    map.insert(cel_key, cel_value);
+                }
+                Box::new(CelMap::from(map))
+            }
+        }
+    }
+
+    fn map_key_to_cel(key: &MapKey) -> cel::common::types::CelMapKey {
+        match key {
+            MapKey::Bool(b) => CelMapKey::Bool(CelBool::from(*b)),
+            MapKey::I32(i) => CelMapKey::Int(CelInt::from(*i as i64)),
+            MapKey::I64(i) => CelMapKey::Int(CelInt::from(*i)),
+            MapKey::U32(u) => CelMapKey::UInt(CelUInt::from(*u as u64)),
+            MapKey::U64(u) => CelMapKey::UInt(CelUInt::from(*u)),
+            MapKey::String(s) => CelMapKey::String(CelString::from(s.clone())),
+        }
+    }
+
     fn struct_to_dynamic_message(
         cel_struct: &Arc<CelStruct>,
         descriptor: &MessageDescriptor,
@@ -156,9 +241,9 @@ impl MessageConverter {
         cel_val: &dyn cel::common::value::Val,
         field: &FieldDescriptor,
     ) -> Result<ProtoValue, ConversionError> {
-        use prost_reflect::Cardinality;
-
-        if field.cardinality() == Cardinality::Repeated {
+        if is_map_field(field) {
+            Self::cel_map_to_proto_map(cel_val, field)
+        } else if field.cardinality() == Cardinality::Repeated {
             Self::cel_list_to_proto_list(cel_val, field)
         } else {
             Self::cel_val_to_single_proto_value(cel_val, field)
@@ -169,8 +254,6 @@ impl MessageConverter {
         cel_val: &dyn cel::common::value::Val,
         field: &FieldDescriptor,
     ) -> Result<ProtoValue, ConversionError> {
-        use cel::common::types::CelList;
-
         let field_name = field.name();
 
         let list =
@@ -190,6 +273,94 @@ impl MessageConverter {
         }
 
         Ok(ProtoValue::List(proto_values))
+    }
+
+    fn cel_map_to_proto_map(
+        cel_val: &dyn cel::common::value::Val,
+        field: &FieldDescriptor,
+    ) -> Result<ProtoValue, ConversionError> {
+        let field_name = field.name();
+
+        let cel_map = cel_val
+            .downcast_ref::<cel::common::types::CelMap>()
+            .ok_or_else(|| ConversionError::TypeMismatch {
+                field: field_name.to_string(),
+                expected: "map".to_string(),
+                got: format!("{:?}", cel_val),
+            })?;
+
+        let map_entry_desc = if let ProtoKind::Message(desc) = field.kind() {
+            desc
+        } else {
+            return Err(ConversionError::UnsupportedFieldType {
+                field: field_name.to_string(),
+                kind: format!("{:?}", field.kind()),
+            });
+        };
+
+        let key_field = map_entry_desc.get_field_by_name("key").ok_or_else(|| {
+            ConversionError::UnsupportedFieldType {
+                field: field_name.to_string(),
+                kind: "map entry missing 'key' field".to_string(),
+            }
+        })?;
+
+        let value_field = map_entry_desc.get_field_by_name("value").ok_or_else(|| {
+            ConversionError::UnsupportedFieldType {
+                field: field_name.to_string(),
+                kind: "map entry missing 'value' field".to_string(),
+            }
+        })?;
+
+        let mut proto_map = HashMap::new();
+        for (cel_key, cel_value) in cel_map.iter() {
+            let proto_key = Self::cel_map_key_to_proto(cel_key, &key_field)?;
+            let proto_value =
+                Self::cel_val_to_single_proto_value(cel_value.as_ref(), &value_field)?;
+            proto_map.insert(proto_key, proto_value);
+        }
+
+        Ok(ProtoValue::Map(proto_map))
+    }
+
+    fn cel_map_key_to_proto(
+        cel_key: &cel::common::types::CelMapKey,
+        key_field: &FieldDescriptor,
+    ) -> Result<MapKey, ConversionError> {
+        use cel::common::types::CelMapKey;
+
+        match cel_key {
+            CelMapKey::Bool(b) => Ok(MapKey::Bool(*b.inner())),
+            CelMapKey::Int(i) => {
+                let value = *i.inner();
+                match key_field.kind() {
+                    ProtoKind::Int32 | ProtoKind::Sint32 | ProtoKind::Sfixed32 => {
+                        Ok(MapKey::I32(value as i32))
+                    }
+                    ProtoKind::Int64 | ProtoKind::Sint64 | ProtoKind::Sfixed64 => {
+                        Ok(MapKey::I64(value))
+                    }
+                    _ => Err(ConversionError::TypeMismatch {
+                        field: key_field.name().to_string(),
+                        expected: "int32 or int64".to_string(),
+                        got: format!("{:?}", key_field.kind()),
+                    }),
+                }
+            }
+            CelMapKey::UInt(u) => {
+                let value = *u.inner();
+                match key_field.kind() {
+                    ProtoKind::Uint32 | ProtoKind::Fixed32 => Ok(MapKey::U32(value as u32)),
+                    ProtoKind::Uint64 | ProtoKind::Fixed64 => Ok(MapKey::U64(value)),
+                    _ => Err(ConversionError::TypeMismatch {
+                        field: key_field.name().to_string(),
+                        expected: "uint32 or uint64".to_string(),
+                        got: format!("{:?}", key_field.kind()),
+                    }),
+                }
+            }
+            CelMapKey::String(s) => Ok(MapKey::String(s.inner().to_string())),
+        }
     }
 
     fn cel_val_to_single_proto_value(
@@ -329,7 +500,7 @@ impl MessageConverter {
             }
             ProtoKind::Message(nested_desc) => {
                 let nested_message =
-                    Self::struct_from_val_to_message(cel_val, &nested_desc, &field_name)?;
+                    Self::struct_from_val_to_message(cel_val, &nested_desc, field_name)?;
                 Ok(ProtoValue::Message(nested_message))
             }
         }
@@ -556,6 +727,8 @@ mod tests {
         let inner_field = message
             .get_field_by_name("inner")
             .expect("inner field not found");
+        assert!(matches!(inner_field.as_ref(), ProtoValue::Message(_)));
+
         if let ProtoValue::Message(inner_msg) = inner_field.as_ref() {
             let value_field = inner_msg
                 .get_field_by_name("value")
@@ -564,8 +737,6 @@ mod tests {
                 value_field.as_ref(),
                 &ProtoValue::String("child".to_string())
             );
-        } else {
-            panic!("inner field is not a message");
         }
     }
 
@@ -611,5 +782,423 @@ mod tests {
             message.get_field_by_name("bool_field"),
             decoded.get_field_by_name("bool_field")
         );
+    }
+
+    #[test]
+    fn test_dynamic_message_to_cel() {
+        let descriptor = create_test_message_descriptor();
+        let mut message = DynamicMessage::new(descriptor.clone());
+
+        message.set_field_by_name("string_field", ProtoValue::String("hello".to_string()));
+        message.set_field_by_name("int32_field", ProtoValue::I32(42));
+        message.set_field_by_name("bool_field", ProtoValue::Bool(true));
+
+        let cel_value = MessageConverter::dynamic_message_to_cel(&message);
+
+        assert!(matches!(&cel_value, Value::Struct(_)));
+
+        if let Value::Struct(s) = &cel_value {
+            assert_eq!(s.name(), "test.TestMessage");
+
+            let string_val = s
+                .field_value("string_field")
+                .expect("string_field not found");
+            assert_eq!(
+                string_val.downcast_ref::<CelString>().map(|v| v.inner()),
+                Some("hello")
+            );
+
+            let int_val = s.field_value("int32_field").expect("int32_field not found");
+            assert_eq!(
+                int_val.downcast_ref::<CelInt>().map(|v| *v.inner()),
+                Some(42)
+            );
+
+            let bool_val = s.field_value("bool_field").expect("bool_field not found");
+            assert_eq!(
+                bool_val.downcast_ref::<CelBool>().map(|v| *v.inner()),
+                Some(true)
+            );
+        }
+    }
+
+    #[test]
+    fn test_cel_to_message_to_cel_roundtrip() {
+        let descriptor = create_test_message_descriptor();
+        let struct_def =
+            DescriptorConverter::to_struct_def(&descriptor).expect("Failed to convert descriptor");
+
+        let mut env = cel::Env::stdlib();
+        env.add_struct(struct_def);
+
+        let ctx = Context::with_env(Arc::new(env));
+
+        let program = Program::compile(
+            "test.TestMessage { string_field: 'roundtrip', int32_field: 999, bool_field: true }",
+        )
+        .expect("Failed to compile");
+
+        let original_cel = program.execute(&ctx).expect("Failed to execute");
+
+        let message = MessageConverter::cel_to_dynamic_message(&original_cel, &descriptor)
+            .expect("Failed to convert to message");
+
+        let converted_cel = MessageConverter::dynamic_message_to_cel(&message);
+
+        assert!(matches!(&converted_cel, Value::Struct(_)));
+
+        if let Value::Struct(s) = &converted_cel {
+            assert_eq!(s.name(), "test.TestMessage");
+
+            let string_val = s
+                .field_value("string_field")
+                .expect("string_field not found");
+            assert_eq!(
+                string_val.downcast_ref::<CelString>().map(|v| v.inner()),
+                Some("roundtrip")
+            );
+
+            let int_val = s.field_value("int32_field").expect("int32_field not found");
+            assert_eq!(
+                int_val.downcast_ref::<CelInt>().map(|v| *v.inner()),
+                Some(999)
+            );
+
+            let bool_val = s.field_value("bool_field").expect("bool_field not found");
+            assert_eq!(
+                bool_val.downcast_ref::<CelBool>().map(|v| *v.inner()),
+                Some(true)
+            );
+        }
+    }
+
+    #[test]
+    fn test_nested_message_to_cel() {
+        let file_descriptor = FileDescriptorProto {
+            name: Some("test.proto".to_string()),
+            package: Some("test".to_string()),
+            message_type: vec![
+                DescriptorProto {
+                    name: Some("Inner".to_string()),
+                    field: vec![FieldDescriptorProto {
+                        name: Some("value".to_string()),
+                        number: Some(1),
+                        r#type: Some(field_descriptor_proto::Type::String.into()),
+                        ..Default::default()
+                    }],
+                    ..Default::default()
+                },
+                DescriptorProto {
+                    name: Some("Outer".to_string()),
+                    field: vec![
+                        FieldDescriptorProto {
+                            name: Some("name".to_string()),
+                            number: Some(1),
+                            r#type: Some(field_descriptor_proto::Type::String.into()),
+                            ..Default::default()
+                        },
+                        FieldDescriptorProto {
+                            name: Some("inner".to_string()),
+                            number: Some(2),
+                            r#type: Some(field_descriptor_proto::Type::Message.into()),
+                            type_name: Some(".test.Inner".to_string()),
+                            ..Default::default()
+                        },
+                    ],
+                    ..Default::default()
+                },
+            ],
+            ..Default::default()
+        };
+
+        let fds = FileDescriptorSet {
+            file: vec![file_descriptor],
+        };
+
+        let pool = prost_reflect::DescriptorPool::from_file_descriptor_set(fds)
+            .expect("Failed to create descriptor pool");
+
+        let outer_descriptor = pool
+            .get_message_by_name("test.Outer")
+            .expect("Outer not found");
+        let inner_descriptor = pool
+            .get_message_by_name("test.Inner")
+            .expect("Inner not found");
+
+        let mut inner_message = DynamicMessage::new(inner_descriptor);
+        inner_message.set_field_by_name("value", ProtoValue::String("nested".to_string()));
+
+        let mut outer_message = DynamicMessage::new(outer_descriptor);
+        outer_message.set_field_by_name("name", ProtoValue::String("parent".to_string()));
+        outer_message.set_field_by_name("inner", ProtoValue::Message(inner_message));
+
+        let cel_value = MessageConverter::dynamic_message_to_cel(&outer_message);
+
+        assert!(matches!(&cel_value, Value::Struct(_)));
+
+        if let Value::Struct(outer_struct) = &cel_value {
+            assert_eq!(outer_struct.name(), "test.Outer");
+
+            let name_val = outer_struct.field_value("name").expect("name not found");
+            assert_eq!(
+                name_val.downcast_ref::<CelString>().map(|v| v.inner()),
+                Some("parent")
+            );
+
+            let inner_val = outer_struct.field_value("inner").expect("inner not found");
+            let inner_struct = inner_val
+                .downcast_ref::<CelStruct>()
+                .expect("inner should be a struct");
+            assert_eq!(inner_struct.name(), "test.Inner");
+
+            let value_val = inner_struct.field_value("value").expect("value not found");
+            assert_eq!(
+                value_val.downcast_ref::<CelString>().map(|v| v.inner()),
+                Some("nested")
+            );
+        }
+    }
+
+    #[test]
+    fn test_map_field_to_cel() {
+        use std::collections::HashMap;
+
+        let file_descriptor = FileDescriptorProto {
+            name: Some("test.proto".to_string()),
+            package: Some("test".to_string()),
+            message_type: vec![DescriptorProto {
+                name: Some("MapMessage".to_string()),
+                field: vec![FieldDescriptorProto {
+                    name: Some("tags".to_string()),
+                    number: Some(1),
+                    r#type: Some(field_descriptor_proto::Type::Message.into()),
+                    type_name: Some(".test.MapMessage.TagsEntry".to_string()),
+                    label: Some(prost_types::field_descriptor_proto::Label::Repeated.into()),
+                    ..Default::default()
+                }],
+                nested_type: vec![DescriptorProto {
+                    name: Some("TagsEntry".to_string()),
+                    options: Some(prost_types::MessageOptions {
+                        map_entry: Some(true),
+                        ..Default::default()
+                    }),
+                    field: vec![
+                        FieldDescriptorProto {
+                            name: Some("key".to_string()),
+                            number: Some(1),
+                            r#type: Some(field_descriptor_proto::Type::String.into()),
+                            ..Default::default()
+                        },
+                        FieldDescriptorProto {
+                            name: Some("value".to_string()),
+                            number: Some(2),
+                            r#type: Some(field_descriptor_proto::Type::String.into()),
+                            ..Default::default()
+                        },
+                    ],
+                    ..Default::default()
+                }],
+                ..Default::default()
+            }],
+            ..Default::default()
+        };
+
+        let fds = FileDescriptorSet {
+            file: vec![file_descriptor],
+        };
+
+        let pool = prost_reflect::DescriptorPool::from_file_descriptor_set(fds)
+            .expect("Failed to create descriptor pool");
+
+        let descriptor = pool
+            .get_message_by_name("test.MapMessage")
+            .expect("MapMessage not found");
+
+        let mut message = DynamicMessage::new(descriptor);
+
+        let mut map_entries = HashMap::new();
+        map_entries.insert(
+            MapKey::String("env".to_string()),
+            ProtoValue::String("prod".to_string()),
+        );
+        map_entries.insert(
+            MapKey::String("region".to_string()),
+            ProtoValue::String("us-east-1".to_string()),
+        );
+
+        message.set_field_by_name("tags", ProtoValue::Map(map_entries));
+
+        let cel_value = MessageConverter::dynamic_message_to_cel(&message);
+
+        assert!(matches!(&cel_value, Value::Struct(_)));
+
+        if let Value::Struct(s) = &cel_value {
+            let tags_val = s.field_value("tags").expect("tags not found");
+            let map = tags_val
+                .downcast_ref::<cel::common::types::CelMap>()
+                .expect("tags should be a map");
+
+            assert_eq!(map.len(), 2);
+        }
+    }
+
+    #[test]
+    fn test_cel_to_map_field() {
+        let file_descriptor = FileDescriptorProto {
+            name: Some("test.proto".to_string()),
+            package: Some("test".to_string()),
+            message_type: vec![DescriptorProto {
+                name: Some("MapMessage".to_string()),
+                field: vec![FieldDescriptorProto {
+                    name: Some("labels".to_string()),
+                    number: Some(1),
+                    r#type: Some(field_descriptor_proto::Type::Message.into()),
+                    type_name: Some(".test.MapMessage.LabelsEntry".to_string()),
+                    label: Some(prost_types::field_descriptor_proto::Label::Repeated.into()),
+                    ..Default::default()
+                }],
+                nested_type: vec![DescriptorProto {
+                    name: Some("LabelsEntry".to_string()),
+                    options: Some(prost_types::MessageOptions {
+                        map_entry: Some(true),
+                        ..Default::default()
+                    }),
+                    field: vec![
+                        FieldDescriptorProto {
+                            name: Some("key".to_string()),
+                            number: Some(1),
+                            r#type: Some(field_descriptor_proto::Type::String.into()),
+                            ..Default::default()
+                        },
+                        FieldDescriptorProto {
+                            name: Some("value".to_string()),
+                            number: Some(2),
+                            r#type: Some(field_descriptor_proto::Type::String.into()),
+                            ..Default::default()
+                        },
+                    ],
+                    ..Default::default()
+                }],
+                ..Default::default()
+            }],
+            ..Default::default()
+        };
+
+        let fds = FileDescriptorSet {
+            file: vec![file_descriptor],
+        };
+
+        let pool = prost_reflect::DescriptorPool::from_file_descriptor_set(fds)
+            .expect("Failed to create descriptor pool");
+
+        let descriptor = pool
+            .get_message_by_name("test.MapMessage")
+            .expect("MapMessage not found");
+
+        let mut env = cel::Env::stdlib();
+        DescriptorConverter::register_message_types(&mut env, &descriptor)
+            .expect("Failed to register types");
+
+        let ctx = Context::with_env(Arc::new(env));
+
+        let program = Program::compile(
+            r#"test.MapMessage { labels: {"env": "prod", "region": "us-east-1"} }"#,
+        )
+        .expect("Failed to compile");
+
+        let cel_value = program.execute(&ctx).expect("Failed to execute");
+
+        let message = MessageConverter::cel_to_dynamic_message(&cel_value, &descriptor)
+            .expect("Failed to convert");
+
+        let labels_field = message
+            .get_field_by_name("labels")
+            .expect("labels field not found");
+
+        assert!(matches!(labels_field.as_ref(), ProtoValue::Map(_)));
+
+        if let ProtoValue::Map(map) = labels_field.as_ref() {
+            assert_eq!(map.len(), 2);
+            assert_eq!(
+                map.get(&MapKey::String("env".to_string())),
+                Some(&ProtoValue::String("prod".to_string()))
+            );
+            assert_eq!(
+                map.get(&MapKey::String("region".to_string())),
+                Some(&ProtoValue::String("us-east-1".to_string()))
+            );
+        }
+    }
+
+    #[test]
+    fn test_list_field_to_cel() {
+        let file_descriptor = FileDescriptorProto {
+            name: Some("test.proto".to_string()),
+            package: Some("test".to_string()),
+            message_type: vec![DescriptorProto {
+                name: Some("ListMessage".to_string()),
+                field: vec![FieldDescriptorProto {
+                    name: Some("items".to_string()),
+                    number: Some(1),
+                    r#type: Some(field_descriptor_proto::Type::String.into()),
+                    label: Some(prost_types::field_descriptor_proto::Label::Repeated.into()),
+                    ..Default::default()
+                }],
+                ..Default::default()
+            }],
+            ..Default::default()
+        };
+
+        let fds = FileDescriptorSet {
+            file: vec![file_descriptor],
+        };
+
+        let pool = prost_reflect::DescriptorPool::from_file_descriptor_set(fds)
+            .expect("Failed to create descriptor pool");
+
+        let descriptor = pool
+            .get_message_by_name("test.ListMessage")
+            .expect("ListMessage not found");
+
+        let mut message = DynamicMessage::new(descriptor);
+        message.set_field_by_name(
+            "items",
+            ProtoValue::List(vec![
+                ProtoValue::String("first".to_string()),
+                ProtoValue::String("second".to_string()),
+                ProtoValue::String("third".to_string()),
+            ]),
+        );
+
+        let cel_value = MessageConverter::dynamic_message_to_cel(&message);
+
+        assert!(matches!(&cel_value, Value::Struct(_)));
+
+        if let Value::Struct(s) = &cel_value {
+            let items_val = s.field_value("items").expect("items not found");
+            let list = items_val
+                .downcast_ref::<cel::common::types::CelList>()
+                .expect("items should be a list");
+
+            assert_eq!(list.len(), 3);
+            assert_eq!(
+                list.first()
+                    .and_then(|v| v.downcast_ref::<CelString>())
+                    .map(|s| s.inner()),
+                Some("first")
+            );
+            assert_eq!(
+                list.get(1)
+                    .and_then(|v| v.downcast_ref::<CelString>())
+                    .map(|s| s.ingner()),
+                Some("second")
+            );
+            assert_eq!(
+                list.get(2)
+                    .and_then(|v| v.downcast_ref::<CelString>())
+                    .map(|s| s.inner()),
+                Some("third")
+            );
+        }
     }
 }

--- a/src/services/dynamic/converters.rs
+++ b/src/services/dynamic/converters.rs
@@ -77,10 +77,18 @@ impl DescriptorConverter {
     /// Convert a protobuf MessageDescriptor to a CEL StructDef
     /// Supports nested messages - they will be referenced by name
     pub fn to_struct_def(descriptor: &MessageDescriptor) -> Result<StructDef, ConversionError> {
+        use cel::common::types::*;
+        use prost_reflect::Cardinality;
+
         let mut struct_def = StructDef::new(descriptor.full_name().to_string());
 
         for field in descriptor.fields() {
-            let cel_type = Self::protobuf_kind_to_cel_type(field.kind())?;
+            let cel_type = if field.cardinality() == Cardinality::Repeated {
+                LIST_TYPE
+            } else {
+                Self::protobuf_kind_to_cel_type(field.kind())?
+            };
+
             struct_def = struct_def.add_field(field.name().to_string(), cel_type);
         }
 
@@ -145,6 +153,46 @@ impl MessageConverter {
     }
 
     fn cel_val_to_proto_value(
+        cel_val: &dyn cel::common::value::Val,
+        field: &FieldDescriptor,
+    ) -> Result<ProtoValue, ConversionError> {
+        use prost_reflect::Cardinality;
+
+        if field.cardinality() == Cardinality::Repeated {
+            Self::cel_list_to_proto_list(cel_val, field)
+        } else {
+            Self::cel_val_to_single_proto_value(cel_val, field)
+        }
+    }
+
+    fn cel_list_to_proto_list(
+        cel_val: &dyn cel::common::value::Val,
+        field: &FieldDescriptor,
+    ) -> Result<ProtoValue, ConversionError> {
+        use cel::common::types::CelList;
+
+        let field_name = field.name();
+
+        let list =
+            cel_val
+                .downcast_ref::<CelList>()
+                .ok_or_else(|| ConversionError::TypeMismatch {
+                    field: field_name.to_string(),
+                    expected: "list".to_string(),
+                    got: format!("{:?}", cel_val),
+                })?;
+
+        let mut proto_values = Vec::new();
+        for item in list.iter() {
+            // Process each list element as a single (non-repeated) value
+            let element_value = Self::cel_val_to_single_proto_value(item.as_ref(), field)?;
+            proto_values.push(element_value);
+        }
+
+        Ok(ProtoValue::List(proto_values))
+    }
+
+    fn cel_val_to_single_proto_value(
         cel_val: &dyn cel::common::value::Val,
         field: &FieldDescriptor,
     ) -> Result<ProtoValue, ConversionError> {
@@ -250,10 +298,11 @@ impl MessageConverter {
                         got: format!("{:?}", cel_val),
                     }
                 })?;
-                Ok(ProtoValue::Bytes(b.inner().to_vec().into()))
+                Ok(ProtoValue::Bytes(prost::bytes::Bytes::from(
+                    b.inner().to_vec(),
+                )))
             }
             ProtoKind::Enum(enum_desc) => {
-                // CEL represents enums as integers
                 let i = cel_val.downcast_ref::<CelInt>().ok_or_else(|| {
                     ConversionError::TypeMismatch {
                         field: field_name.to_string(),
@@ -279,7 +328,6 @@ impl MessageConverter {
                 Ok(ProtoValue::EnumNumber(value.number()))
             }
             ProtoKind::Message(nested_desc) => {
-                // Nested message - recurse
                 let nested_message =
                     Self::struct_from_val_to_message(cel_val, &nested_desc, &field_name)?;
                 Ok(ProtoValue::Message(nested_message))

--- a/src/services/dynamic/converters.rs
+++ b/src/services/dynamic/converters.rs
@@ -1190,7 +1190,7 @@ mod tests {
             assert_eq!(
                 list.get(1)
                     .and_then(|v| v.downcast_ref::<CelString>())
-                    .map(|s| s.ingner()),
+                    .map(|s| s.inner()),
                 Some("second")
             );
             assert_eq!(

--- a/src/services/mod.rs
+++ b/src/services/mod.rs
@@ -83,14 +83,17 @@ impl ServiceInstance {
                     ServiceError::Dispatch("Missing grpc_method for Dynamic service".to_string())
                 })?;
 
-                Ok(ServiceInstance::Dynamic(Rc::new(DynamicService::new(
+                let dynamic_service = DynamicService::new(
                     service.endpoint,
                     grpc_service.clone(),
                     grpc_method.clone(),
                     service.timeout.0,
                     service.failure_mode,
                     Rc::clone(descriptor_manager),
-                ))))
+                );
+                dynamic_service.register_for_fetch();
+
+                Ok(ServiceInstance::Dynamic(Rc::new(dynamic_service)))
             }
         }
     }

--- a/src/services/mod.rs
+++ b/src/services/mod.rs
@@ -5,20 +5,18 @@ use std::{rc::Rc, time::Duration};
 
 mod auth;
 mod dynamic;
-pub mod rate_limit;
 mod tracing;
 
 pub use auth::AuthService;
 pub use dynamic::DynamicService;
-pub use rate_limit::RateLimitService;
 pub use tracing::TracingService;
 
 #[derive(Clone)]
 pub enum ServiceInstance {
     Auth(Rc<AuthService>),
-    RateLimit(Rc<RateLimitService>),
-    RateLimitCheck(Rc<RateLimitService>),
-    RateLimitReport(Rc<RateLimitService>),
+    RateLimit(Rc<DynamicService>),
+    RateLimitCheck(Rc<DynamicService>),
+    RateLimitReport(Rc<DynamicService>),
     Tracing(Option<Rc<TracingService>>),
     Dynamic(Rc<DynamicService>),
 }
@@ -45,31 +43,32 @@ impl ServiceInstance {
                 service.timeout.0,
                 service.failure_mode,
             )))),
-            ServiceType::RateLimit => {
-                Ok(ServiceInstance::RateLimit(Rc::new(RateLimitService::new(
-                    service.endpoint,
-                    service.timeout.0,
-                    "envoy.service.ratelimit.v3.RateLimitService",
-                    "ShouldRateLimit",
-                    service.failure_mode,
-                ))))
-            }
+            ServiceType::RateLimit => Ok(ServiceInstance::RateLimit(Rc::new(DynamicService::new(
+                service.endpoint,
+                "envoy.service.ratelimit.v3.RateLimitService".to_string(),
+                "ShouldRateLimit".to_string(),
+                service.timeout.0,
+                service.failure_mode,
+                Rc::clone(descriptor_manager),
+            )))),
             ServiceType::RateLimitCheck => Ok(ServiceInstance::RateLimitCheck(Rc::new(
-                RateLimitService::new(
+                DynamicService::new(
                     service.endpoint,
+                    "kuadrant.service.ratelimit.v1.RateLimitService".to_string(),
+                    "CheckRateLimit".to_string(),
                     service.timeout.0,
-                    "kuadrant.service.ratelimit.v1.RateLimitService",
-                    "CheckRateLimit",
                     service.failure_mode,
+                    Rc::clone(descriptor_manager),
                 ),
             ))),
             ServiceType::RateLimitReport => Ok(ServiceInstance::RateLimitReport(Rc::new(
-                RateLimitService::new(
+                DynamicService::new(
                     service.endpoint,
+                    "kuadrant.service.ratelimit.v1.RateLimitService".to_string(),
+                    "Report".to_string(),
                     service.timeout.0,
-                    "kuadrant.service.ratelimit.v1.RateLimitService",
-                    "Report",
                     service.failure_mode,
+                    Rc::clone(descriptor_manager),
                 ),
             ))),
             ServiceType::Tracing => Ok(ServiceInstance::Tracing(Some(Rc::new(

--- a/vendor-protobufs/kuadrant/service/ratelimit/v1/ratelimit.proto
+++ b/vendor-protobufs/kuadrant/service/ratelimit/v1/ratelimit.proto
@@ -1,0 +1,13 @@
+syntax = "proto3";
+
+package kuadrant.service.ratelimit.v1;
+
+import "envoy/service/ratelimit/v3/rls.proto";
+
+service RateLimitService {
+  // Determine whether a request should be allowed or denied based on rate limiting rules.
+  rpc CheckRateLimit(envoy.service.ratelimit.v3.RateLimitRequest) returns (envoy.service.ratelimit.v3.RateLimitResponse);
+
+  // The report method modifies specific counters associated with the descriptors, incrementing each one by the amount specified in $hits_addend$
+  rpc Report(envoy.service.ratelimit.v3.RateLimitRequest) returns (envoy.service.ratelimit.v3.RateLimitResponse);
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Dynamic CEL-driven rate-limit dispatch and a new RateLimit RPC service.
  * Preloaded embedded rate-limit and auth descriptors for reliable fallback.

* **Improvements**
  * Descriptor deduplication to avoid redundant descriptor loads.
  * Rich bidirectional protobuf↔CEL conversion enabling CEL-built requests and dynamic response parsing.
  * Improved CEL struct/type handling with clearer, specific error messages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->