### PR TITLE
feat: add gRPC well-known attributes (request.grpc)

### DIFF
--- a/src/data/cel.rs
+++ b/src/data/cel.rs
@@ -158,14 +158,12 @@ impl Expression {
             &mut Vec::default(),
         );
 
-        let needs_grpc = props
-            .iter()
-            .any(|tokens| tokens.len() >= 2 && tokens[0] == "request" && tokens[1] == "grpc");
-
+        let mut needs_grpc = false;
         let mut attributes: Vec<Attribute> = props
             .into_iter()
             .filter_map(|tokens| {
                 if tokens.len() >= 2 && tokens[0] == "request" && tokens[1] == "grpc" {
+                    needs_grpc = true;
                     return None;
                 }
                 let root = tokens.first()?;
@@ -276,27 +274,23 @@ impl Expression {
     }
 
     fn resolve_grpc(&self, req_ctx: &ReqRespCtx) -> Option<Value> {
-        let content_type: Option<String> = req_ctx
-            .get_attribute::<Headers>("request.headers")
-            .ok()
-            .and_then(|state| match state {
-                AttributeState::Available(Some(headers)) => {
-                    headers.get("content-type").map(|s| s.to_string())
-                }
-                _ => None,
-            });
+        let content_type = req_ctx.get_request_header("content-type");
 
         if !content_type.as_deref().is_some_and(is_grpc_content_type) {
             return None;
         }
 
-        let url_path: Option<String> = req_ctx
-            .get_attribute::<String>("request.url_path")
-            .ok()
-            .and_then(|state| match state {
-                AttributeState::Available(opt) => opt,
-                _ => None,
-            });
+        let url_path: Option<String> = match req_ctx.get_attribute::<String>("request.url_path") {
+            Ok(AttributeState::Available(opt)) => opt,
+            Ok(AttributeState::Pending) => {
+                warn!("request.url_path is pending during gRPC attribute resolution");
+                None
+            }
+            Err(e) => {
+                warn!("failed to get request.url_path for gRPC resolution: {e}");
+                None
+            }
+        };
 
         let (service, method) = match url_path.as_deref().and_then(parse_grpc_path) {
             Some((s, m)) => (Value::String(s.into()), Value::String(m.into())),
@@ -1425,6 +1419,23 @@ mod tests {
             );
         let ctx = ReqRespCtx::new(Arc::new(mock_host));
         let predicate = Predicate::new("request.grpc.method == 'GetUser'").expect("valid CEL");
+        assert_eq!(
+            predicate.test(&ctx).expect("must evaluate"),
+            AttributeState::Available(true)
+        );
+    }
+
+    #[test]
+    fn grpc_has_true_for_grpc_request() {
+        let headers = vec![("content-type".to_string(), "application/grpc".to_string())];
+        let mock_host = MockWasmHost::new()
+            .with_map("request.headers".to_string(), headers)
+            .with_property(
+                "request.url_path".into(),
+                "/UserService/GetUser".bytes().collect(),
+            );
+        let ctx = ReqRespCtx::new(Arc::new(mock_host));
+        let predicate = Predicate::new("has(request.grpc)").expect("valid CEL");
         assert_eq!(
             predicate.test(&ctx).expect("must evaluate"),
             AttributeState::Available(true)

--- a/src/data/cel.rs
+++ b/src/data/cel.rs
@@ -1,5 +1,6 @@
 use crate::data::attribute::{AttributeError, AttributeState, Path};
 use crate::data::cel::errors::{CelError, EvaluationError};
+use crate::data::grpc::{is_grpc_content_type, parse_grpc_path};
 use crate::data::Headers;
 use crate::kuadrant::ReqRespCtx;
 use cel::common::ast::{EntryExpr, Expr, IdedExpr, LiteralValue};
@@ -104,6 +105,7 @@ pub struct Expression {
     body_values: Vec<String>,
     expression: CelExpression,
     extended: bool,
+    needs_grpc: bool,
 }
 
 pub type EvalResult = Result<AttributeState<Value>, CelError>;
@@ -112,8 +114,8 @@ impl Display for Expression {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         write!(
             f,
-            "Expression {{ expression: {:?}, attributes: {:?}, extended: {} }}",
-            self.expression, self.attributes, self.extended
+            "Expression {{ expression: {:?}, attributes: {:?}, extended: {}, needs_grpc: {} }}",
+            self.expression, self.attributes, self.extended, self.needs_grpc
         )
     }
 }
@@ -122,9 +124,10 @@ impl PartialEq for Expression {
     fn eq(&self, other: &Self) -> bool {
         let attributes_match = self.attributes == other.attributes;
         let extended_match = self.extended == other.extended;
+        let needs_grpc_match = self.needs_grpc == other.needs_grpc;
         let expressions_match =
             format!("{:?}", self.expression) == format!("{:?}", other.expression);
-        attributes_match && extended_match && expressions_match
+        attributes_match && extended_match && needs_grpc_match && expressions_match
     }
 }
 
@@ -155,9 +158,16 @@ impl Expression {
             &mut Vec::default(),
         );
 
+        let needs_grpc = props
+            .iter()
+            .any(|tokens| tokens.len() >= 2 && tokens[0] == "request" && tokens[1] == "grpc");
+
         let mut attributes: Vec<Attribute> = props
             .into_iter()
             .filter_map(|tokens| {
+                if tokens.len() >= 2 && tokens[0] == "request" && tokens[1] == "grpc" {
+                    return None;
+                }
                 let root = tokens.first()?;
                 if !HOST_PROPERTY_ROOTS.contains(root) {
                     return None;
@@ -177,6 +187,7 @@ impl Expression {
             body_values: response_props,
             expression,
             extended,
+            needs_grpc,
         })
     }
 
@@ -213,7 +224,21 @@ impl Expression {
             AttributeState::Available(m) => m,
         };
 
-        for binding in ["request", "metadata", "source", "destination", "auth"] {
+        let request_key: Key = "request".into();
+        let mut request_value = map.get(&request_key).cloned().unwrap_or(Value::Null);
+        if self.needs_grpc {
+            let mut request_map: HashMap<Key, Value> = match request_value {
+                Value::Map(ref m) => m.map.as_ref().clone(),
+                _ => HashMap::new(),
+            };
+            if let Some(grpc_map) = self.resolve_grpc(req_ctx) {
+                request_map.insert(Key::String(Arc::new("grpc".to_string())), grpc_map);
+            }
+            request_value = Value::Map(request_map.into());
+        }
+        cel_ctx.add_variable_from_value("request", request_value);
+
+        for binding in ["metadata", "source", "destination", "auth"] {
             let key: Key = binding.into();
             cel_ctx.add_variable_from_value(binding, map.get(&key).cloned().unwrap_or(Value::Null));
         }
@@ -248,6 +273,41 @@ impl Expression {
 
     pub fn body_values(&self) -> &[String] {
         &self.body_values
+    }
+
+    fn resolve_grpc(&self, req_ctx: &ReqRespCtx) -> Option<Value> {
+        let content_type: Option<String> = req_ctx
+            .get_attribute::<Headers>("request.headers")
+            .ok()
+            .and_then(|state| match state {
+                AttributeState::Available(Some(headers)) => {
+                    headers.get("content-type").map(|s| s.to_string())
+                }
+                _ => None,
+            });
+
+        if !content_type.as_deref().is_some_and(is_grpc_content_type) {
+            return None;
+        }
+
+        let url_path: Option<String> = req_ctx
+            .get_attribute::<String>("request.url_path")
+            .ok()
+            .and_then(|state| match state {
+                AttributeState::Available(opt) => opt,
+                _ => None,
+            });
+
+        let (service, method) = match url_path.as_deref().and_then(parse_grpc_path) {
+            Some((s, m)) => (Value::String(s.into()), Value::String(m.into())),
+            None => return None,
+        };
+
+        let map: HashMap<Key, Value> = HashMap::from([
+            (Key::String(Arc::new("service".to_string())), service),
+            (Key::String(Arc::new("method".to_string())), method),
+        ]);
+        Some(Value::Map(map.into()))
     }
 }
 
@@ -1318,6 +1378,120 @@ mod tests {
             .into(&ctx)
             .expect("Should not return AttributeError");
         assert_eq!(result, AttributeState::Pending);
+    }
+
+    #[test]
+    fn grpc_properties_filtered_from_attributes() {
+        let expr = Expression::new("request.grpc.service == 'UserService'").expect("valid CEL");
+        // request.grpc.* paths should be filtered; only non-grpc request attrs remain
+        assert!(
+            !expr.attributes.iter().any(|a| {
+                let tokens = a.path.tokens();
+                tokens.len() >= 2 && tokens[0] == "request" && tokens[1] == "grpc"
+            }),
+            "request.grpc.* paths should be filtered from attributes: {:?}",
+            expr.attributes
+        );
+    }
+
+    #[test]
+    fn grpc_service_matches() {
+        let headers = vec![("content-type".to_string(), "application/grpc".to_string())];
+        let mock_host = MockWasmHost::new()
+            .with_map("request.headers".to_string(), headers)
+            .with_property(
+                "request.url_path".into(),
+                "/UserService/GetUser".bytes().collect(),
+            );
+        let ctx = ReqRespCtx::new(Arc::new(mock_host));
+        let predicate = Predicate::new("request.grpc.service == 'UserService'").expect("valid CEL");
+        assert_eq!(
+            predicate.test(&ctx).expect("must evaluate"),
+            AttributeState::Available(true)
+        );
+    }
+
+    #[test]
+    fn grpc_method_matches() {
+        let headers = vec![(
+            "content-type".to_string(),
+            "application/grpc+proto".to_string(),
+        )];
+        let mock_host = MockWasmHost::new()
+            .with_map("request.headers".to_string(), headers)
+            .with_property(
+                "request.url_path".into(),
+                "/UserService/GetUser".bytes().collect(),
+            );
+        let ctx = ReqRespCtx::new(Arc::new(mock_host));
+        let predicate = Predicate::new("request.grpc.method == 'GetUser'").expect("valid CEL");
+        assert_eq!(
+            predicate.test(&ctx).expect("must evaluate"),
+            AttributeState::Available(true)
+        );
+    }
+
+    #[test]
+    fn grpc_not_set_for_http_request() {
+        let headers = vec![("content-type".to_string(), "application/json".to_string())];
+        let mock_host = MockWasmHost::new()
+            .with_map("request.headers".to_string(), headers)
+            .with_property("request.url_path".into(), "/api/users".bytes().collect());
+        let ctx = ReqRespCtx::new(Arc::new(mock_host));
+        let predicate = Predicate::new("has(request.grpc)").expect("valid CEL");
+        assert_eq!(
+            predicate.test(&ctx).expect("must evaluate"),
+            AttributeState::Available(false)
+        );
+    }
+
+    #[test]
+    fn grpc_not_set_for_malformed_path() {
+        let headers = vec![("content-type".to_string(), "application/grpc".to_string())];
+        let mock_host = MockWasmHost::new()
+            .with_map("request.headers".to_string(), headers)
+            .with_property("request.url_path".into(), "/malformed".bytes().collect());
+        let ctx = ReqRespCtx::new(Arc::new(mock_host));
+        let predicate = Predicate::new("has(request.grpc)").expect("valid CEL");
+        assert_eq!(
+            predicate.test(&ctx).expect("must evaluate"),
+            AttributeState::Available(false)
+        );
+    }
+
+    #[test]
+    fn grpc_has_guard_with_service_match() {
+        let headers = vec![("content-type".to_string(), "application/grpc".to_string())];
+        let mock_host = MockWasmHost::new()
+            .with_map("request.headers".to_string(), headers)
+            .with_property(
+                "request.url_path".into(),
+                "/UserService/GetUser".bytes().collect(),
+            );
+        let ctx = ReqRespCtx::new(Arc::new(mock_host));
+        let predicate =
+            Predicate::new("has(request.grpc) && request.grpc.service == 'UserService'")
+                .expect("valid CEL");
+        assert_eq!(
+            predicate.test(&ctx).expect("must evaluate"),
+            AttributeState::Available(true)
+        );
+    }
+
+    #[test]
+    fn grpc_has_guard_false_on_http() {
+        let headers = vec![("content-type".to_string(), "application/json".to_string())];
+        let mock_host = MockWasmHost::new()
+            .with_map("request.headers".to_string(), headers)
+            .with_property("request.url_path".into(), "/api/users".bytes().collect());
+        let ctx = ReqRespCtx::new(Arc::new(mock_host));
+        let predicate =
+            Predicate::new("has(request.grpc) && request.grpc.service == 'UserService'")
+                .expect("valid CEL");
+        assert_eq!(
+            predicate.test(&ctx).expect("must evaluate"),
+            AttributeState::Available(false)
+        );
     }
 
     #[test]

--- a/src/data/grpc.rs
+++ b/src/data/grpc.rs
@@ -1,0 +1,63 @@
+/// Returns `true` if the content-type indicates a gRPC request.
+pub(crate) fn is_grpc_content_type(content_type: &str) -> bool {
+    content_type.starts_with("application/grpc")
+}
+
+/// Parses a gRPC path of the form `/Service/Method`.
+/// Returns `None` for paths that don't match the expected format.
+pub(crate) fn parse_grpc_path(path: &str) -> Option<(String, String)> {
+    let trimmed = path.strip_prefix('/')?;
+    let (service, method) = trimmed.split_once('/')?;
+    if service.is_empty() || method.is_empty() || method.contains('/') {
+        return None;
+    }
+    Some((service.to_string(), method.to_string()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_is_grpc_content_type() {
+        let tests = vec![
+            ("application/grpc", true),
+            ("application/grpc+proto", true),
+            ("application/grpc+json", true),
+            ("application/json", false),
+            ("text/plain", false),
+            ("", false),
+        ];
+
+        for (input, expected) in tests {
+            assert_eq!(
+                is_grpc_content_type(input),
+                expected,
+                "is_grpc_content_type({input:?})"
+            );
+        }
+    }
+
+    #[test]
+    fn test_parse_grpc_path() {
+        let tests: Vec<(&str, Option<(&str, &str)>)> = vec![
+            ("/UserService/GetUser", Some(("UserService", "GetUser"))),
+            (
+                "/com.example.UserService/GetUser",
+                Some(("com.example.UserService", "GetUser")),
+            ),
+            ("/Service/Method/Extra", None),
+            ("/Service/", None),
+            ("//Method", None),
+            ("Service/Method", None),
+            ("/", None),
+            ("", None),
+        ];
+
+        for (input, expected) in tests {
+            let result = parse_grpc_path(input);
+            let expected = expected.map(|(s, m)| (s.to_string(), m.to_string()));
+            assert_eq!(result, expected, "parse_grpc_path({input:?})");
+        }
+    }
+}

--- a/src/data/mod.rs
+++ b/src/data/mod.rs
@@ -1,5 +1,6 @@
 pub mod attribute;
 pub mod cel;
+mod grpc;
 mod headers;
 
 pub use cel::Expression;

--- a/src/kuadrant/context.rs
+++ b/src/kuadrant/context.rs
@@ -151,6 +151,19 @@ impl ReqRespCtx {
         }
     }
 
+    pub fn get_request_header(&self, key: &str) -> Option<String> {
+        match self
+            .backend
+            .get_attribute_map_value(proxy_wasm::types::MapType::HttpRequestHeaders, key)
+        {
+            Ok(value) => value,
+            Err(e) => {
+                warn!("failed to get request header '{key}': {e}");
+                None
+            }
+        }
+    }
+
     pub fn get_attribute_ref<T: AttributeValue>(
         &self,
         path: &Path,

--- a/src/kuadrant/resolver/mock.rs
+++ b/src/kuadrant/resolver/mock.rs
@@ -109,6 +109,15 @@ impl AttributeResolver for MockWasmHost {
         }
     }
 
+    fn get_attribute_map_value(
+        &self,
+        map_type: proxy_wasm::types::MapType,
+        key: &str,
+    ) -> Result<Option<String>, AttributeError> {
+        let map = self.get_attribute_map(map_type)?;
+        Ok(map.into_iter().find(|(k, _)| k == key).map(|(_, v)| v))
+    }
+
     fn set_attribute(&self, path: &Path, value: &[u8]) -> Result<(), AttributeError> {
         assert_eq!(
             path.tokens().len(),

--- a/src/kuadrant/resolver/mod.rs
+++ b/src/kuadrant/resolver/mod.rs
@@ -17,6 +17,11 @@ pub trait AttributeResolver: Send + Sync {
         &self,
         map_type: proxy_wasm::types::MapType,
     ) -> Result<Vec<(String, String)>, AttributeError>;
+    fn get_attribute_map_value(
+        &self,
+        map_type: proxy_wasm::types::MapType,
+        key: &str,
+    ) -> Result<Option<String>, AttributeError>;
     fn set_attribute(&self, path: &Path, value: &[u8]) -> Result<(), AttributeError>;
     fn set_attribute_map(
         &self,

--- a/src/kuadrant/resolver/wasm_host.rs
+++ b/src/kuadrant/resolver/wasm_host.rs
@@ -41,6 +41,23 @@ impl AttributeResolver for ProxyWasmHost {
         }
     }
 
+    fn get_attribute_map_value(
+        &self,
+        map_type: proxy_wasm::types::MapType,
+        key: &str,
+    ) -> Result<Option<String>, AttributeError> {
+        debug!("Getting map value: `{:?}[{key}]`", map_type);
+        match hostcalls::get_map_value(map_type, key) {
+            Ok(value) => Ok(value),
+            Err(Status::BadArgument) => Err(AttributeError::NotAvailable(format!(
+                "Map `{map_type:?}` not available in current phase",
+            ))),
+            Err(err) => Err(AttributeError::Retrieval(format!(
+                "Error getting map value: {err:?}"
+            ))),
+        }
+    }
+
     fn set_attribute(&self, path: &Path, value: &[u8]) -> Result<(), AttributeError> {
         debug!("Setting property: `{}`", path);
         match hostcalls::set_property(path.tokens(), Some(value)) {


### PR DESCRIPTION
## Summary

- Add `request.grpc.service` and `request.grpc.method` as computed CEL attributes
- gRPC requests detected via `content-type: application/grpc` header and `/Service/Method` path parsing
- For non-gRPC requests, `request.grpc` is absent — `has(request.grpc)` returns `false`
- New `src/data/grpc.rs` module with detection and parsing functions
- No CEL optional types extension required — uses standard `has()` macro for presence checking

### Usage

```yaml
# Check if request is gRPC
when:
  - predicate: has(request.grpc) && request.grpc.service == 'UserService'
  - predicate: has(request.grpc) && request.grpc.method == 'GetUser'
```

## Test plan

- [x] Unit tests for `is_grpc_content_type()` (6 cases)
- [x] Unit tests for `parse_grpc_path()` (8 cases)
- [x] CEL integration: `request.grpc.service` matches on gRPC request
- [x] CEL integration: `request.grpc.method` matches on gRPC request
- [x] CEL integration: `has(request.grpc)` returns false for HTTP requests
- [x] CEL integration: `has(request.grpc)` returns false for malformed gRPC path
- [x] CEL integration: `has(request.grpc) && request.grpc.service == 'X'` guard pattern works
- [x] CEL integration: guard pattern returns false on HTTP traffic

Resolves https://github.com/Kuadrant/wasm-shim/issues/317

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * CEL policies are now gRPC-aware, exposing request gRPC service/method for more precise policy matching.
  * Added gRPC detection and path-parsing utilities.

* **Chores**
  * Enhanced request header and attribute-map retrieval helpers across host/resolver implementations to support gRPC logic.

* **Tests**
  * Added tests for gRPC content-type detection, path parsing, attribute filtering and correct gRPC match/guard behaviour.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->