### PR TITLE
Open config up for more explicitly defining tasks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -218,7 +218,7 @@ dependencies = [
 [[package]]
 name = "cel"
 version = "0.13.0"
-source = "git+https://github.com/cel-rust/cel-rust.git?branch=master#212f441dbf3fa41289bfdb9f0a8c234e6db7125a"
+source = "git+https://github.com/cel-rust/cel-rust.git?branch=master#cc7c3781d2a6d9bdefa736103be56fd439d98330"
 dependencies = [
  "antlr4rust",
  "chrono",

--- a/src/configuration.rs
+++ b/src/configuration.rs
@@ -31,7 +31,6 @@ pub struct Action {
 
 #[derive(Deserialize, Debug, Clone)]
 #[serde(rename_all = "camelCase")]
-#[allow(dead_code)]
 pub struct TypedAction {
     pub predicate: String,
     pub terminal: bool,
@@ -41,7 +40,6 @@ pub struct TypedAction {
 
 #[derive(Deserialize, Debug, Clone)]
 #[serde(tag = "type", rename_all = "lowercase")]
-#[allow(dead_code)]
 pub enum Operation {
     Grpc(GrpcOperation),
     Deny(DenyOperation),
@@ -52,7 +50,6 @@ pub enum Operation {
 
 #[derive(Deserialize, Debug, Clone)]
 #[serde(rename_all = "camelCase")]
-#[allow(dead_code)]
 pub struct GrpcOperation {
     pub var: String,
     pub service: String,
@@ -63,7 +60,6 @@ pub struct GrpcOperation {
 
 #[derive(Deserialize, Debug, Clone)]
 #[serde(rename_all = "camelCase")]
-#[allow(dead_code)]
 pub struct DenyOperation {
     pub deny_with: String,
 }
@@ -77,7 +73,6 @@ pub enum HeadersTarget {
 
 #[derive(Deserialize, Debug, Clone)]
 #[serde(rename_all = "camelCase")]
-#[allow(dead_code)]
 pub struct HeadersOperation {
     pub target: HeadersTarget,
     pub headers: String,
@@ -85,13 +80,11 @@ pub struct HeadersOperation {
 
 #[derive(Deserialize, Debug, Clone)]
 #[serde(rename_all = "camelCase")]
-#[allow(dead_code)]
 pub struct StoreOperation {
     pub data: Vec<StoreItem>,
 }
 
 #[derive(Deserialize, Debug, Clone)]
-#[allow(dead_code)]
 pub struct StoreItem {
     pub path: String,
     pub value: String,
@@ -679,7 +672,7 @@ mod test {
     }
 
     #[test]
-    fn parse_grpc_action_with_on_reply() {q
+    fn parse_grpc_action_with_on_reply() {
         let config = r#"{
             "services": {
                 "limitador": {

--- a/src/configuration.rs
+++ b/src/configuration.rs
@@ -29,6 +29,87 @@ pub struct Action {
     pub sources: Vec<String>,
 }
 
+#[derive(Deserialize, Debug, Clone)]
+#[serde(rename_all = "camelCase")]
+#[allow(dead_code)]
+pub struct TypedAction {
+    pub predicate: String,
+    pub terminal: bool,
+    #[serde(flatten)]
+    pub operation: Operation,
+}
+
+#[derive(Deserialize, Debug, Clone)]
+#[serde(tag = "type", rename_all = "lowercase")]
+#[allow(dead_code)]
+pub enum Operation {
+    Grpc(GrpcOperation),
+    Deny(DenyOperation),
+    Headers(HeadersOperation),
+    Store(StoreOperation),
+    Fail(FailOperation),
+}
+
+#[derive(Deserialize, Debug, Clone)]
+#[serde(rename_all = "camelCase")]
+#[allow(dead_code)]
+pub struct GrpcOperation {
+    pub var: String,
+    pub service: String,
+    pub message_builder: String,
+    #[serde(default)]
+    pub on_reply: Vec<TypedAction>,
+}
+
+#[derive(Deserialize, Debug, Clone)]
+#[serde(rename_all = "camelCase")]
+#[allow(dead_code)]
+pub struct DenyOperation {
+    pub deny_with: String,
+}
+
+#[derive(Deserialize, Debug, Clone)]
+#[serde(rename_all = "lowercase")]
+pub enum HeadersTarget {
+    Request,
+    Response,
+}
+
+#[derive(Deserialize, Debug, Clone)]
+#[serde(rename_all = "camelCase")]
+#[allow(dead_code)]
+pub struct HeadersOperation {
+    pub target: HeadersTarget,
+    pub headers: String,
+}
+
+#[derive(Deserialize, Debug, Clone)]
+#[serde(rename_all = "camelCase")]
+#[allow(dead_code)]
+pub struct StoreOperation {
+    pub data: Vec<StoreItem>,
+}
+
+#[derive(Deserialize, Debug, Clone)]
+#[allow(dead_code)]
+pub struct StoreItem {
+    pub path: String,
+    pub value: String,
+}
+
+#[derive(Deserialize, Debug, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct FailOperation {
+    pub log_message: String,
+}
+
+#[derive(Deserialize, Debug, Clone)]
+#[serde(untagged)]
+pub enum ActionConfig {
+    Typed(TypedAction),
+    Legacy(Action),
+}
+
 #[derive(Deserialize, Debug, Clone, Default)]
 pub struct RouteRuleConditions {
     pub hostnames: Vec<String>,
@@ -41,7 +122,7 @@ pub struct RouteRuleConditions {
 pub struct ActionSet {
     pub name: String,
     pub route_rule_conditions: RouteRuleConditions,
-    pub actions: Vec<Action>,
+    pub actions: Vec<ActionConfig>,
 }
 
 #[derive(Deserialize, Debug, Clone)]
@@ -298,11 +379,15 @@ mod test {
         let actions = &plugin_config.action_sets[0].actions;
         assert_eq!(actions.len(), 2);
 
-        let auth_action = &actions[0];
+        let ActionConfig::Legacy(auth_action) = &actions[0] else {
+            unreachable!("expected legacy action");
+        };
         assert_eq!(auth_action.service, "authorino");
         assert_eq!(auth_action.scope, "authconfig-A");
 
-        let rl_action = &actions[1];
+        let ActionConfig::Legacy(rl_action) = &actions[1] else {
+            unreachable!("expected legacy action");
+        };
         assert_eq!(rl_action.service, "limitador");
         assert_eq!(rl_action.scope, "rlp-ns-A/rlp-name-A");
 
@@ -469,8 +554,10 @@ mod test {
         let actions = &plugin_config.action_sets[0].actions;
         assert_eq!(actions.len(), 1);
 
-        let action_predicates = &actions[0].predicates;
-        assert_eq!(action_predicates.len(), 0);
+        let ActionConfig::Legacy(action) = &actions[0] else {
+            unreachable!("expected legacy action");
+        };
+        assert_eq!(action.predicates.len(), 0);
     }
 
     #[test]
@@ -589,5 +676,313 @@ mod test {
             dynamic_service.grpc_method.as_ref(),
             Some(&"ShouldRateLimit".to_string())
         );
+    }
+
+    #[test]
+    fn parse_grpc_action_with_on_reply() {q
+        let config = r#"{
+            "services": {
+                "limitador": {
+                    "type": "dynamic",
+                    "endpoint": "limitador-cluster",
+                    "failureMode": "deny",
+                    "timeout": "100ms",
+                    "grpcService": "envoy.service.ratelimit.v3.RateLimitService",
+                    "grpcMethod": "ShouldRateLimit"
+                }
+            },
+            "actionSets": [{
+                "name": "test-rl",
+                "routeRuleConditions": {
+                    "hostnames": ["api.example.com"]
+                },
+                "actions": [{
+                    "type": "grpc",
+                    "predicate": "request.method == 'GET'",
+                    "terminal": false,
+                    "var": "rl_check",
+                    "service": "limitador",
+                    "messageBuilder": "envoy.service.ratelimit.v3.RateLimitRequest { domain: 'test' }",
+                    "onReply": [
+                        {
+                            "type": "deny",
+                            "predicate": "rl_check.overall_code == 2",
+                            "terminal": true,
+                            "denyWith": "DenyResponse{status: 429u}"
+                        },
+                        {
+                            "type": "headers",
+                            "predicate": "true",
+                            "terminal": false,
+                            "target": "response",
+                            "headers": "rl_check.response_headers_to_add"
+                        }
+                    ]
+                }]
+            }]
+        }"#;
+
+        let res = serde_json::from_str::<PluginConfiguration>(config);
+        if let Err(ref e) = res {
+            eprintln!("{e}");
+        }
+        assert!(res.is_ok());
+
+        let plugin_config = res.expect("result is ok");
+        let actions = &plugin_config.action_sets[0].actions;
+        assert_eq!(actions.len(), 1);
+
+        let ActionConfig::Typed(typed) = &actions[0] else {
+            unreachable!("expected typed action");
+        };
+        assert_eq!(typed.predicate, "request.method == 'GET'");
+        assert!(!typed.terminal);
+
+        let Operation::Grpc(grpc) = &typed.operation else {
+            unreachable!("expected grpc operation");
+        };
+        assert_eq!(grpc.var, "rl_check");
+        assert_eq!(grpc.service, "limitador");
+        assert_eq!(
+            grpc.message_builder,
+            "envoy.service.ratelimit.v3.RateLimitRequest { domain: 'test' }"
+        );
+        assert_eq!(grpc.on_reply.len(), 2);
+
+        let reply_deny = &grpc.on_reply[0];
+        assert_eq!(reply_deny.predicate, "rl_check.overall_code == 2");
+        assert!(reply_deny.terminal);
+        let Operation::Deny(deny) = &reply_deny.operation else {
+            unreachable!("expected deny operation");
+        };
+        assert_eq!(deny.deny_with, "DenyResponse{status: 429u}");
+
+        let reply_headers = &grpc.on_reply[1];
+        assert!(!reply_headers.terminal);
+        let Operation::Headers(headers) = &reply_headers.operation else {
+            unreachable!("expected headers operation");
+        };
+        assert!(matches!(headers.target, HeadersTarget::Response));
+        assert_eq!(headers.headers, "rl_check.response_headers_to_add");
+    }
+
+    #[test]
+    fn parse_deny_action() {
+        let config = r#"{
+            "services": {},
+            "actionSets": [{
+                "name": "test-deny",
+                "routeRuleConditions": {
+                    "hostnames": ["example.com"]
+                },
+                "actions": [{
+                    "type": "deny",
+                    "predicate": "request.path.startsWith('/admin')",
+                    "terminal": true,
+                    "denyWith": "DenyResponse{status: 403u}"
+                }]
+            }]
+        }"#;
+
+        let res = serde_json::from_str::<PluginConfiguration>(config);
+        assert!(res.is_ok());
+
+        let plugin_config = res.expect("result is ok");
+        let ActionConfig::Typed(typed) = &plugin_config.action_sets[0].actions[0] else {
+            unreachable!("expected typed action");
+        };
+        assert_eq!(typed.predicate, "request.path.startsWith('/admin')");
+        assert!(typed.terminal);
+        let Operation::Deny(deny) = &typed.operation else {
+            unreachable!("expected deny operation");
+        };
+        assert_eq!(deny.deny_with, "DenyResponse{status: 403u}");
+    }
+
+    #[test]
+    fn parse_headers_action() {
+        let config = r#"{
+            "services": {},
+            "actionSets": [{
+                "name": "test-headers",
+                "routeRuleConditions": {
+                    "hostnames": ["example.com"]
+                },
+                "actions": [
+                    {
+                        "type": "headers",
+                        "predicate": "has(auth_check.ok_response)",
+                        "terminal": false,
+                        "target": "request",
+                        "headers": "auth_check.ok_response.headers"
+                    },
+                    {
+                        "type": "headers",
+                        "predicate": "true",
+                        "terminal": false,
+                        "target": "response",
+                        "headers": "rl_check.response_headers_to_add"
+                    }
+                ]
+            }]
+        }"#;
+
+        let res = serde_json::from_str::<PluginConfiguration>(config);
+        assert!(res.is_ok());
+
+        let plugin_config = res.expect("result is ok");
+        let ActionConfig::Typed(typed_req) = &plugin_config.action_sets[0].actions[0] else {
+            unreachable!("expected typed action");
+        };
+        let Operation::Headers(req_headers) = &typed_req.operation else {
+            unreachable!("expected headers operation");
+        };
+        assert!(matches!(req_headers.target, HeadersTarget::Request));
+        assert_eq!(req_headers.headers, "auth_check.ok_response.headers");
+
+        let ActionConfig::Typed(typed_resp) = &plugin_config.action_sets[0].actions[1] else {
+            unreachable!("expected typed action");
+        };
+        let Operation::Headers(resp_headers) = &typed_resp.operation else {
+            unreachable!("expected headers operation");
+        };
+        assert!(matches!(resp_headers.target, HeadersTarget::Response));
+        assert_eq!(resp_headers.headers, "rl_check.response_headers_to_add");
+    }
+
+    #[test]
+    fn parse_store_action() {
+        let config = r#"{
+            "services": {},
+            "actionSets": [{
+                "name": "test-store",
+                "routeRuleConditions": {
+                    "hostnames": ["example.com"]
+                },
+                "actions": [{
+                    "type": "store",
+                    "predicate": "true",
+                    "terminal": false,
+                    "data": [
+                        { "path": "auth.metadata", "value": "auth_check.dynamic_metadata" },
+                        { "path": "auth.identity", "value": "auth_check.identity" }
+                    ]
+                }]
+            }]
+        }"#;
+
+        let res = serde_json::from_str::<PluginConfiguration>(config);
+        assert!(res.is_ok());
+
+        let plugin_config = res.expect("result is ok");
+        let ActionConfig::Typed(typed) = &plugin_config.action_sets[0].actions[0] else {
+            unreachable!("expected typed action");
+        };
+        let Operation::Store(store) = &typed.operation else {
+            unreachable!("expected store operation");
+        };
+        assert_eq!(store.data.len(), 2);
+        assert_eq!(store.data[0].path, "auth.metadata");
+        assert_eq!(store.data[0].value, "auth_check.dynamic_metadata");
+        assert_eq!(store.data[1].path, "auth.identity");
+        assert_eq!(store.data[1].value, "auth_check.identity");
+    }
+
+    #[test]
+    fn parse_fail_action() {
+        let config = r#"{
+            "services": {},
+            "actionSets": [{
+                "name": "test-store",
+                "routeRuleConditions": {
+                    "hostnames": ["example.com"]
+                },
+                "actions": [{
+                    "type": "fail",
+                    "predicate": "true",
+                    "terminal": true,
+                    "logMessage": "error has occurred"
+                }]
+            }]
+        }"#;
+
+        let res = serde_json::from_str::<PluginConfiguration>(config);
+        assert!(res.is_ok());
+
+        let plugin_config = res.expect("result is ok");
+        let ActionConfig::Typed(typed) = &plugin_config.action_sets[0].actions[0] else {
+            unreachable!("expected typed action");
+        };
+        let Operation::Fail(fail) = &typed.operation else {
+            unreachable!("expected fail operation");
+        };
+        assert_eq!(fail.log_message, "error has occurred");
+    }
+
+    #[test]
+    fn parse_mixed_legacy_and_typed_actions() {
+        let config = r#"{
+            "services": {
+                "authorino": {
+                    "type": "auth",
+                    "endpoint": "authorino-cluster",
+                    "failureMode": "deny",
+                    "timeout": "24ms"
+                },
+                "limitador": {
+                    "type": "dynamic",
+                    "endpoint": "limitador-cluster",
+                    "failureMode": "deny",
+                    "timeout": "100ms",
+                    "grpcService": "envoy.service.ratelimit.v3.RateLimitService",
+                    "grpcMethod": "ShouldRateLimit"
+                }
+            },
+            "actionSets": [{
+                "name": "mixed",
+                "routeRuleConditions": {
+                    "hostnames": ["example.com"]
+                },
+                "actions": [
+                    {
+                        "service": "authorino",
+                        "scope": "authconfig-A"
+                    },
+                    {
+                        "type": "grpc",
+                        "predicate": "true",
+                        "terminal": false,
+                        "var": "rl_check",
+                        "service": "limitador",
+                        "messageBuilder": "envoy.service.ratelimit.v3.RateLimitRequest { domain: 'test' }",
+                        "onReply": [{
+                            "type": "deny",
+                            "predicate": "rl_check.overall_code == 2",
+                            "terminal": true,
+                            "denyWith": "DenyResponse{status: 429u}"
+                        }]
+                    }
+                ]
+            }]
+        }"#;
+
+        let res = serde_json::from_str::<PluginConfiguration>(config);
+        if let Err(ref e) = res {
+            eprintln!("{e}");
+        }
+        assert!(res.is_ok());
+
+        let plugin_config = res.expect("result is ok");
+        let actions = &plugin_config.action_sets[0].actions;
+        assert_eq!(actions.len(), 2);
+
+        assert!(matches!(&actions[0], ActionConfig::Legacy(_)));
+        assert!(matches!(
+            &actions[1],
+            ActionConfig::Typed(TypedAction {
+                operation: Operation::Grpc(_),
+                ..
+            })
+        ));
     }
 }

--- a/src/data/cel.rs
+++ b/src/data/cel.rs
@@ -128,6 +128,18 @@ impl PartialEq for Expression {
     }
 }
 
+const HOST_PROPERTY_ROOTS: &[&str] = &[
+    "request",
+    "response",
+    "source",
+    "destination",
+    "connection",
+    "ratelimit",
+    "filter_state",
+    "metadata",
+    "auth",
+];
+
 impl Expression {
     pub fn new_expression(expression: &str, extended: bool) -> Result<Self, ParseErrors> {
         let expression = Parser::new()
@@ -145,12 +157,16 @@ impl Expression {
 
         let mut attributes: Vec<Attribute> = props
             .into_iter()
-            .map(|tokens| {
+            .filter_map(|tokens| {
+                let root = tokens.first()?;
+                if !HOST_PROPERTY_ROOTS.contains(root) {
+                    return None;
+                }
                 let path = Path::new(tokens);
-                known_attribute_for(&path).unwrap_or(Attribute {
+                Some(known_attribute_for(&path).unwrap_or(Attribute {
                     path,
                     cel_type: None,
-                })
+                }))
             })
             .collect();
 
@@ -174,9 +190,14 @@ impl Expression {
     }
 
     pub fn eval(&self, req_ctx: &ReqRespCtx) -> EvalResult {
-        let mut ctx = create_context();
+        let mut cel_ctx = Context::default();
+        self.eval_with_ctx(req_ctx, &mut cel_ctx)
+    }
+
+    pub fn eval_with_ctx(&self, req_ctx: &ReqRespCtx, cel_ctx: &mut Context<'_>) -> EvalResult {
+        add_string_extensions(cel_ctx);
         if self.extended {
-            Self::add_extended_capabilities(&mut ctx)
+            Self::add_extended_capabilities(cel_ctx)
         }
 
         // Eagerly cache all attributes used by this expression
@@ -194,7 +215,7 @@ impl Expression {
 
         for binding in ["request", "metadata", "source", "destination", "auth"] {
             let key: Key = binding.into();
-            ctx.add_variable_from_value(binding, map.get(&key).cloned().unwrap_or(Value::Null));
+            cel_ctx.add_variable_from_value(binding, map.get(&key).cloned().unwrap_or(Value::Null));
         }
 
         let mut response_json_map = HashMap::new();
@@ -206,13 +227,13 @@ impl Expression {
                 None => return Ok(AttributeState::Pending),
             }
         }
-        ctx.add_variable_from_value(
+        cel_ctx.add_variable_from_value(
             RESPONSE_BODY_JSON_DATA,
             Value::Map(response_json_map.into()),
         );
-        ctx.add_function(RESPONSE_BODY_JSON_FN, response_body_json);
+        cel_ctx.add_function(RESPONSE_BODY_JSON_FN, response_body_json);
 
-        let result = Value::resolve(&self.expression, &ctx).map_err(CelError::from)?;
+        let result = Value::resolve(&self.expression, cel_ctx).map_err(CelError::from)?;
         Ok(AttributeState::Available(result))
     }
 
@@ -331,8 +352,7 @@ fn decode_query_string(This(s): This<Arc<String>>, Arguments(args): Arguments) -
     Ok(map.into())
 }
 
-fn create_context<'a>() -> Context<'a> {
-    let mut ctx = Context::default();
+fn add_string_extensions(ctx: &mut Context<'_>) {
     ctx.add_function("charAt", strings::char_at);
     ctx.add_function("indexOf", strings::index_of);
     ctx.add_function("join", strings::join);
@@ -343,7 +363,6 @@ fn create_context<'a>() -> Context<'a> {
     ctx.add_function("replace", strings::replace);
     ctx.add_function("split", strings::split);
     ctx.add_function("substring", strings::substring);
-    ctx
 }
 
 pub mod strings;
@@ -373,7 +392,16 @@ impl Predicate {
     }
 
     pub fn test(&self, req_ctx: &ReqRespCtx) -> PredicateResult {
-        match self.expression.eval(req_ctx) {
+        let mut cel_ctx = Context::default();
+        self.test_with_ctx(req_ctx, &mut cel_ctx)
+    }
+
+    pub fn test_with_ctx(
+        &self,
+        req_ctx: &ReqRespCtx,
+        cel_ctx: &mut Context<'_>,
+    ) -> PredicateResult {
+        match self.expression.eval_with_ctx(req_ctx, cel_ctx) {
             Ok(AttributeState::Pending) => Ok(AttributeState::Pending),
             Ok(AttributeState::Available(value)) => match value {
                 Value::Bool(result) => Ok(AttributeState::Available(result)),
@@ -907,13 +935,15 @@ mod tests {
         assert_eq!(value.attributes[0].path, "auth.identity".into());
 
         let value = Expression::new("foo.bar && a.b.c").expect("This is valid CEL!");
-        assert_eq!(value.attributes.len(), 2);
-        assert_eq!(value.attributes[0].path, "foo.bar".into());
-        assert_eq!(value.attributes[1].path, "a.b.c".into());
+        assert_eq!(value.attributes.len(), 0);
 
         let value = Expression::new("my_func(foo.bar).a.b > 3").expect("This is valid CEL!");
-        assert_eq!(value.attributes.len(), 1);
-        assert_eq!(value.attributes[0].path, "foo.bar".into());
+        assert_eq!(value.attributes.len(), 0);
+
+        let value = Expression::new("request.host && source.address").expect("This is valid CEL!");
+        assert_eq!(value.attributes.len(), 2);
+        assert_eq!(value.attributes[0].path, "request.host".into());
+        assert_eq!(value.attributes[1].path, "source.address".into());
     }
 
     #[test]

--- a/src/kuadrant/pipeline/blueprint.rs
+++ b/src/kuadrant/pipeline/blueprint.rs
@@ -125,14 +125,21 @@ impl Blueprint {
             .actions
             .iter()
             .enumerate()
-            .map(|(i, action)| {
+            .map(|(i, action_config)| {
                 let id = i.to_string();
                 let dependencies = if i > 0 {
                     vec![(i - 1).to_string()]
                 } else {
                     vec![]
                 };
-                Action::compile(action, services, id, dependencies)
+                match action_config {
+                    configuration::ActionConfig::Legacy(action) => {
+                        Action::compile(action, services, id, dependencies)
+                    }
+                    configuration::ActionConfig::Typed(_typed) => {
+                        todo!("Typed action compilation not yet implemented")
+                    }
+                }
             })
             .collect::<Result<_, _>>()?;
 
@@ -341,7 +348,7 @@ mod tests {
     use super::*;
     use crate::configuration::FailureMode;
     use crate::configuration::{
-        Action as ConfigAction, ActionSet, ConditionalData as ConfigConditionalData,
+        Action as ConfigAction, ActionConfig, ActionSet, ConditionalData as ConfigConditionalData,
         DataItem as ConfigDataItem, DataType, ExpressionItem, RouteRuleConditions, StaticItem,
     };
     use crate::services::{AuthService, ServiceInstance};
@@ -571,7 +578,7 @@ mod tests {
                 hostnames: vec!["*.example.com".to_string()],
                 predicates: vec!["request.path.startsWith('/api')".to_string()],
             },
-            actions: vec![ConfigAction {
+            actions: vec![ActionConfig::Legacy(ConfigAction {
                 service: "auth-service".to_string(),
                 scope: "api-scope".to_string(),
                 predicates: vec!["request.method == 'POST'".to_string()],
@@ -593,7 +600,7 @@ mod tests {
                     ],
                 }],
                 sources: vec![],
-            }],
+            })],
         };
 
         let result = Blueprint::compile(&config, &services);

--- a/src/kuadrant/pipeline/blueprint.rs
+++ b/src/kuadrant/pipeline/blueprint.rs
@@ -43,14 +43,14 @@ pub(crate) struct TypedAction {
 #[derive(Clone)]
 pub(crate) enum Operation {
     Deny {
-        deny_with: String,
+        deny_with: Expression,
     },
     Headers {
         target: HeadersType,
-        headers: String,
+        headers: Expression,
     },
     Store {
-        data: Vec<(String, String)>,
+        data: Vec<(String, Expression)>,
     },
     Fail {
         log_message: String,
@@ -435,25 +435,27 @@ impl TypedAction {
         })?;
 
         let operation = match &config.operation {
-            configuration::Operation::Deny(deny) => Operation::Deny {
-                deny_with: deny.deny_with.clone(),
-            },
+            configuration::Operation::Deny(deny) => {
+                let deny_with = Expression::new(&deny.deny_with)?;
+                Operation::Deny { deny_with }
+            }
             configuration::Operation::Headers(headers) => {
                 let target = match headers.target {
                     configuration::HeadersTarget::Request => HeadersType::HttpRequestHeaders,
                     configuration::HeadersTarget::Response => HeadersType::HttpResponseHeaders,
                 };
+                let headers_expr = Expression::new(&headers.headers)?;
                 Operation::Headers {
                     target,
-                    headers: headers.headers.clone(),
+                    headers: headers_expr,
                 }
             }
             configuration::Operation::Store(store) => {
                 let data = store
                     .data
                     .iter()
-                    .map(|item| (item.path.clone(), item.value.clone()))
-                    .collect();
+                    .map(|item| Ok((item.path.clone(), Expression::new(&item.value)?)))
+                    .collect::<Result<_, CompileError>>()?;
                 Operation::Store { data }
             }
             configuration::Operation::Fail(fail) => Operation::Fail {

--- a/src/kuadrant/pipeline/blueprint.rs
+++ b/src/kuadrant/pipeline/blueprint.rs
@@ -28,7 +28,7 @@ pub(crate) struct Action {
     pub conditional_data: Vec<ConditionalData>,
     pub dependencies: Vec<String>,
     pub sources: Vec<String>,
-    pub message_builder: Option<String>,
+    pub message_builder: Option<Expression>,
     pub on_reply: Vec<TypedAction>,
 }
 
@@ -392,6 +392,13 @@ impl Action {
                     .map(TypedAction::compile)
                     .collect::<Result<_, _>>()?;
 
+                let message_builder =
+                    Some(Expression::new(&grpc.message_builder).map_err(|e| {
+                        CompileError::InvalidDataExpression(format!(
+                            "Failed to compile message_builder: {e}"
+                        ))
+                    })?);
+
                 Ok(Self {
                     id,
                     service: service_instance.clone(),
@@ -400,7 +407,7 @@ impl Action {
                     conditional_data: vec![],
                     dependencies,
                     sources: vec![],
-                    message_builder: Some(grpc.message_builder.clone()),
+                    message_builder,
                     on_reply,
                 })
             }

--- a/src/kuadrant/pipeline/blueprint.rs
+++ b/src/kuadrant/pipeline/blueprint.rs
@@ -1,8 +1,8 @@
 use crate::configuration;
 use crate::data::{cel::Predicate, Expression};
 use crate::kuadrant::pipeline::tasks::{
-    AuthTask, ExportTracesTask, FailureModeTask, HeaderOperation, HeadersType, ModifyHeadersTask,
-    RateLimitTask, Task, TeardownAction, TokenUsageTask, TracingDecoratorTask,
+    AuthTask, DynamicTask, ExportTracesTask, FailureModeTask, HeaderOperation, HeadersType,
+    ModifyHeadersTask, RateLimitTask, Task, TeardownAction, TokenUsageTask, TracingDecoratorTask,
 };
 use crate::kuadrant::ReqRespCtx;
 use crate::services::ServiceInstance;
@@ -28,15 +28,12 @@ pub(crate) struct Action {
     pub conditional_data: Vec<ConditionalData>,
     pub dependencies: Vec<String>,
     pub sources: Vec<String>,
-    #[allow(dead_code)]
     pub message_builder: Option<String>,
-    #[allow(dead_code)]
     pub on_reply: Vec<TypedAction>,
 }
 
 // todo(@adam-cattermole): collapse TypedAction into Action once built-in services are migrated to DynamicTask
 #[derive(Clone)]
-#[allow(dead_code)]
 pub(crate) struct TypedAction {
     pub predicate: Predicate,
     pub terminal: bool,
@@ -44,7 +41,6 @@ pub(crate) struct TypedAction {
 }
 
 #[derive(Clone)]
-#[allow(dead_code)]
 pub(crate) enum Operation {
     Deny {
         deny_with: String,
@@ -289,8 +285,33 @@ impl Blueprint {
                             .push(Box::new(ExportTracesTask::new(ctx, Rc::clone(service))));
                     }
                 }
-                ServiceInstance::Dynamic(_) => {
-                    todo!("DynamicTask not yet implemented")
+                ServiceInstance::Dynamic(dynamic_service) => {
+                    let message_builder = match &action.message_builder {
+                        Some(mb) => mb.clone(),
+                        None => {
+                            tracing::error!("Dynamic action missing message_builder");
+                            continue;
+                        }
+                    };
+                    let task: Box<dyn Task> = Box::new(DynamicTask::new(
+                        action.id.clone(),
+                        Rc::clone(dynamic_service),
+                        action.scope.clone(),
+                        message_builder,
+                        action.on_reply.clone(),
+                        action.predicates.clone(),
+                        action.dependencies.clone(),
+                    ));
+                    let task = Box::new(FailureModeTask::new(task, abort_on_failure));
+                    if tracing_enabled {
+                        tasks.push(Box::new(TracingDecoratorTask::new(
+                            "dynamic",
+                            task,
+                            action.sources.clone(),
+                        )));
+                    } else {
+                        tasks.push(task);
+                    }
                 }
             }
         }

--- a/src/kuadrant/pipeline/blueprint.rs
+++ b/src/kuadrant/pipeline/blueprint.rs
@@ -28,6 +28,37 @@ pub(crate) struct Action {
     pub conditional_data: Vec<ConditionalData>,
     pub dependencies: Vec<String>,
     pub sources: Vec<String>,
+    #[allow(dead_code)]
+    pub message_builder: Option<String>,
+    #[allow(dead_code)]
+    pub on_reply: Vec<TypedAction>,
+}
+
+// todo(@adam-cattermole): collapse TypedAction into Action once built-in services are migrated to DynamicTask
+#[derive(Clone)]
+#[allow(dead_code)]
+pub(crate) struct TypedAction {
+    pub predicate: Predicate,
+    pub terminal: bool,
+    pub operation: Operation,
+}
+
+#[derive(Clone)]
+#[allow(dead_code)]
+pub(crate) enum Operation {
+    Deny {
+        deny_with: String,
+    },
+    Headers {
+        target: HeadersType,
+        headers: String,
+    },
+    Store {
+        data: Vec<(String, String)>,
+    },
+    Fail {
+        log_message: String,
+    },
 }
 
 impl Action {
@@ -136,8 +167,8 @@ impl Blueprint {
                     configuration::ActionConfig::Legacy(action) => {
                         Action::compile(action, services, id, dependencies)
                     }
-                    configuration::ActionConfig::Typed(_typed) => {
-                        todo!("Typed action compilation not yet implemented")
+                    configuration::ActionConfig::Typed(typed) => {
+                        Action::compile_typed(typed, services, id, dependencies)
                     }
                 }
             })
@@ -303,6 +334,114 @@ impl Action {
             conditional_data,
             dependencies,
             sources: config.sources.clone(),
+            message_builder: None,
+            on_reply: vec![],
+        })
+    }
+
+    fn compile_typed(
+        typed: &configuration::TypedAction,
+        services: &HashMap<String, ServiceInstance>,
+        id: String,
+        dependencies: Vec<String>,
+    ) -> Result<Self, CompileError> {
+        match &typed.operation {
+            configuration::Operation::Grpc(grpc) => {
+                let service_instance = services
+                    .get(&grpc.service)
+                    .ok_or_else(|| CompileError::UnknownService(grpc.service.clone()))?;
+
+                if !matches!(service_instance, ServiceInstance::Dynamic(_)) {
+                    return Err(CompileError::ServiceCreationFailed(format!(
+                        "Service '{}' is not a dynamic service type",
+                        grpc.service
+                    )));
+                }
+
+                let predicate = Predicate::new(&typed.predicate).map_err(|e| {
+                    CompileError::InvalidActionPredicate {
+                        service: grpc.service.clone(),
+                        error: e.to_string(),
+                    }
+                })?;
+
+                let on_reply: Vec<TypedAction> = grpc
+                    .on_reply
+                    .iter()
+                    .map(TypedAction::compile)
+                    .collect::<Result<_, _>>()?;
+
+                Ok(Self {
+                    id,
+                    service: service_instance.clone(),
+                    scope: grpc.var.clone(),
+                    predicates: vec![predicate],
+                    conditional_data: vec![],
+                    dependencies,
+                    sources: vec![],
+                    message_builder: Some(grpc.message_builder.clone()),
+                    on_reply,
+                })
+            }
+            _ => Err(CompileError::InvalidDataExpression(
+                "Only gRPC typed actions are currently supported as top-level actions".to_string(),
+            )),
+        }
+    }
+}
+
+impl TypedAction {
+    fn compile(config: &configuration::TypedAction) -> Result<Self, CompileError> {
+        let predicate = Predicate::new(&config.predicate).map_err(|e| {
+            CompileError::InvalidActionPredicate {
+                service: match &config.operation {
+                    configuration::Operation::Deny(_) => "deny",
+                    configuration::Operation::Headers(_) => "headers",
+                    configuration::Operation::Store(_) => "store",
+                    configuration::Operation::Grpc(_) => "grpc",
+                    configuration::Operation::Fail(_) => "fail",
+                }
+                .to_string(),
+                error: e.to_string(),
+            }
+        })?;
+
+        let operation = match &config.operation {
+            configuration::Operation::Deny(deny) => Operation::Deny {
+                deny_with: deny.deny_with.clone(),
+            },
+            configuration::Operation::Headers(headers) => {
+                let target = match headers.target {
+                    configuration::HeadersTarget::Request => HeadersType::HttpRequestHeaders,
+                    configuration::HeadersTarget::Response => HeadersType::HttpResponseHeaders,
+                };
+                Operation::Headers {
+                    target,
+                    headers: headers.headers.clone(),
+                }
+            }
+            configuration::Operation::Store(store) => {
+                let data = store
+                    .data
+                    .iter()
+                    .map(|item| (item.path.clone(), item.value.clone()))
+                    .collect();
+                Operation::Store { data }
+            }
+            configuration::Operation::Fail(fail) => Operation::Fail {
+                log_message: fail.log_message.clone(),
+            },
+            configuration::Operation::Grpc(_) => {
+                return Err(CompileError::InvalidDataExpression(
+                    "gRPC actions cannot be nested inside 'onReply' blocks".to_string(),
+                ));
+            }
+        };
+
+        Ok(TypedAction {
+            predicate,
+            terminal: config.terminal,
+            operation,
         })
     }
 }
@@ -346,12 +485,15 @@ impl DataItem {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::configuration::FailureMode;
     use crate::configuration::{
         Action as ConfigAction, ActionConfig, ActionSet, ConditionalData as ConfigConditionalData,
-        DataItem as ConfigDataItem, DataType, ExpressionItem, RouteRuleConditions, StaticItem,
+        DataItem as ConfigDataItem, DataType, DenyOperation, ExpressionItem, GrpcOperation,
+        HeadersOperation, HeadersTarget, Operation as ConfigOperation, RouteRuleConditions,
+        StaticItem, StoreItem, StoreOperation, TypedAction as ConfigTypedAction,
     };
-    use crate::services::{AuthService, ServiceInstance};
+    use crate::configuration::{FailOperation, FailureMode};
+    use crate::filter::DescriptorManager;
+    use crate::services::{AuthService, DynamicService, ServiceInstance};
     use std::collections::HashMap;
     use std::rc::Rc;
 
@@ -362,6 +504,21 @@ mod tests {
                 "test-cluster".to_string(),
                 std::time::Duration::from_secs(10),
                 FailureMode::Deny,
+            ))),
+        )
+    }
+
+    fn build_dynamic_service(name: &str) -> (String, ServiceInstance) {
+        let descriptor_manager = Rc::new(DescriptorManager::default());
+        (
+            name.to_string(),
+            ServiceInstance::Dynamic(Rc::new(DynamicService::new(
+                "test-cluster".to_string(),
+                "test.Service".to_string(),
+                "TestMethod".to_string(),
+                std::time::Duration::from_secs(10),
+                FailureMode::Deny,
+                descriptor_manager,
             ))),
         )
     }
@@ -612,5 +769,277 @@ mod tests {
         assert_eq!(blueprint.actions[0].predicates.len(), 1);
         assert_eq!(blueprint.actions[0].conditional_data.len(), 1);
         assert_eq!(blueprint.actions[0].conditional_data[0].data.len(), 2);
+    }
+
+    #[test]
+    fn grpc_typed_action_compiles() {
+        let services = HashMap::from([build_dynamic_service("my-dynamic")]);
+
+        let typed = ConfigTypedAction {
+            predicate: "request.method == 'GET'".to_string(),
+            terminal: false,
+            operation: ConfigOperation::Grpc(GrpcOperation {
+                var: "rl_check".to_string(),
+                service: "my-dynamic".to_string(),
+                message_builder: "envoy.service.ratelimit.v3.RateLimitRequest{}".to_string(),
+                on_reply: vec![
+                    ConfigTypedAction {
+                        predicate: "rl_check.overall_code == 2".to_string(),
+                        terminal: true,
+                        operation: ConfigOperation::Deny(DenyOperation {
+                            deny_with: "DenyResponse{status: 429u}".to_string(),
+                        }),
+                    },
+                    ConfigTypedAction {
+                        predicate: "rl_check.overall_code == 0".to_string(),
+                        terminal: true,
+                        operation: ConfigOperation::Fail(FailOperation {
+                            log_message: "Received UNKNOWN from rate limiting service".to_string(),
+                        }),
+                    },
+                    ConfigTypedAction {
+                        predicate: "rl_check.overall_code != 1 && rl_check.overall_code != 2"
+                            .to_string(),
+                        terminal: true,
+                        operation: ConfigOperation::Fail(FailOperation {
+                            log_message:
+                                "Received invalid response code from rate limiting service"
+                                    .to_string(),
+                        }),
+                    },
+                    ConfigTypedAction {
+                        predicate: "true".to_string(),
+                        terminal: false,
+                        operation: ConfigOperation::Headers(HeadersOperation {
+                            target: HeadersTarget::Request,
+                            headers: "result.headers".to_string(),
+                        }),
+                    },
+                    ConfigTypedAction {
+                        predicate: "true".to_string(),
+                        terminal: false,
+                        operation: ConfigOperation::Store(StoreOperation {
+                            data: vec![StoreItem {
+                                path: "rl.remaining".to_string(),
+                                value: "result.remaining".to_string(),
+                            }],
+                        }),
+                    },
+                ],
+            }),
+        };
+
+        let result = Action::compile_typed(&typed, &services, "0".to_string(), vec![]);
+        assert!(result.is_ok());
+        let action = result.unwrap();
+        assert_eq!(action.id, "0");
+        assert_eq!(action.scope, "rl_check");
+        assert!(matches!(action.service, ServiceInstance::Dynamic(_)));
+        assert_eq!(action.predicates.len(), 1);
+        assert!(action.message_builder.is_some());
+        assert_eq!(action.on_reply.len(), 5);
+        assert!(action.conditional_data.is_empty());
+    }
+
+    #[test]
+    fn grpc_typed_action_fails_on_unknown_service() {
+        let services = HashMap::new();
+
+        let typed = ConfigTypedAction {
+            predicate: "true".to_string(),
+            terminal: false,
+            operation: ConfigOperation::Grpc(GrpcOperation {
+                var: "check".to_string(),
+                service: "nonexistent".to_string(),
+                message_builder: "test.Request{}".to_string(),
+                on_reply: vec![],
+            }),
+        };
+
+        let result = Action::compile_typed(&typed, &services, "0".to_string(), vec![]);
+        assert!(matches!(result, Err(CompileError::UnknownService(ref s)) if s == "nonexistent"));
+    }
+
+    #[test]
+    fn grpc_typed_action_fails_on_non_dynamic_service() {
+        let services = HashMap::from([build_test_service("auth-svc")]);
+
+        let typed = ConfigTypedAction {
+            predicate: "true".to_string(),
+            terminal: false,
+            operation: ConfigOperation::Grpc(GrpcOperation {
+                var: "check".to_string(),
+                service: "auth-svc".to_string(),
+                message_builder: "test.Request{}".to_string(),
+                on_reply: vec![],
+            }),
+        };
+
+        let result = Action::compile_typed(&typed, &services, "0".to_string(), vec![]);
+        assert!(matches!(
+            result,
+            Err(CompileError::ServiceCreationFailed(_))
+        ));
+    }
+
+    #[test]
+    fn grpc_in_on_reply_block_is_rejected() {
+        let nested_grpc = ConfigTypedAction {
+            predicate: "true".to_string(),
+            terminal: false,
+            operation: ConfigOperation::Grpc(GrpcOperation {
+                var: "nested".to_string(),
+                service: "svc".to_string(),
+                message_builder: "test.Request{}".to_string(),
+                on_reply: vec![],
+            }),
+        };
+
+        let result = TypedAction::compile(&nested_grpc);
+        assert!(matches!(
+            result,
+            Err(CompileError::InvalidDataExpression(ref msg)) if msg.contains("cannot be nested")
+        ));
+    }
+
+    #[test]
+    fn typed_actions_compile() {
+        let deny_config = ConfigTypedAction {
+            predicate: "result.code == 2".to_string(),
+            terminal: true,
+            operation: ConfigOperation::Deny(DenyOperation {
+                deny_with: "DenyResponse{status: 429u}".to_string(),
+            }),
+        };
+        let deny_result = TypedAction::compile(&deny_config);
+        assert!(deny_result.is_ok());
+        let deny = deny_result.unwrap();
+        assert!(deny.terminal);
+        assert!(matches!(deny.operation, Operation::Deny { .. }));
+
+        let headers_config = ConfigTypedAction {
+            predicate: "true".to_string(),
+            terminal: false,
+            operation: ConfigOperation::Headers(HeadersOperation {
+                target: HeadersTarget::Response,
+                headers: "result.resp_headers".to_string(),
+            }),
+        };
+        let headers_result = TypedAction::compile(&headers_config);
+        assert!(headers_result.is_ok());
+        let headers = headers_result.unwrap();
+        assert!(!headers.terminal);
+        assert!(matches!(
+            headers.operation,
+            Operation::Headers {
+                ref target,
+                ..
+            } if matches!(target, HeadersType::HttpResponseHeaders)
+        ));
+
+        let store_config = ConfigTypedAction {
+            predicate: "true".to_string(),
+            terminal: false,
+            operation: ConfigOperation::Store(StoreOperation {
+                data: vec![
+                    StoreItem {
+                        path: "a.b".to_string(),
+                        value: "result.x".to_string(),
+                    },
+                    StoreItem {
+                        path: "c.d".to_string(),
+                        value: "result.y".to_string(),
+                    },
+                ],
+            }),
+        };
+        let store_result = TypedAction::compile(&store_config);
+        assert!(store_result.is_ok());
+        let store = store_result.unwrap();
+        assert!(!store.terminal);
+        assert!(matches!(
+            store.operation,
+            Operation::Store { ref data, .. }
+                if data.len() == 2
+                && data[0].0 == "a.b"
+        ));
+    }
+
+    #[test]
+    fn typed_action_fails_on_invalid_predicate() {
+        let config = ConfigTypedAction {
+            predicate: "bad syntax !!".to_string(),
+            terminal: true,
+            operation: ConfigOperation::Deny(DenyOperation {
+                deny_with: "DenyResponse{status: 429u}".to_string(),
+            }),
+        };
+        let result = TypedAction::compile(&config);
+        assert!(matches!(
+            result,
+            Err(CompileError::InvalidActionPredicate { .. })
+        ));
+    }
+
+    #[test]
+    fn mixed_legacy_and_typed_actions_compile() {
+        let services = HashMap::from([
+            build_test_service("auth-svc"),
+            build_dynamic_service("dyn-svc"),
+        ]);
+
+        let config = ActionSet {
+            name: "mixed-set".to_string(),
+            route_rule_conditions: RouteRuleConditions {
+                hostnames: vec!["example.com".to_string()],
+                predicates: vec![],
+            },
+            actions: vec![
+                ActionConfig::Legacy(ConfigAction {
+                    service: "auth-svc".to_string(),
+                    scope: "auth-scope".to_string(),
+                    predicates: vec![],
+                    conditional_data: vec![],
+                    sources: vec![],
+                }),
+                ActionConfig::Typed(ConfigTypedAction {
+                    predicate: "true".to_string(),
+                    terminal: false,
+                    operation: ConfigOperation::Grpc(GrpcOperation {
+                        var: "rl_check".to_string(),
+                        service: "dyn-svc".to_string(),
+                        message_builder: "test.Request{}".to_string(),
+                        on_reply: vec![ConfigTypedAction {
+                            predicate: "rl_check.code == 2".to_string(),
+                            terminal: true,
+                            operation: ConfigOperation::Deny(DenyOperation {
+                                deny_with: "DenyResponse{status: 429u}".to_string(),
+                            }),
+                        }],
+                    }),
+                }),
+            ],
+        };
+
+        let result = Blueprint::compile(&config, &services);
+        assert!(result.is_ok());
+        let blueprint = result.unwrap();
+        assert_eq!(blueprint.actions.len(), 2);
+
+        assert!(matches!(
+            blueprint.actions[0].service,
+            ServiceInstance::Auth(_)
+        ));
+        assert!(blueprint.actions[0].message_builder.is_none());
+        assert!(blueprint.actions[0].on_reply.is_empty());
+        assert!(blueprint.actions[0].dependencies.is_empty());
+
+        assert!(matches!(
+            blueprint.actions[1].service,
+            ServiceInstance::Dynamic(_)
+        ));
+        assert!(blueprint.actions[1].message_builder.is_some());
+        assert_eq!(blueprint.actions[1].on_reply.len(), 1);
+        assert_eq!(blueprint.actions[1].dependencies, vec!["0"]);
     }
 }

--- a/src/kuadrant/pipeline/factory.rs
+++ b/src/kuadrant/pipeline/factory.rs
@@ -252,7 +252,8 @@ fn domain_and_field_name(name: &str) -> (&str, &str) {
 mod tests {
     use super::*;
     use crate::configuration::{
-        Action, ActionSet, FailureMode, RouteRuleConditions, Service, ServiceType, Timeout,
+        Action, ActionConfig, ActionSet, FailureMode, RouteRuleConditions, Service, ServiceType,
+        Timeout,
     };
     use crate::filter::DescriptorManager;
     use crate::kuadrant::MockWasmHost;
@@ -283,13 +284,13 @@ mod tests {
                     hostnames,
                     predicates,
                 },
-                actions: vec![Action {
+                actions: vec![ActionConfig::Legacy(Action {
                     service: service_name.to_string(),
                     scope: "test-scope".to_string(),
                     predicates: vec![],
                     conditional_data: vec![],
                     sources: vec![],
-                }],
+                })],
             }],
         )
     }

--- a/src/kuadrant/pipeline/factory.rs
+++ b/src/kuadrant/pipeline/factory.rs
@@ -84,6 +84,8 @@ impl PipelineFactory {
                 conditional_data: Default::default(),
                 dependencies: Default::default(),
                 sources: vec![],
+                message_builder: None,
+                on_reply: vec![],
             });
         let mut index = Trie::new();
         for config_action_set in &config.action_sets {

--- a/src/kuadrant/pipeline/tasks/dynamic.rs
+++ b/src/kuadrant/pipeline/tasks/dynamic.rs
@@ -1,6 +1,6 @@
 use std::rc::Rc;
 
-use cel::{Program, Value};
+use cel::Value;
 use tracing::{debug, error};
 
 use crate::data::attribute::AttributeState;
@@ -157,7 +157,7 @@ fn process_dynamic_response(
         return TaskOutcome::Done;
     }
 
-    let cel_ctx = match service.response_cel_context(ctx, response_size, name) {
+    let mut cel_ctx = match service.response_cel_context(ctx, response_size, name) {
         Ok(c) => c,
         Err(e) => {
             record_error!("Failed to build response context: {e:?}");
@@ -168,7 +168,7 @@ fn process_dynamic_response(
     let mut tasks: Vec<Box<dyn Task>> = Vec::new();
 
     for action in on_reply {
-        match action.predicate.test(ctx) {
+        match action.predicate.test_with_ctx(ctx, &mut cel_ctx) {
             Ok(AttributeState::Available(true)) => {}
             Ok(AttributeState::Available(false)) => continue,
             Ok(AttributeState::Pending) => {
@@ -181,20 +181,26 @@ fn process_dynamic_response(
         }
 
         match &action.operation {
-            Operation::Deny { deny_with } => match compile_and_eval(deny_with, &cel_ctx) {
-                Ok(val @ Value::Struct(_)) => match SendReplyTask::try_from(val) {
-                    Ok(task) => {
-                        if action.terminal {
-                            return TaskOutcome::Terminate(Box::new(task));
+            Operation::Deny { deny_with } => match deny_with.eval_with_ctx(ctx, &mut cel_ctx) {
+                Ok(AttributeState::Pending) => {
+                    error!("Unexpected pending state in onReply deny");
+                    return TaskOutcome::Failed;
+                }
+                Ok(AttributeState::Available(val @ Value::Struct(_))) => {
+                    match SendReplyTask::try_from(val) {
+                        Ok(task) => {
+                            if action.terminal {
+                                return TaskOutcome::Terminate(Box::new(task));
+                            }
+                            tasks.push(Box::new(task));
                         }
-                        tasks.push(Box::new(task));
+                        Err(e) => {
+                            error!("Invalid DenyResponse: {e}");
+                            return TaskOutcome::Failed;
+                        }
                     }
-                    Err(e) => {
-                        error!("Invalid DenyResponse: {e}");
-                        return TaskOutcome::Failed;
-                    }
-                },
-                Ok(other) => {
+                }
+                Ok(AttributeState::Available(other)) => {
                     error!("denyWith must return DenyResponse, got: {other:?}");
                     return TaskOutcome::Failed;
                 }
@@ -203,28 +209,38 @@ fn process_dynamic_response(
                     return TaskOutcome::Failed;
                 }
             },
-            Operation::Headers { target, headers } => match compile_and_eval(headers, &cel_ctx) {
-                Ok(ref val) => {
-                    let pairs = cel_value_to_header_pairs(val);
-                    if !pairs.is_empty() {
-                        tasks.push(Box::new(ModifyHeadersTask::new(
-                            HeaderOperation::Set(pairs.into()),
-                            target.clone(),
-                        )));
+            Operation::Headers { target, headers } => {
+                match headers.eval_with_ctx(ctx, &mut cel_ctx) {
+                    Ok(AttributeState::Available(ref val)) => {
+                        let pairs = cel_value_to_header_pairs(val);
+                        if !pairs.is_empty() {
+                            tasks.push(Box::new(ModifyHeadersTask::new(
+                                HeaderOperation::Set(pairs.into()),
+                                target.clone(),
+                            )));
+                        }
+                    }
+                    Ok(AttributeState::Pending) => {
+                        error!("Unexpected pending state in onReply headers");
+                        return TaskOutcome::Failed;
+                    }
+                    Err(e) => {
+                        error!("Failed to evaluate headers expression: {e}");
+                        return TaskOutcome::Failed;
                     }
                 }
-                Err(e) => {
-                    error!("Failed to evaluate headers expression: {e}");
-                    return TaskOutcome::Failed;
-                }
-            },
+            }
             Operation::Store { data } => {
                 let mut store_items: Vec<(String, Vec<u8>)> = Vec::new();
                 for (path, expr) in data {
-                    match compile_and_eval(expr, &cel_ctx) {
-                        Ok(val) => {
+                    match expr.eval_with_ctx(ctx, &mut cel_ctx) {
+                        Ok(AttributeState::Available(val)) => {
                             let bytes = cel_value_to_bytes(&val);
                             store_items.push((path.clone(), bytes));
+                        }
+                        Ok(AttributeState::Pending) => {
+                            error!("Unexpected pending state in onReply store");
+                            return TaskOutcome::Failed;
                         }
                         Err(e) => {
                             error!("Failed to evaluate store expression for '{path}': {e}");
@@ -248,13 +264,6 @@ fn process_dynamic_response(
     } else {
         TaskOutcome::Requeued(tasks)
     }
-}
-
-fn compile_and_eval(expression: &str, ctx: &cel::Context) -> Result<Value, String> {
-    let program = Program::compile(expression).map_err(|e| format!("CEL compile error: {}", e))?;
-    program
-        .execute(ctx)
-        .map_err(|e| format!("CEL execution error: {}", e))
 }
 
 fn cel_value_to_bytes(val: &Value) -> Vec<u8> {

--- a/src/kuadrant/pipeline/tasks/dynamic.rs
+++ b/src/kuadrant/pipeline/tasks/dynamic.rs
@@ -1,0 +1,250 @@
+use std::rc::Rc;
+
+use cel::{Program, Value};
+use tracing::{debug, error};
+
+use crate::data::attribute::AttributeState;
+use crate::data::cel::{Predicate, PredicateVec};
+use crate::kuadrant::pipeline::blueprint::{Operation, TypedAction};
+use crate::kuadrant::pipeline::tasks::{
+    HeaderOperation, ModifyHeadersTask, PendingTask, SendReplyTask, StoreDataTask, Task,
+    TaskOutcome,
+};
+use crate::kuadrant::ReqRespCtx;
+use crate::record_error;
+use crate::services::{cel_value_to_header_pairs, DynamicService};
+
+pub struct DynamicTask {
+    task_id: String,
+    service: Rc<DynamicService>,
+    name: String,
+    message_builder: String,
+    on_reply: Vec<TypedAction>,
+    predicates: Vec<Predicate>,
+    dependencies: Vec<String>,
+}
+
+impl DynamicTask {
+    pub fn new(
+        task_id: String,
+        service: Rc<DynamicService>,
+        name: String,
+        message_builder: String,
+        on_reply: Vec<TypedAction>,
+        predicates: Vec<Predicate>,
+        dependencies: Vec<String>,
+    ) -> Self {
+        Self {
+            task_id,
+            service,
+            name,
+            message_builder,
+            on_reply,
+            predicates,
+            dependencies,
+        }
+    }
+}
+
+impl Task for DynamicTask {
+    fn id(&self) -> Option<String> {
+        Some(self.task_id.clone())
+    }
+
+    fn pauses_filter(&self) -> bool {
+        true
+    }
+
+    fn dependencies(&self) -> &[String] {
+        &self.dependencies
+    }
+
+    fn apply(self: Box<Self>, ctx: &mut ReqRespCtx) -> TaskOutcome {
+        match self.predicates.apply(ctx) {
+            Ok(AttributeState::Pending) => return TaskOutcome::Requeued(vec![self]),
+            Ok(AttributeState::Available(false)) => return TaskOutcome::Done,
+            Ok(AttributeState::Available(true)) => {}
+            Err(e) => {
+                error!("Failed to apply predicates: {e:?}");
+                return TaskOutcome::Failed;
+            }
+        }
+
+        let token_id = {
+            let _span =
+                tracing::debug_span!("dynamic_request", task_id = self.task_id, name = self.name)
+                    .entered();
+            match self.service.dispatch_dynamic(ctx, &self.message_builder) {
+                Ok(id) => id,
+                Err(e) => {
+                    error!("Failed to dispatch dynamic service: {e}");
+                    return TaskOutcome::Failed;
+                }
+            }
+        };
+
+        let service = self.service.clone();
+        let task_id = self.task_id.clone();
+        let name = self.name.clone();
+        let on_reply = self.on_reply.clone();
+
+        TaskOutcome::Deferred {
+            token_id,
+            pending: Box::new(PendingTask::new(
+                self.task_id,
+                Box::new(move |ctx| {
+                    process_dynamic_response(ctx, &service, &task_id, token_id, &name, &on_reply)
+                }),
+            )),
+        }
+    }
+}
+
+fn process_dynamic_response(
+    ctx: &mut ReqRespCtx,
+    service: &DynamicService,
+    task_id: &str,
+    token_id: u32,
+    name: &str,
+    on_reply: &[TypedAction],
+) -> TaskOutcome {
+    let span = tracing::debug_span!(
+        "dynamic_response",
+        task_id = task_id,
+        token_id = token_id,
+        grpc_status_code = tracing::field::Empty,
+        otel.status_code = tracing::field::Empty,
+        otel.status_message = tracing::field::Empty
+    )
+    .entered();
+
+    let (status_code, response_size) = match ctx.get_grpc_response_data() {
+        Ok(data) => data,
+        Err(e) => {
+            record_error!("Failed to get gRPC response: {e:?}");
+            return TaskOutcome::Failed;
+        }
+    };
+    span.record("grpc_status_code", status_code);
+
+    if status_code != proxy_wasm::types::Status::Ok as u32 {
+        record_error!("gRPC status code is not OK");
+        return TaskOutcome::Failed;
+    }
+
+    if on_reply.is_empty() {
+        debug!("No onReply actions, completing");
+        return TaskOutcome::Done;
+    }
+
+    let cel_ctx = match service.response_cel_context(ctx, response_size, name) {
+        Ok(c) => c,
+        Err(e) => {
+            record_error!("Failed to build response context: {e:?}");
+            return TaskOutcome::Failed;
+        }
+    };
+
+    let mut tasks: Vec<Box<dyn Task>> = Vec::new();
+
+    for action in on_reply {
+        match action.predicate.test(ctx) {
+            Ok(AttributeState::Available(true)) => {}
+            Ok(AttributeState::Available(false)) => continue,
+            Ok(AttributeState::Pending) => {
+                //todo(@adam-cattermole): if we requeue here, we lose predicates as headers/store/sendreply are not modelled with predicates
+            }
+            Err(e) => {
+                error!("Failed to apply predicates: {e:?}");
+                return TaskOutcome::Failed;
+            }
+        }
+
+        match &action.operation {
+            Operation::Deny { deny_with } => match compile_and_eval(deny_with, &cel_ctx) {
+                Ok(val @ Value::Struct(_)) => match SendReplyTask::try_from(val) {
+                    Ok(task) => {
+                        if action.terminal {
+                            return TaskOutcome::Terminate(Box::new(task));
+                        }
+                        tasks.push(Box::new(task));
+                    }
+                    Err(e) => {
+                        error!("Invalid DenyResponse: {e}");
+                        return TaskOutcome::Failed;
+                    }
+                },
+                Ok(other) => {
+                    error!("denyWith must return DenyResponse, got: {other:?}");
+                    return TaskOutcome::Failed;
+                }
+                Err(e) => {
+                    error!("Failed to evaluate denyWith expression: {e}");
+                    return TaskOutcome::Failed;
+                }
+            },
+            Operation::Headers { target, headers } => match compile_and_eval(headers, &cel_ctx) {
+                Ok(ref val) => {
+                    let pairs = cel_value_to_header_pairs(val);
+                    if !pairs.is_empty() {
+                        tasks.push(Box::new(ModifyHeadersTask::new(
+                            HeaderOperation::Set(pairs.into()),
+                            target.clone(),
+                        )));
+                    }
+                }
+                Err(e) => {
+                    error!("Failed to evaluate headers expression: {e}");
+                    return TaskOutcome::Failed;
+                }
+            },
+            Operation::Store { data } => {
+                let mut store_items: Vec<(String, Vec<u8>)> = Vec::new();
+                for (path, expr) in data {
+                    match compile_and_eval(expr, &cel_ctx) {
+                        Ok(val) => {
+                            let bytes = cel_value_to_bytes(&val);
+                            store_items.push((path.clone(), bytes));
+                        }
+                        Err(e) => {
+                            error!("Failed to evaluate store expression for '{path}': {e}");
+                            return TaskOutcome::Failed;
+                        }
+                    }
+                }
+                if !store_items.is_empty() {
+                    tasks.push(Box::new(StoreDataTask::new(store_items)));
+                }
+            }
+            Operation::Fail { log_message } => {
+                error!("Action failure: {log_message}");
+                return TaskOutcome::Failed;
+            }
+        }
+    }
+
+    if tasks.is_empty() {
+        TaskOutcome::Done
+    } else {
+        TaskOutcome::Requeued(tasks)
+    }
+}
+
+fn compile_and_eval(expression: &str, ctx: &cel::Context) -> Result<Value, String> {
+    let program = Program::compile(expression).map_err(|e| format!("CEL compile error: {}", e))?;
+    program
+        .execute(ctx)
+        .map_err(|e| format!("CEL execution error: {}", e))
+}
+
+fn cel_value_to_bytes(val: &Value) -> Vec<u8> {
+    match val {
+        Value::String(s) => s.to_string().into_bytes(),
+        Value::Int(n) => n.to_string().into_bytes(),
+        Value::UInt(n) => n.to_string().into_bytes(),
+        Value::Float(n) => n.to_string().into_bytes(),
+        Value::Bool(b) => b.to_string().into_bytes(),
+        Value::Null => Vec::new(),
+        _ => format!("{val:?}").into_bytes(),
+    }
+}

--- a/src/kuadrant/pipeline/tasks/dynamic.rs
+++ b/src/kuadrant/pipeline/tasks/dynamic.rs
@@ -5,6 +5,7 @@ use tracing::{debug, error};
 
 use crate::data::attribute::AttributeState;
 use crate::data::cel::{Predicate, PredicateVec};
+use crate::data::Expression;
 use crate::kuadrant::pipeline::blueprint::{Operation, TypedAction};
 use crate::kuadrant::pipeline::tasks::{
     HeaderOperation, ModifyHeadersTask, PendingTask, SendReplyTask, StoreDataTask, Task,
@@ -18,7 +19,7 @@ pub struct DynamicTask {
     task_id: String,
     service: Rc<DynamicService>,
     name: String,
-    message_builder: String,
+    message_builder: Expression,
     on_reply: Vec<TypedAction>,
     predicates: Vec<Predicate>,
     dependencies: Vec<String>,
@@ -29,7 +30,7 @@ impl DynamicTask {
         task_id: String,
         service: Rc<DynamicService>,
         name: String,
-        message_builder: String,
+        message_builder: Expression,
         on_reply: Vec<TypedAction>,
         predicates: Vec<Predicate>,
         dependencies: Vec<String>,
@@ -74,7 +75,26 @@ impl Task for DynamicTask {
             let _span =
                 tracing::debug_span!("dynamic_request", task_id = self.task_id, name = self.name)
                     .entered();
-            match self.service.dispatch_dynamic(ctx, &self.message_builder) {
+
+            let env = match self.service.cel_env() {
+                Ok(env) => env,
+                Err(e) => {
+                    error!("Failed to get CEL environment: {e}");
+                    return TaskOutcome::Failed;
+                }
+            };
+
+            let mut cel_ctx = cel::Context::with_env(env);
+            let cel_value = match self.message_builder.eval_with_ctx(ctx, &mut cel_ctx) {
+                Ok(AttributeState::Pending) => return TaskOutcome::Requeued(vec![self]),
+                Ok(AttributeState::Available(val)) => val,
+                Err(e) => {
+                    error!("Failed to evaluate message builder: {e}");
+                    return TaskOutcome::Failed;
+                }
+            };
+
+            match self.service.dispatch_value(ctx, &cel_value) {
                 Ok(id) => id,
                 Err(e) => {
                     error!("Failed to dispatch dynamic service: {e}");

--- a/src/kuadrant/pipeline/tasks/mod.rs
+++ b/src/kuadrant/pipeline/tasks/mod.rs
@@ -1,4 +1,5 @@
 mod auth;
+mod dynamic;
 mod export_traces;
 mod failure_mode;
 mod headers;
@@ -9,6 +10,7 @@ mod token_usage;
 mod tracing_decorator;
 
 pub use auth::AuthTask;
+pub use dynamic::DynamicTask;
 pub use export_traces::ExportTracesTask;
 pub use failure_mode::FailureModeTask;
 pub use headers::{HeaderOperation, HeadersType, ModifyHeadersTask};

--- a/src/kuadrant/pipeline/tasks/ratelimit.rs
+++ b/src/kuadrant/pipeline/tasks/ratelimit.rs
@@ -322,6 +322,7 @@ impl Task for RateLimitTask {
             let _span =
                 tracing::debug_span!("ratelimit_request", task_id = self.task_id, scope = domain)
                     .entered();
+            #[allow(deprecated)]
             match self.service.dispatch_dynamic(ctx, &cel_expr) {
                 Ok(id) => id,
                 Err(e) => {

--- a/src/kuadrant/pipeline/tasks/send_reply.rs
+++ b/src/kuadrant/pipeline/tasks/send_reply.rs
@@ -1,8 +1,12 @@
+use cel::common::types::{CelString, CelUInt};
+use cel::Value;
+use tracing::error;
+
 use crate::envoy::StatusCode;
 use crate::kuadrant::pipeline::tasks::{Task, TaskOutcome};
 use crate::kuadrant::ReqRespCtx;
 use crate::metrics::METRICS;
-use tracing::error;
+use crate::services::cel_value_to_header_pairs;
 
 pub struct SendReplyTask {
     status_code: u32,
@@ -26,6 +30,36 @@ impl SendReplyTask {
             Vec::new(),
             Some("Internal Server Error.\n".to_string()),
         )
+    }
+}
+
+impl TryFrom<Value> for SendReplyTask {
+    type Error = String;
+
+    fn try_from(value: Value) -> Result<Self, Self::Error> {
+        let Value::Struct(deny_response) = value else {
+            return Err(format!("expected DenyResponse struct, got: {value:?}"));
+        };
+
+        let status = deny_response
+            .field_value("status")
+            .and_then(|v| v.downcast_ref::<CelUInt>())
+            .map(|v| *v.inner() as u32)
+            .ok_or("DenyResponse missing or invalid 'status' field")?;
+
+        let body = deny_response
+            .field_value("body")
+            .and_then(|v| v.downcast_ref::<CelString>())
+            .map(|v| v.inner().to_string())
+            .filter(|s| !s.is_empty());
+
+        let headers = deny_response
+            .field_value("headers")
+            .and_then(|v| Value::try_from(v).ok())
+            .map(|v| cel_value_to_header_pairs(&v))
+            .unwrap_or_default();
+
+        Ok(Self::new(status, headers, body))
     }
 }
 

--- a/src/services/dynamic.rs
+++ b/src/services/dynamic.rs
@@ -15,7 +15,7 @@ use crate::kuadrant::ReqRespCtx;
 
 pub mod converters;
 
-use converters::{DescriptorConverter, MessageConverter};
+use converters::{deny_response_struct_def, DescriptorConverter, MessageConverter};
 
 pub struct DynamicService {
     upstream_name: String,
@@ -91,6 +91,7 @@ impl DynamicService {
                     .map_err(|e| {
                         ServiceError::Dispatch(format!("Failed to register message types: {}", e))
                     })?;
+                new_env.add_struct(deny_response_struct_def());
                 let env_arc = Arc::new(new_env);
                 let _ = self.cel_env.set(Arc::clone(&env_arc));
                 env_arc
@@ -125,6 +126,26 @@ impl DynamicService {
             message_bytes,
             self.timeout,
         )
+    }
+
+    pub fn response_cel_context(
+        &self,
+        ctx: &mut ReqRespCtx,
+        response_size: usize,
+        name: &str,
+    ) -> Result<Context<'_>, ServiceError> {
+        let response = self.get_response(ctx, response_size)?;
+        let cel_value = MessageConverter::dynamic_message_to_cel(&response);
+
+        let env = self.cel_env.get().cloned().unwrap_or_else(|| {
+            let mut env = Env::stdlib();
+            env.add_struct(deny_response_struct_def());
+            Arc::new(env)
+        });
+
+        let mut cel_ctx = Context::with_env(env);
+        cel_ctx.add_variable_from_value(name, cel_value);
+        Ok(cel_ctx)
     }
 }
 

--- a/src/services/dynamic.rs
+++ b/src/services/dynamic.rs
@@ -3,7 +3,7 @@ use std::rc::Rc;
 use std::sync::Arc;
 use std::time::Duration;
 
-use cel::{Context, Env, Program};
+use cel::{Context, Env, Program, Value};
 use prost::Message;
 use prost_reflect::DynamicMessage;
 use tracing::debug;
@@ -53,63 +53,37 @@ impl DynamicService {
         self.failure_mode
     }
 
-    pub fn dispatch_dynamic(
+    pub fn cel_env(&self) -> Result<Arc<Env>, ServiceError> {
+        match self.cel_env.get() {
+            Some(env) => Ok(Arc::clone(env)),
+            None => {
+                let input_descriptor = self.input_descriptor()?;
+                let output_descriptor = self.output_descriptor()?;
+                let mut env = Env::stdlib();
+                DescriptorConverter::register_message_types(&mut env, &input_descriptor).map_err(
+                    |e| ServiceError::Dispatch(format!("Failed to register message types: {}", e)),
+                )?;
+                DescriptorConverter::register_message_types(&mut env, &output_descriptor).map_err(
+                    |e| ServiceError::Dispatch(format!("Failed to register message types: {}", e)),
+                )?;
+                env.add_struct(deny_response_struct_def());
+                let env_arc = Arc::new(env);
+                let _ = self.cel_env.set(Arc::clone(&env_arc));
+                Ok(env_arc)
+            }
+        }
+    }
+
+    pub fn dispatch_value(
         &self,
         ctx: &mut ReqRespCtx,
-        message_expression: &str,
+        cel_value: &Value,
     ) -> Result<u32, ServiceError> {
-        let pool = self
-            .descriptor_manager
-            .get_pool(&self.upstream_name, &self.service_name)
-            .map_err(|e| ServiceError::Dispatch(e.to_string()))?;
+        let input_descriptor = self.input_descriptor()?;
 
-        let service_descriptor = pool
-            .get_service_by_name(&self.service_name)
-            .ok_or_else(|| {
-                ServiceError::Dispatch(format!(
-                    "Service '{}' not found in descriptor pool",
-                    self.service_name
-                ))
-            })?;
-        let method_descriptor = service_descriptor
-            .methods()
-            .find(|m| m.name() == self.method)
-            .ok_or_else(|| {
-                ServiceError::Dispatch(format!(
-                    "Method '{}' not found in service '{}'",
-                    self.method, self.service_name
-                ))
-            })?;
-        let input_descriptor = method_descriptor.input();
-
-        debug!("Building message from CEL expression");
-        let env = match self.cel_env.get() {
-            Some(env) => Arc::clone(env),
-            None => {
-                let mut new_env = Env::stdlib();
-                DescriptorConverter::register_message_types(&mut new_env, &input_descriptor)
-                    .map_err(|e| {
-                        ServiceError::Dispatch(format!("Failed to register message types: {}", e))
-                    })?;
-                new_env.add_struct(deny_response_struct_def());
-                let env_arc = Arc::new(new_env);
-                let _ = self.cel_env.set(Arc::clone(&env_arc));
-                env_arc
-            }
-        };
-
-        let cel_ctx = Context::with_env(env);
-
-        let program = Program::compile(message_expression).map_err(|e| {
-            ServiceError::Dispatch(format!("Failed to compile CEL expression: {}", e))
-        })?;
-
-        let cel_value = program.execute(&cel_ctx).map_err(|e| {
-            ServiceError::Dispatch(format!("Failed to execute CEL expression: {}", e))
-        })?;
-
+        debug!("Converting CEL value to protobuf message");
         let request_message =
-            MessageConverter::cel_to_dynamic_message(&cel_value, &input_descriptor).map_err(
+            MessageConverter::cel_to_dynamic_message(cel_value, &input_descriptor).map_err(
                 |e| ServiceError::Dispatch(format!("Failed to convert CEL to message: {}", e)),
             )?;
 
@@ -128,6 +102,60 @@ impl DynamicService {
         )
     }
 
+    #[deprecated(note = "use dispatch_value instead")]
+    pub fn dispatch_dynamic(
+        &self,
+        ctx: &mut ReqRespCtx,
+        message_expression: &str,
+    ) -> Result<u32, ServiceError> {
+        let env = self.cel_env()?;
+        let cel_ctx = Context::with_env(env);
+
+        let program = Program::compile(message_expression).map_err(|e| {
+            ServiceError::Dispatch(format!("Failed to compile CEL expression: {}", e))
+        })?;
+
+        let cel_value = program.execute(&cel_ctx).map_err(|e| {
+            ServiceError::Dispatch(format!("Failed to execute CEL expression: {}", e))
+        })?;
+
+        self.dispatch_value(ctx, &cel_value)
+    }
+
+    fn method_descriptor(&self) -> Result<prost_reflect::MethodDescriptor, ServiceError> {
+        let pool = self
+            .descriptor_manager
+            .get_pool(&self.upstream_name, &self.service_name)
+            .map_err(|e| ServiceError::Dispatch(e.to_string()))?;
+
+        let service_descriptor = pool
+            .get_service_by_name(&self.service_name)
+            .ok_or_else(|| {
+                ServiceError::Dispatch(format!(
+                    "Service '{}' not found in descriptor pool",
+                    self.service_name
+                ))
+            })?;
+        let method = service_descriptor
+            .methods()
+            .find(|m| m.name() == self.method)
+            .ok_or_else(|| {
+                ServiceError::Dispatch(format!(
+                    "Method '{}' not found in service '{}'",
+                    self.method, self.service_name
+                ))
+            })?;
+        Ok(method)
+    }
+
+    fn input_descriptor(&self) -> Result<prost_reflect::MessageDescriptor, ServiceError> {
+        Ok(self.method_descriptor()?.input())
+    }
+
+    fn output_descriptor(&self) -> Result<prost_reflect::MessageDescriptor, ServiceError> {
+        Ok(self.method_descriptor()?.output())
+    }
+
     pub fn response_cel_context(
         &self,
         ctx: &mut ReqRespCtx,
@@ -136,12 +164,7 @@ impl DynamicService {
     ) -> Result<Context<'_>, ServiceError> {
         let response = self.get_response(ctx, response_size)?;
         let cel_value = MessageConverter::dynamic_message_to_cel(&response);
-
-        let env = self.cel_env.get().cloned().unwrap_or_else(|| {
-            let mut env = Env::stdlib();
-            env.add_struct(deny_response_struct_def());
-            Arc::new(env)
-        });
+        let env = self.cel_env()?;
 
         let mut cel_ctx = Context::with_env(env);
         cel_ctx.add_variable_from_value(name, cel_value);

--- a/src/services/dynamic/converters.rs
+++ b/src/services/dynamic/converters.rs
@@ -140,7 +140,6 @@ impl DescriptorConverter {
     }
 }
 
-#[allow(dead_code)]
 pub fn deny_response_struct_def() -> StructDef {
     StructDef::new("DenyResponse".to_string())
         .add_field("status".to_string(), UINT_TYPE)
@@ -148,7 +147,6 @@ pub fn deny_response_struct_def() -> StructDef {
         .add_field_with_default("headers".to_string(), Box::new(CelList::from(vec![])))
 }
 
-#[allow(dead_code)]
 pub fn cel_value_to_header_pairs(value: &Value) -> Vec<(String, String)> {
     let Value::List(items) = value else {
         return vec![];
@@ -211,7 +209,6 @@ impl MessageConverter {
         }
     }
 
-    #[allow(dead_code)]
     pub fn dynamic_message_to_cel(message: &DynamicMessage) -> Value {
         let descriptor = message.descriptor();
         let mut cel_struct = CelStruct::new(descriptor.full_name().to_string());

--- a/src/services/dynamic/converters.rs
+++ b/src/services/dynamic/converters.rs
@@ -140,6 +140,64 @@ impl DescriptorConverter {
     }
 }
 
+#[allow(dead_code)]
+pub fn deny_response_struct_def() -> StructDef {
+    StructDef::new("DenyResponse".to_string())
+        .add_field("status".to_string(), UINT_TYPE)
+        .add_field_with_default("body".to_string(), Box::new(CelString::from("")))
+        .add_field_with_default("headers".to_string(), Box::new(CelList::from(vec![])))
+}
+
+#[allow(dead_code)]
+pub fn cel_value_to_header_pairs(value: &Value) -> Vec<(String, String)> {
+    let Value::List(items) = value else {
+        return vec![];
+    };
+
+    let mut pairs = Vec::new();
+    for item in items.iter() {
+        match item {
+            Value::List(inner) if inner.len() == 2 => {
+                if let (Value::String(k), Value::String(v)) = (&inner[0], &inner[1]) {
+                    pairs.push((k.to_string(), v.to_string()));
+                }
+            }
+            Value::Struct(s) => {
+                if let (Some(key_val), Some(value_val)) =
+                    (s.field_value("key"), s.field_value("value"))
+                {
+                    if let (Some(k), Some(v)) = (
+                        key_val.downcast_ref::<CelString>(),
+                        value_val.downcast_ref::<CelString>(),
+                    ) {
+                        pairs.push((k.inner().to_string(), v.inner().to_string()));
+                        continue;
+                    }
+                }
+
+                if let Some(header_val) = s.field_value("header") {
+                    if let Some(header_struct) = header_val.downcast_ref::<CelStruct>() {
+                        if let (Some(key_val), Some(value_val)) = (
+                            header_struct.field_value("key"),
+                            header_struct.field_value("value"),
+                        ) {
+                            if let (Some(k), Some(v)) = (
+                                key_val.downcast_ref::<CelString>(),
+                                value_val.downcast_ref::<CelString>(),
+                            ) {
+                                pairs.push((k.inner().to_string(), v.inner().to_string()));
+                            }
+                        }
+                    }
+                }
+            }
+            _ => {}
+        }
+    }
+
+    pairs
+}
+
 pub struct MessageConverter;
 
 impl MessageConverter {
@@ -536,6 +594,7 @@ impl MessageConverter {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use cel::common::value::Val;
     use cel::{Context, Program};
     use prost::Message;
     use prost_types::{field_descriptor_proto, DescriptorProto, FieldDescriptorProto};
@@ -1200,5 +1259,203 @@ mod tests {
                 Some("third")
             );
         }
+    }
+
+    #[test]
+    fn deny_response_struct_def_registers_and_evaluates() {
+        let mut env = cel::Env::stdlib();
+        env.add_struct(deny_response_struct_def());
+        let ctx = Context::with_env(Arc::new(env));
+
+        let program = Program::compile("DenyResponse{status: 429u}").expect("Failed to compile");
+        let result = program.execute(&ctx).expect("Failed to execute");
+
+        assert!(matches!(&result, Value::Struct(_)));
+
+        if let Value::Struct(s) = &result {
+            assert_eq!(s.name(), "DenyResponse");
+
+            let status = s.field_value("status").expect("status field missing");
+            assert_eq!(
+                status.downcast_ref::<CelUInt>().map(|v| *v.inner()),
+                Some(429)
+            );
+
+            let body = s.field_value("body").expect("body field missing");
+            assert_eq!(
+                body.downcast_ref::<CelString>().map(|v| v.inner()),
+                Some("")
+            );
+
+            let headers = s.field_value("headers").expect("headers field missing");
+            let list = headers
+                .downcast_ref::<CelList>()
+                .expect("headers should be a list");
+            assert_eq!(list.len(), 0);
+        }
+    }
+
+    #[test]
+    fn deny_response_with_all_fields() {
+        let mut env = cel::Env::stdlib();
+        env.add_struct(deny_response_struct_def());
+        let ctx = Context::with_env(Arc::new(env));
+
+        let program =
+            Program::compile("DenyResponse{status: 403u, body: 'Forbidden', headers: []}")
+                .expect("Failed to compile");
+        let result = program.execute(&ctx).expect("Failed to execute");
+
+        assert!(matches!(&result, Value::Struct(_)));
+
+        if let Value::Struct(s) = &result {
+            let status = s.field_value("status").expect("status missing");
+            assert_eq!(
+                status.downcast_ref::<CelUInt>().map(|v| *v.inner()),
+                Some(403)
+            );
+
+            let body = s.field_value("body").expect("body missing");
+            assert_eq!(
+                body.downcast_ref::<CelString>().map(|v| v.inner()),
+                Some("Forbidden")
+            );
+        }
+    }
+
+    #[test]
+    fn cel_value_to_header_pairs_direct_key_value() {
+        let mut s1 = CelStruct::new("HeaderValue".to_string());
+        s1.add_field_value(
+            "key".to_string(),
+            Cow::Owned(Box::new(CelString::from("x-ratelimit-limit")) as Box<dyn Val>),
+        );
+        s1.add_field_value(
+            "value".to_string(),
+            Cow::Owned(Box::new(CelString::from("100")) as Box<dyn Val>),
+        );
+
+        let mut s2 = CelStruct::new("HeaderValue".to_string());
+        s2.add_field_value(
+            "key".to_string(),
+            Cow::Owned(Box::new(CelString::from("x-ratelimit-remaining")) as Box<dyn Val>),
+        );
+        s2.add_field_value(
+            "value".to_string(),
+            Cow::Owned(Box::new(CelString::from("42")) as Box<dyn Val>),
+        );
+
+        let list = Value::List(Arc::new(vec![
+            Value::Struct(Arc::new(s1)),
+            Value::Struct(Arc::new(s2)),
+        ]));
+
+        let pairs = cel_value_to_header_pairs(&list);
+        assert_eq!(pairs.len(), 2);
+        assert_eq!(
+            pairs[0],
+            ("x-ratelimit-limit".to_string(), "100".to_string())
+        );
+        assert_eq!(
+            pairs[1],
+            ("x-ratelimit-remaining".to_string(), "42".to_string())
+        );
+    }
+
+    #[test]
+    fn cel_value_to_header_pairs_nested_header_field() {
+        let mut header = CelStruct::new("HeaderValue".to_string());
+        header.add_field_value(
+            "key".to_string(),
+            Cow::Owned(Box::new(CelString::from("x-custom")) as Box<dyn Val>),
+        );
+        header.add_field_value(
+            "value".to_string(),
+            Cow::Owned(Box::new(CelString::from("test")) as Box<dyn Val>),
+        );
+
+        let mut option = CelStruct::new("HeaderValueOption".to_string());
+        option.add_field_value(
+            "header".to_string(),
+            Cow::Owned(Box::new(header) as Box<dyn Val>),
+        );
+
+        let list = Value::List(Arc::new(vec![Value::Struct(Arc::new(option))]));
+
+        let pairs = cel_value_to_header_pairs(&list);
+        assert_eq!(pairs.len(), 1);
+        assert_eq!(pairs[0], ("x-custom".to_string(), "test".to_string()));
+    }
+
+    #[test]
+    fn cel_value_to_header_pairs_empty_list() {
+        let list = Value::List(Arc::new(vec![]));
+        let pairs = cel_value_to_header_pairs(&list);
+        assert!(pairs.is_empty());
+    }
+
+    #[test]
+    fn cel_value_to_header_pairs_non_list_returns_empty() {
+        let value = Value::String(Arc::new("not a list".to_string()));
+        let pairs = cel_value_to_header_pairs(&value);
+        assert!(pairs.is_empty());
+    }
+
+    #[test]
+    fn cel_value_to_header_pairs_list_of_lists() {
+        let list = Value::List(Arc::new(vec![
+            Value::List(Arc::new(vec![
+                Value::String(Arc::new("x-result".to_string())),
+                Value::String(Arc::new("check-passed".to_string())),
+            ])),
+            Value::List(Arc::new(vec![
+                Value::String(Arc::new("x-custom".to_string())),
+                Value::String(Arc::new("static-value".to_string())),
+            ])),
+        ]));
+
+        let pairs = cel_value_to_header_pairs(&list);
+        assert_eq!(pairs.len(), 2);
+        assert_eq!(
+            pairs[0],
+            ("x-result".to_string(), "check-passed".to_string())
+        );
+        assert_eq!(
+            pairs[1],
+            ("x-custom".to_string(), "static-value".to_string())
+        );
+    }
+
+    #[test]
+    fn cel_value_to_header_pairs_list_of_lists_wrong_length_skipped() {
+        let list = Value::List(Arc::new(vec![
+            Value::List(Arc::new(vec![
+                Value::String(Arc::new("x-valid".to_string())),
+                Value::String(Arc::new("value".to_string())),
+            ])),
+            Value::List(Arc::new(vec![Value::String(Arc::new(
+                "only-one".to_string(),
+            ))])),
+            Value::List(Arc::new(vec![
+                Value::String(Arc::new("a".to_string())),
+                Value::String(Arc::new("b".to_string())),
+                Value::String(Arc::new("c".to_string())),
+            ])),
+        ]));
+
+        let pairs = cel_value_to_header_pairs(&list);
+        assert_eq!(pairs.len(), 1);
+        assert_eq!(pairs[0], ("x-valid".to_string(), "value".to_string()));
+    }
+
+    #[test]
+    fn cel_value_to_header_pairs_list_of_lists_non_string_skipped() {
+        let list = Value::List(Arc::new(vec![Value::List(Arc::new(vec![
+            Value::Int(42),
+            Value::String(Arc::new("value".to_string())),
+        ]))]));
+
+        let pairs = cel_value_to_header_pairs(&list);
+        assert!(pairs.is_empty());
     }
 }

--- a/src/services/mod.rs
+++ b/src/services/mod.rs
@@ -8,6 +8,7 @@ mod dynamic;
 mod tracing;
 
 pub use auth::AuthService;
+pub use dynamic::converters::cel_value_to_header_pairs;
 pub use dynamic::DynamicService;
 pub use tracing::TracingService;
 

--- a/tests/dynamic.rs
+++ b/tests/dynamic.rs
@@ -1,43 +1,15 @@
 use crate::util::common::{wasm_module, LOG_LEVEL};
 use crate::util::data;
 use proxy_wasm_test_framework::tester;
-use proxy_wasm_test_framework::types::{BufferType, LogLevel, MetricType, ReturnType};
+use proxy_wasm_test_framework::types::{
+    Action, BufferType, LogLevel, MapType, MetricType, ReturnType,
+};
 use serial_test::serial;
 
 pub mod util;
 
-const CONFIG: &str = r#"{
-    "descriptorService": "descriptor-service-cluster",
-    "services": {
-        "dynamic-ratelimit": {
-            "type": "dynamic",
-            "endpoint": "limitador-cluster",
-            "failureMode": "deny",
-            "timeout": "5s",
-            "grpcService": "test.TestService",
-            "grpcMethod": "TestMethod"
-        }
-    },
-    "actionSets": []
-}"#;
-
-#[test]
-#[serial]
-fn it_fetches_descriptors_on_configure() {
-    let args = tester::MockSettings {
-        wasm_path: wasm_module(),
-        quiet: false,
-        allow_unexpected: false,
-    };
-    let mut module = tester::mock(args).unwrap();
-
-    module
-        .call_start()
-        .execute_and_expect(ReturnType::None)
-        .unwrap();
-
-    let root_context = 1;
-
+#[allow(clippy::unwrap_used)]
+fn configure_dynamic_service(module: &mut tester::Tester, root_context: i32, cfg: &str) {
     module
         .call_proxy_on_context_create(root_context, 0)
         .expect_log(Some(LogLevel::Info), Some("#1 set_root_context"))
@@ -61,7 +33,7 @@ fn it_fetches_descriptors_on_configure() {
         .returning(Some(6))
         .expect_increment_metric(Some(1), Some(1))
         .expect_get_buffer_bytes(Some(BufferType::PluginConfiguration))
-        .returning(Some(CONFIG.as_bytes()))
+        .returning(Some(cfg.as_bytes()))
         .expect_get_log_level()
         .returning(Some(LOG_LEVEL))
         .expect_grpc_call(
@@ -77,13 +49,86 @@ fn it_fetches_descriptors_on_configure() {
         .execute_and_expect(ReturnType::Bool(true))
         .unwrap();
 
-    let response_bytes = data::descriptor_response::TEST_SERVICE;
+    let descriptor_response = data::descriptor_response::TEST_SERVICE;
     module
-        .call_proxy_on_grpc_receive(root_context, 42, response_bytes.len() as i32)
+        .call_proxy_on_grpc_receive(root_context, 42, descriptor_response.len() as i32)
         .expect_get_buffer_bytes(Some(BufferType::GrpcReceiveBuffer))
-        .returning(Some(response_bytes))
+        .returning(Some(descriptor_response))
         .execute_and_expect(ReturnType::None)
         .unwrap();
+}
+
+const DESCRIPTOR_FETCH_CONFIG: &str = r#"{
+    "descriptorService": "descriptor-service-cluster",
+    "services": {
+        "dynamic-ratelimit": {
+            "type": "dynamic",
+            "endpoint": "limitador-cluster",
+            "failureMode": "deny",
+            "timeout": "5s",
+            "grpcService": "test.TestService",
+            "grpcMethod": "TestMethod"
+        }
+    },
+    "actionSets": []
+}"#;
+
+const DENY_CONFIG: &str = r#"{
+    "descriptorService": "descriptor-service-cluster",
+    "services": {
+        "my-service": {
+            "type": "dynamic",
+            "endpoint": "limitador-cluster",
+            "failureMode": "deny",
+            "timeout": "5s",
+            "grpcService": "test.TestService",
+            "grpcMethod": "TestMethod"
+        }
+    },
+    "actionSets": [{
+        "name": "deny-test",
+        "routeRuleConditions": {
+            "hostnames": ["*.toystore.com"]
+        },
+        "actions": [{
+            "type": "grpc",
+            "var": "my_check",
+            "service": "my-service",
+            "predicate": "true",
+            "terminal": false,
+            "messageBuilder": "test.TestRequest{message: 'hello'}",
+            "onReply": [{
+                "type": "deny",
+                "predicate": "my_check.result == 'denied'",
+                "denyWith": "DenyResponse{status: 429u, body: 'Too Many Requests', headers: [['x-ratelimit-reason', my_check.result]]}",
+                "terminal": true
+            }, {
+                "type": "fail",
+                "predicate": "my_check.result != 'allowed' && my_check.result != 'denied'",
+                "terminal": true,
+                "logMessage": "Invalid result from service"
+            }]
+        }]
+    }]
+}"#;
+
+#[test]
+#[serial]
+fn it_fetches_descriptors_on_configure() {
+    let args = tester::MockSettings {
+        wasm_path: wasm_module(),
+        quiet: false,
+        allow_unexpected: false,
+    };
+    let mut module = tester::mock(args).unwrap();
+
+    module
+        .call_start()
+        .execute_and_expect(ReturnType::None)
+        .unwrap();
+
+    let root_context = 1;
+    configure_dynamic_service(&mut module, root_context, DESCRIPTOR_FETCH_CONFIG);
 
     let http_context = 2;
     module
@@ -91,5 +136,502 @@ fn it_fetches_descriptors_on_configure() {
         .expect_get_log_level()
         .returning(Some(LOG_LEVEL))
         .execute_and_expect(ReturnType::None)
+        .unwrap();
+}
+
+#[test]
+#[serial]
+fn it_allows_when_deny_predicate_is_false() {
+    let args = tester::MockSettings {
+        wasm_path: wasm_module(),
+        quiet: false,
+        allow_unexpected: false,
+    };
+    let mut module = tester::mock(args).unwrap();
+
+    module
+        .call_start()
+        .execute_and_expect(ReturnType::None)
+        .unwrap();
+
+    let root_context = 1;
+    configure_dynamic_service(&mut module, root_context, DENY_CONFIG);
+
+    let http_context = 2;
+    module
+        .call_proxy_on_context_create(http_context, root_context)
+        .expect_get_log_level()
+        .returning(Some(LOG_LEVEL))
+        .execute_and_expect(ReturnType::None)
+        .unwrap();
+
+    module
+        .call_proxy_on_request_headers(http_context, 0, false)
+        .expect_get_property(Some(vec!["request", "host"]))
+        .returning(Some(data::request::HOST))
+        .expect_get_header_map_pairs(Some(MapType::HttpRequestHeaders))
+        .returning(None)
+        .expect_increment_metric(Some(2), Some(1))
+        .expect_grpc_call(
+            Some("limitador-cluster"),
+            Some("test.TestService"),
+            Some("TestMethod"),
+            None,
+            None,
+            Some(5000),
+        )
+        .returning(Ok(43))
+        .execute_and_expect(ReturnType::Action(Action::Pause))
+        .unwrap();
+
+    let grpc_response = data::dynamic_response::RESULT_ALLOWED;
+    module
+        .call_proxy_on_grpc_receive(http_context, 43, grpc_response.len() as i32)
+        .expect_get_buffer_bytes(Some(BufferType::GrpcReceiveBuffer))
+        .returning(Some(grpc_response))
+        .execute_and_expect(ReturnType::None)
+        .unwrap();
+
+    module
+        .call_proxy_on_response_headers(http_context, 0, false)
+        .expect_increment_metric(Some(4), Some(1))
+        .execute_and_expect(ReturnType::Action(Action::Continue))
+        .unwrap();
+}
+
+#[test]
+#[serial]
+fn it_denies_when_deny_predicate_is_true() {
+    let args = tester::MockSettings {
+        wasm_path: wasm_module(),
+        quiet: false,
+        allow_unexpected: false,
+    };
+    let mut module = tester::mock(args).unwrap();
+
+    module
+        .call_start()
+        .execute_and_expect(ReturnType::None)
+        .unwrap();
+
+    let root_context = 1;
+    configure_dynamic_service(&mut module, root_context, DENY_CONFIG);
+
+    let http_context = 2;
+    module
+        .call_proxy_on_context_create(http_context, root_context)
+        .expect_get_log_level()
+        .returning(Some(LOG_LEVEL))
+        .execute_and_expect(ReturnType::None)
+        .unwrap();
+
+    module
+        .call_proxy_on_request_headers(http_context, 0, false)
+        .expect_get_property(Some(vec!["request", "host"]))
+        .returning(Some(data::request::HOST))
+        .expect_get_header_map_pairs(Some(MapType::HttpRequestHeaders))
+        .returning(None)
+        .expect_increment_metric(Some(2), Some(1))
+        .expect_grpc_call(
+            Some("limitador-cluster"),
+            Some("test.TestService"),
+            Some("TestMethod"),
+            None,
+            None,
+            Some(5000),
+        )
+        .returning(Ok(43))
+        .execute_and_expect(ReturnType::Action(Action::Pause))
+        .unwrap();
+
+    let grpc_response = data::dynamic_response::RESULT_DENIED;
+    module
+        .call_proxy_on_grpc_receive(http_context, 43, grpc_response.len() as i32)
+        .expect_get_buffer_bytes(Some(BufferType::GrpcReceiveBuffer))
+        .returning(Some(grpc_response))
+        .expect_increment_metric(Some(5), Some(1))
+        .expect_send_local_response(
+            Some(429),
+            Some("Too Many Requests"),
+            Some(vec![("x-ratelimit-reason", "denied")]),
+            None,
+        )
+        .execute_and_expect(ReturnType::None)
+        .unwrap();
+}
+
+#[test]
+#[serial]
+fn it_fails_when_fail_predicate_is_true() {
+    let args = tester::MockSettings {
+        wasm_path: wasm_module(),
+        quiet: false,
+        allow_unexpected: false,
+    };
+    let mut module = tester::mock(args).unwrap();
+
+    module
+        .call_start()
+        .execute_and_expect(ReturnType::None)
+        .unwrap();
+
+    let root_context = 1;
+    let cfg = r#"{
+        "descriptorService": "descriptor-service-cluster",
+        "services": {
+            "my-service": {
+                "type": "dynamic",
+                "endpoint": "limitador-cluster",
+                "failureMode": "deny",
+                "timeout": "5s",
+                "grpcService": "test.TestService",
+                "grpcMethod": "TestMethod"
+            }
+        },
+        "actionSets": [{
+            "name": "predicate-test",
+            "routeRuleConditions": {
+                "hostnames": ["*.toystore.com"]
+            },
+            "actions": [{
+                "type": "grpc",
+                "var": "my_check",
+                "service": "my-service",
+                "predicate": "request.method == 'POST'",
+                "terminal": false,
+                "messageBuilder": "test.TestRequest{message: 'hello'}",
+                "onReply": [{
+                    "type": "deny",
+                    "predicate": "my_check.result == 'denied'",
+                    "denyWith": "DenyResponse{status: 403u}",
+                    "terminal": true
+                }, {
+                    "type": "fail",
+                    "predicate": "my_check.result != 'allowed' && my_check.result != 'denied'",
+                    "terminal": true,
+                    "logMessage": "Invalid result from service"
+                }]
+            }]
+        }]
+    }"#;
+    configure_dynamic_service(&mut module, root_context, cfg);
+
+    let http_context = 2;
+    module
+        .call_proxy_on_context_create(http_context, root_context)
+        .expect_get_log_level()
+        .returning(Some(LOG_LEVEL))
+        .execute_and_expect(ReturnType::None)
+        .unwrap();
+
+    module
+        .call_proxy_on_request_headers(http_context, 0, false)
+        .expect_get_property(Some(vec!["request", "host"]))
+        .returning(Some(data::request::HOST))
+        .expect_get_header_map_pairs(Some(MapType::HttpRequestHeaders))
+        .returning(None)
+        .expect_increment_metric(Some(2), Some(1))
+        .expect_get_property(Some(vec!["request", "method"]))
+        .returning(Some(data::request::method::POST))
+        .expect_grpc_call(
+            Some("limitador-cluster"),
+            Some("test.TestService"),
+            Some("TestMethod"),
+            None,
+            None,
+            Some(5000),
+        )
+        .returning(Ok(43))
+        .execute_and_expect(ReturnType::Action(Action::Pause))
+        .unwrap();
+
+    let grpc_response = data::dynamic_response::RESULT_CHECK_PASSED;
+    module
+        .call_proxy_on_grpc_receive(http_context, 43, grpc_response.len() as i32)
+        .expect_get_buffer_bytes(Some(BufferType::GrpcReceiveBuffer))
+        .returning(Some(grpc_response))
+        .expect_log(
+            Some(LogLevel::Error),
+            Some("Action failure: Invalid result from service"),
+        )
+        .expect_increment_metric(Some(6), Some(1))
+        .expect_increment_metric(Some(5), Some(1))
+        .expect_send_local_response(
+            Some(500),
+            Some("Internal Server Error.\n"),
+            Some(vec![]),
+            Some(-1),
+        )
+        .execute_and_expect(ReturnType::None)
+        .unwrap();
+}
+
+#[test]
+#[serial]
+fn it_skips_grpc_action_when_predicate_is_false() {
+    let args = tester::MockSettings {
+        wasm_path: wasm_module(),
+        quiet: false,
+        allow_unexpected: false,
+    };
+    let mut module = tester::mock(args).unwrap();
+
+    module
+        .call_start()
+        .execute_and_expect(ReturnType::None)
+        .unwrap();
+
+    let root_context = 1;
+    let cfg = r#"{
+        "descriptorService": "descriptor-service-cluster",
+        "services": {
+            "my-service": {
+                "type": "dynamic",
+                "endpoint": "limitador-cluster",
+                "failureMode": "deny",
+                "timeout": "5s",
+                "grpcService": "test.TestService",
+                "grpcMethod": "TestMethod"
+            }
+        },
+        "actionSets": [{
+            "name": "predicate-test",
+            "routeRuleConditions": {
+                "hostnames": ["*.toystore.com"]
+            },
+            "actions": [{
+                "type": "grpc",
+                "var": "my_check",
+                "service": "my-service",
+                "predicate": "request.method == 'DELETE'",
+                "terminal": false,
+                "messageBuilder": "test.TestRequest{message: 'hello'}",
+                "onReply": [{
+                    "type": "deny",
+                    "predicate": "true",
+                    "denyWith": "DenyResponse{status: 403u}",
+                    "terminal": true
+                }]
+            }]
+        }]
+    }"#;
+    configure_dynamic_service(&mut module, root_context, cfg);
+
+    let http_context = 2;
+    module
+        .call_proxy_on_context_create(http_context, root_context)
+        .expect_get_log_level()
+        .returning(Some(LOG_LEVEL))
+        .execute_and_expect(ReturnType::None)
+        .unwrap();
+
+    module
+        .call_proxy_on_request_headers(http_context, 0, false)
+        .expect_get_property(Some(vec!["request", "host"]))
+        .returning(Some(data::request::HOST))
+        .expect_get_header_map_pairs(Some(MapType::HttpRequestHeaders))
+        .returning(None)
+        .expect_increment_metric(Some(2), Some(1))
+        .expect_get_property(Some(vec!["request", "method"]))
+        .returning(Some(data::request::method::GET))
+        .execute_and_expect(ReturnType::Action(Action::Continue))
+        .unwrap();
+
+    module
+        .call_proxy_on_response_headers(http_context, 0, false)
+        .expect_increment_metric(Some(4), Some(1))
+        .execute_and_expect(ReturnType::Action(Action::Continue))
+        .unwrap();
+}
+
+#[test]
+#[serial]
+fn it_sets_headers_from_grpc_response() {
+    let args = tester::MockSettings {
+        wasm_path: wasm_module(),
+        quiet: false,
+        allow_unexpected: false,
+    };
+    let mut module = tester::mock(args).unwrap();
+
+    module
+        .call_start()
+        .execute_and_expect(ReturnType::None)
+        .unwrap();
+
+    let root_context = 1;
+    let cfg = r#"{
+        "descriptorService": "descriptor-service-cluster",
+        "services": {
+            "my-service": {
+                "type": "dynamic",
+                "endpoint": "limitador-cluster",
+                "failureMode": "deny",
+                "timeout": "5s",
+                "grpcService": "test.TestService",
+                "grpcMethod": "TestMethod"
+            }
+        },
+        "actionSets": [{
+            "name": "headers-test",
+            "routeRuleConditions": {
+                "hostnames": ["*.toystore.com"]
+            },
+            "actions": [{
+                "type": "grpc",
+                "var": "my_check",
+                "service": "my-service",
+                "predicate": "true",
+                "terminal": false,
+                "messageBuilder": "test.TestRequest{message: 'hello'}",
+                "onReply": [{
+                    "type": "headers",
+                    "predicate": "true",
+                    "terminal": false,
+                    "target": "request",
+                    "headers": "[['x-result', my_check.result], ['x-custom', 'static-value']]"
+                }]
+            }]
+        }]
+    }"#;
+    configure_dynamic_service(&mut module, root_context, cfg);
+
+    let http_context = 2;
+    module
+        .call_proxy_on_context_create(http_context, root_context)
+        .expect_get_log_level()
+        .returning(Some(LOG_LEVEL))
+        .execute_and_expect(ReturnType::None)
+        .unwrap();
+
+    module
+        .call_proxy_on_request_headers(http_context, 0, false)
+        .expect_get_property(Some(vec!["request", "host"]))
+        .returning(Some(data::request::HOST))
+        .expect_get_header_map_pairs(Some(MapType::HttpRequestHeaders))
+        .returning(None)
+        .expect_increment_metric(Some(2), Some(1))
+        .expect_grpc_call(
+            Some("limitador-cluster"),
+            Some("test.TestService"),
+            Some("TestMethod"),
+            None,
+            None,
+            Some(5000),
+        )
+        .returning(Ok(43))
+        .execute_and_expect(ReturnType::Action(Action::Pause))
+        .unwrap();
+
+    let grpc_response = data::dynamic_response::RESULT_CHECK_PASSED;
+    module
+        .call_proxy_on_grpc_receive(http_context, 43, grpc_response.len() as i32)
+        .expect_get_buffer_bytes(Some(BufferType::GrpcReceiveBuffer))
+        .returning(Some(grpc_response))
+        .expect_set_header_map_pairs(None, None)
+        .execute_and_expect(ReturnType::None)
+        .unwrap();
+
+    module
+        .call_proxy_on_response_headers(http_context, 0, false)
+        .expect_increment_metric(Some(4), Some(1))
+        .execute_and_expect(ReturnType::Action(Action::Continue))
+        .unwrap();
+}
+
+#[test]
+#[serial]
+fn it_stores_data_from_grpc_response() {
+    let args = tester::MockSettings {
+        wasm_path: wasm_module(),
+        quiet: false,
+        allow_unexpected: false,
+    };
+    let mut module = tester::mock(args).unwrap();
+
+    module
+        .call_start()
+        .execute_and_expect(ReturnType::None)
+        .unwrap();
+
+    let root_context = 1;
+    let cfg = r#"{
+        "descriptorService": "descriptor-service-cluster",
+        "services": {
+            "my-service": {
+                "type": "dynamic",
+                "endpoint": "limitador-cluster",
+                "failureMode": "deny",
+                "timeout": "5s",
+                "grpcService": "test.TestService",
+                "grpcMethod": "TestMethod"
+            }
+        },
+        "actionSets": [{
+            "name": "store-test",
+            "routeRuleConditions": {
+                "hostnames": ["*.toystore.com"]
+            },
+            "actions": [{
+                "type": "grpc",
+                "var": "my_check",
+                "service": "my-service",
+                "predicate": "true",
+                "terminal": false,
+                "messageBuilder": "test.TestRequest{message: 'hello'}",
+                "onReply": [{
+                    "type": "store",
+                    "predicate": "true",
+                    "terminal": false,
+                    "data": [{
+                        "path": "check.result",
+                        "value": "my_check.result"
+                    }]
+                }]
+            }]
+        }]
+    }"#;
+    configure_dynamic_service(&mut module, root_context, cfg);
+
+    let http_context = 2;
+    module
+        .call_proxy_on_context_create(http_context, root_context)
+        .expect_get_log_level()
+        .returning(Some(LOG_LEVEL))
+        .execute_and_expect(ReturnType::None)
+        .unwrap();
+
+    module
+        .call_proxy_on_request_headers(http_context, 0, false)
+        .expect_get_property(Some(vec!["request", "host"]))
+        .returning(Some(data::request::HOST))
+        .expect_get_header_map_pairs(Some(MapType::HttpRequestHeaders))
+        .returning(None)
+        .expect_increment_metric(Some(2), Some(1))
+        .expect_grpc_call(
+            Some("limitador-cluster"),
+            Some("test.TestService"),
+            Some("TestMethod"),
+            None,
+            None,
+            Some(5000),
+        )
+        .returning(Ok(43))
+        .execute_and_expect(ReturnType::Action(Action::Pause))
+        .unwrap();
+
+    let grpc_response = data::dynamic_response::RESULT_STORED_VALUE;
+    module
+        .call_proxy_on_grpc_receive(http_context, 43, grpc_response.len() as i32)
+        .expect_get_buffer_bytes(Some(BufferType::GrpcReceiveBuffer))
+        .returning(Some(grpc_response))
+        .expect_set_property(Some(vec!["kuadrant.check.result"]), Some(b"stored_value"))
+        .execute_and_expect(ReturnType::None)
+        .unwrap();
+
+    module
+        .call_proxy_on_response_headers(http_context, 0, false)
+        .expect_increment_metric(Some(4), Some(1))
+        .execute_and_expect(ReturnType::Action(Action::Continue))
         .unwrap();
 }

--- a/tests/util/data.rs
+++ b/tests/util/data.rs
@@ -168,6 +168,24 @@ pub mod auth_response {
     ];
 }
 
+pub mod dynamic_response {
+    /// TestResponse { result: "denied" }
+    pub const RESULT_DENIED: &[u8] = &[0x0a, 0x06, 0x64, 0x65, 0x6e, 0x69, 0x65, 0x64];
+
+    /// TestResponse { result: "allowed" }
+    pub const RESULT_ALLOWED: &[u8] = &[0x0a, 0x07, 0x61, 0x6c, 0x6c, 0x6f, 0x77, 0x65, 0x64];
+
+    /// TestResponse { result: "check-passed" }
+    pub const RESULT_CHECK_PASSED: &[u8] = &[
+        0x0a, 0x0c, 0x63, 0x68, 0x65, 0x63, 0x6b, 0x2d, 0x70, 0x61, 0x73, 0x73, 0x65, 0x64,
+    ];
+
+    /// TestResponse { result: "stored_value" }
+    pub const RESULT_STORED_VALUE: &[u8] = &[
+        0x0a, 0x0c, 0x73, 0x74, 0x6f, 0x72, 0x65, 0x64, 0x5f, 0x76, 0x61, 0x6c, 0x75, 0x65,
+    ];
+}
+
 pub mod descriptor_response {
     /// GetServiceDescriptorsResponse containing a FileDescriptorSet for test.TestService
     /// GetServiceDescriptorsResponse {


### PR DESCRIPTION


### Next Steps

1. We're missing the logic for `pauses_filter` - we discussed the notion of having a field `is_guard` or something similar to allow us to know whether it's important for an action to run before the request reaches the upstream or not
2. I started to work towards porting our old configuration to the new compiled typed actions and dynamictasks for rate limiting
3. Same again but for auth
4. Once 3+4 are done, we can 🔥 `services/auth.rs`, `services/rate_limit.rs`, `tasks/auth.rs` `tasks/ratelimit.rs`. 
5. Make predicates universal across action tasks (`SendReply/Headers/StoreData`) - right now these are evaluated to build the task - instead the matches could map (maybe `try_from` `Operation` -> `Task`?) to the task type and try apply/requeue to seriously simplify that function
6. Promote `Deny/Headers/Store/Fail` to top-level actions and restructure the `Action` struct to handle any of the types - right now we support one use-case as top-level which is `grpc`. For extensions to be able to register a single 'add header action' etc we can update the model
7.  Generate new config types from kuadrant-operator
8. 🔥  the `ActionConfig::Legacy`
9. (future): we would now have the 'cache warming' in one place - on the `DynamicTask` creation - we could pull this out into something that 'prepares' the task, and one that applies it - grab out all needed props, once all are present transition from preptask to inner.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for typed action configurations enabling dynamic gRPC operations with predicate-based conditional execution.
  * Enabled CEL expression evaluation for dynamic policy enforcement, including response handling for headers, data storage, and denial responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->