### PR TITLE
MULTIARCH-5995: add ppc64le support to the build

### DIFF
--- a/.github/workflows/build-image.yaml
+++ b/.github/workflows/build-image.yaml
@@ -11,12 +11,23 @@ env:
   IMG_TAGS: ${{ github.ref_name }}
   IMG_REGISTRY_HOST: quay.io
   IMG_REGISTRY_ORG: kuadrant
+  IMG_NAME: wasm-shim
   MAIN_BRANCH_NAME: main
 
 jobs:
   build:
     name: Build
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: linux/amd64
+            artifactsuffix: amd64
+            scope: build-amd64
+          - platform: linux/ppc64le
+            artifactsuffix: ppc64le
+            scope: build-ppc64le
     steps:
       - name: Check out code
         uses: actions/checkout@v6
@@ -30,25 +41,103 @@ jobs:
         id: add-git-sha-tag
         run: |
           echo "IMG_TAGS=${{ github.sha }} ${{ env.IMG_TAGS }}" >> $GITHUB_ENV
-      - name: Build Image
-        id: build-image
-        uses: redhat-actions/buildah-build@v2
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v5
         with:
-          image: wasm-shim
-          tags: ${{ env.IMG_TAGS }}
-          build-args: |
-            GITHUB_SHA=${{ github.sha }}
-          dockerfiles: |
-            ./Dockerfile
-      - name: Push Image
-        if: ${{ !env.ACT }}
-        id: push-to-quay
-        uses: redhat-actions/push-to-registry@v2
+          images: |
+            ${{ env.IMG_REGISTRY_HOST }}/${{ env.IMG_REGISTRY_ORG }}/${{ env.IMG_NAME }}
+      - name: Login to container registry
+        uses: docker/login-action@v2
         with:
-          image: ${{ steps.build-image.outputs.image }}
-          tags: ${{ steps.build-image.outputs.tags }}
-          registry: ${{ env.IMG_REGISTRY_HOST }}/${{ env.IMG_REGISTRY_ORG }}
           username: ${{ secrets.IMG_REGISTRY_USERNAME }}
           password: ${{ secrets.IMG_REGISTRY_TOKEN }}
-      - name: Print Image URL
-        run: echo "Image pushed to ${{ steps.push-to-quay.outputs.registry-paths }}"
+          registry: ${{ env.IMG_REGISTRY_HOST }}
+      - name: Build and push by digest
+        id: build
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            GITHUB_SHA=${{ github.sha }}
+          cache-from: type=gha,scope=${{ matrix.scope }}
+          cache-to: type=gha,mode=max,scope=${{ matrix.scope}}
+          outputs: type=image,name=${{ env.IMG_REGISTRY_HOST }}/${{ env.IMG_REGISTRY_ORG }}/${{ env.IMG_NAME }},push-by-digest=true,name-canonical=true,push=true
+          file: ./Dockerfile
+          platforms: |
+            ${{ matrix.platform }}
+          provenance: false
+      - name: Export digest
+        run: |
+          mkdir -p /tmp/digests
+          digest="${{ steps.build.outputs.digest }}"
+          touch "/tmp/digests/${digest#sha256:}"
+      - name: Upload digest
+        uses: actions/upload-artifact@v4
+        with:
+          name: digests-${{ matrix.artifactsuffix }}
+          path: /tmp/digests/*
+          if-no-files-found: error
+          retention-days: 1
+  merge:
+    runs-on: ubuntu-latest
+    needs:
+      - build
+    steps:
+      - name: Download digests
+        uses: actions/download-artifact@v4
+        with:
+          pattern: digests-*
+          path: /tmp/digests
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: |
+            ${{ env.IMG_REGISTRY_HOST }}/${{ env.IMG_REGISTRY_ORG }}/${{ env.IMG_NAME }}
+          tags: |
+            # SHA tag for main branch
+            type=raw,value=${{ github.sha }},enable=${{ github.ref_name == env.MAIN_BRANCH_NAME }}
+            # set latest tag for main branch
+            type=raw,value=latest,enable=${{ github.ref_name == env.MAIN_BRANCH_NAME }}
+            # set ref name tag for non-main branches
+            type=raw,value=${{ github.ref_name }},enable=${{ github.ref_name != env.MAIN_BRANCH_NAME }}
+      - name: Login to container registry
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.IMG_REGISTRY_USERNAME }}
+          password: ${{ secrets.IMG_REGISTRY_TOKEN }}
+          registry: ${{ env.IMG_REGISTRY_HOST }}
+      - name: Create manifest list and push
+        working-directory: /tmp/digests
+        run: |
+          docker buildx imagetools create $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
+            $(printf '${{ env.IMG_REGISTRY_HOST }}/${{ env.IMG_REGISTRY_ORG }}/${{ env.IMG_NAME }}@sha256:%s ' $(find . -type f -exec basename {} \;))
+      - name: Inspect image
+        run: |
+          docker buildx imagetools inspect ${{ env.IMG_REGISTRY_HOST }}/${{ env.IMG_REGISTRY_ORG }}/${{ env.IMG_NAME }}:${{ steps.meta.outputs.version }}   
+
+      - name: Smoke Test
+        run: |
+          image="${{ env.IMG_REGISTRY_HOST }}/${{ env.IMG_REGISTRY_ORG }}/${{ env.IMG_NAME }}:${{ steps.meta.outputs.version }}"
+          
+          echo "=== Checking amd64 platform ==="
+          docker buildx imagetools inspect "$image" \
+            --format "{{json .Manifest}}" | \
+            jq -e '.manifests[] | select(.platform.architecture=="amd64")' && \
+            echo ":white_check_mark: amd64 OK"
+
+          echo "=== Checking ppc64le platform ==="
+          docker buildx imagetools inspect "$image" \
+            --format "{{json .Manifest}}" | \
+            jq -e '.manifests[] | select(.platform.architecture=="ppc64le")' && \
+            echo ":white_check_mark: ppc64le OK"          
+
+          echo "=== Multi-arch wasm-shim image verified successfully ==="

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 # Build Stage
 # ------------------------------------------------------------------------------
 
-FROM mirror.gcr.io/library/alpine:3.16 as wasm-shim-build
+FROM --platform=${BUILDPLATFORM} mirror.gcr.io/library/alpine:3.16 as wasm-shim-build
 
 ARG GITHUB_SHA
 ENV GITHUB_SHA=${GITHUB_SHA:-unknown}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

**Chores**
- Upgraded build infrastructure to Docker Buildx for improved multi-architecture container image builds, now supporting amd64 and ppc64le platforms
- Enhanced artifact management and manifest creation processes
- Optimised Dockerfile with platform-aware base image support for better cross-platform compatibility

<!-- end of auto-generated comment: release notes by coderabbit.ai -->