### PR TITLE
Request body json

### DIFF
--- a/src/data/cel.rs
+++ b/src/data/cel.rs
@@ -102,6 +102,7 @@ pub(crate) mod errors {
 #[derive(Clone, Debug)]
 pub struct Expression {
     attributes: Vec<Attribute>,
+    request_body_values: Vec<String>,
     response_body_values: Vec<String>,
     expression: CelExpression,
     extended: bool,
@@ -150,10 +151,12 @@ impl Expression {
             .parse(expression)?;
 
         let mut props = Vec::with_capacity(5);
+        let mut request_props = Vec::with_capacity(1);
         let mut response_props = Vec::with_capacity(1);
         properties(
             &expression,
             &mut props,
+            &mut request_props,
             &mut response_props,
             &mut Vec::default(),
         );
@@ -182,6 +185,7 @@ impl Expression {
 
         Ok(Self {
             attributes,
+            request_body_values: request_props,
             response_body_values: response_props,
             expression,
             extended,
@@ -241,20 +245,39 @@ impl Expression {
             cel_ctx.add_variable_from_value(binding, map.get(&key).cloned().unwrap_or(Value::Null));
         }
 
-        let mut response_json_map = HashMap::new();
-        for field_key in &self.response_body_values {
-            match req_ctx.get_body_value(field_key) {
-                Some(value) => {
-                    response_json_map.insert(field_key.clone(), value.clone());
+        {
+            let mut response_json_map = HashMap::new();
+            for field_key in &self.response_body_values {
+                match req_ctx.get_response_body_value(field_key) {
+                    Some(value) => {
+                        response_json_map.insert(field_key.clone(), value.clone());
+                    }
+                    None => return Ok(AttributeState::Pending),
                 }
-                None => return Ok(AttributeState::Pending),
             }
+            cel_ctx.add_variable_from_value(
+                RESPONSE_BODY_JSON_DATA,
+                Value::Map(response_json_map.into()),
+            );
+            cel_ctx.add_function(RESPONSE_BODY_JSON_FN, response_body_json);
         }
-        cel_ctx.add_variable_from_value(
-            RESPONSE_BODY_JSON_DATA,
-            Value::Map(response_json_map.into()),
-        );
-        cel_ctx.add_function(RESPONSE_BODY_JSON_FN, response_body_json);
+
+        {
+            let mut request_json_map = HashMap::new();
+            for field_key in &self.request_body_values {
+                match req_ctx.get_request_body_value(field_key) {
+                    Some(value) => {
+                        request_json_map.insert(field_key.clone(), value.clone());
+                    }
+                    None => return Ok(AttributeState::Pending),
+                }
+            }
+            cel_ctx.add_variable_from_value(
+                REQUEST_BODY_JSON_DATA,
+                Value::Map(request_json_map.into()),
+            );
+            cel_ctx.add_function(REQUEST_BODY_JSON_FN, request_body_json);
+        }
 
         let result = Value::resolve(&self.expression, cel_ctx).map_err(CelError::from)?;
         Ok(AttributeState::Available(result))
@@ -308,6 +331,9 @@ impl Expression {
 const RESPONSE_BODY_JSON_DATA: &str = "@responseBodyJSON";
 const RESPONSE_BODY_JSON_FN: &str = "responseBodyJSON";
 
+const REQUEST_BODY_JSON_DATA: &str = "@requestBodyJSON";
+const REQUEST_BODY_JSON_FN: &str = "requestBodyJSON";
+
 pub fn response_body_json(ftx: &FunctionContext, arg: Value) -> ResolveResult {
     let key: Result<Key, Value> = arg.try_into();
     match key {
@@ -329,6 +355,36 @@ pub fn response_body_json(ftx: &FunctionContext, arg: Value) -> ResolveResult {
             None => Err(ExecutionError::FunctionError {
                 function: RESPONSE_BODY_JSON_FN.to_string(),
                 message: format!("Variable {} not found", RESPONSE_BODY_JSON_DATA),
+            }),
+        },
+        Err(e) => Err(ExecutionError::UnexpectedType {
+            got: format!("{e:?}"),
+            want: "Key".to_string(),
+        }),
+    }
+}
+
+pub fn request_body_json(ftx: &FunctionContext, arg: Value) -> ResolveResult {
+    let key: Result<Key, Value> = arg.try_into();
+    match key {
+        Ok(key) => match ftx.ptx.get_variable(REQUEST_BODY_JSON_DATA) {
+            Some(var) => match Value::try_from(var.as_ref()) {
+                Ok(Value::Map(map)) => match map.get(&key) {
+                    None => Ok(Value::Null),
+                    Some(value) => Ok(value.clone()),
+                },
+                Ok(_) => Err(ExecutionError::FunctionError {
+                    function: REQUEST_BODY_JSON_FN.to_string(),
+                    message: "Bad internal state!".to_string(),
+                }),
+                Err(_) => Err(ExecutionError::FunctionError {
+                    function: REQUEST_BODY_JSON_FN.to_string(),
+                    message: "Failed to convert variable to Value".to_string(),
+                }),
+            },
+            None => Err(ExecutionError::FunctionError {
+                function: REQUEST_BODY_JSON_FN.to_string(),
+                message: format!("Variable {} not found", REQUEST_BODY_JSON_DATA),
             }),
         },
         Err(e) => Err(ExecutionError::UnexpectedType {
@@ -725,29 +781,39 @@ fn new_well_known_attribute_map() -> HashMap<Path, ValueType> {
 fn properties<'e>(
     ided_exp: &'e IdedExpr,
     all: &mut Vec<Vec<&'e str>>,
+    request_props: &mut Vec<String>,
     response_props: &mut Vec<String>,
     path: &mut Vec<&'e str>,
 ) {
     match &ided_exp.expr {
         Expr::Call(call) => {
-            if call.target.is_none() && call.func_name == "responseBodyJSON" && call.args.len() == 1
+            if call.target.is_none()
+                && call.func_name == RESPONSE_BODY_JSON_FN
+                && call.args.len() == 1
             {
                 if let Expr::Literal(LiteralValue::String(prop)) = &call.args[0].expr {
                     response_props.push(prop.to_string());
                 }
+            } else if call.target.is_none()
+                && call.func_name == REQUEST_BODY_JSON_FN
+                && call.args.len() == 1
+            {
+                if let Expr::Literal(LiteralValue::String(prop)) = &call.args[0].expr {
+                    request_props.push(prop.to_string());
+                }
             }
             if let Some(target) = &call.target {
-                properties(target, all, response_props, path);
+                properties(target, all, request_props, response_props, path);
             } else {
                 path.clear();
             }
             for arg in &call.args {
-                properties(arg, all, response_props, path);
+                properties(arg, all, request_props, response_props, path);
             }
         }
         Expr::Select(select) => {
             path.insert(0, select.field.as_str());
-            properties(&select.operand, all, response_props, path);
+            properties(&select.operand, all, request_props, response_props, path);
         }
         Expr::Ident(name) => {
             if !path.is_empty() {
@@ -758,18 +824,18 @@ fn properties<'e>(
         }
         Expr::List(list) => {
             for elem in &list.elements {
-                properties(elem, all, response_props, path);
+                properties(elem, all, request_props, response_props, path);
             }
         }
         Expr::Map(map) => {
             for entry in &map.entries {
                 match &entry.expr {
                     EntryExpr::MapEntry(map_entry) => {
-                        properties(&map_entry.key, all, response_props, path);
-                        properties(&map_entry.value, all, response_props, path);
+                        properties(&map_entry.key, all, request_props, response_props, path);
+                        properties(&map_entry.value, all, request_props, response_props, path);
                     }
                     EntryExpr::StructField(field) => {
-                        properties(&field.value, all, response_props, path);
+                        properties(&field.value, all, request_props, response_props, path);
                     }
                 }
             }
@@ -777,16 +843,16 @@ fn properties<'e>(
         Expr::Struct(struct_expr) => {
             for entry in &struct_expr.entries {
                 if let EntryExpr::StructField(field) = &entry.expr {
-                    properties(&field.value, all, response_props, path);
+                    properties(&field.value, all, request_props, response_props, path);
                 }
             }
         }
         Expr::Comprehension(comp) => {
-            properties(&comp.iter_range, all, response_props, path);
-            properties(&comp.accu_init, all, response_props, path);
-            properties(&comp.loop_cond, all, response_props, path);
-            properties(&comp.loop_step, all, response_props, path);
-            properties(&comp.result, all, response_props, path);
+            properties(&comp.iter_range, all, request_props, response_props, path);
+            properties(&comp.accu_init, all, request_props, response_props, path);
+            properties(&comp.loop_cond, all, request_props, response_props, path);
+            properties(&comp.loop_step, all, request_props, response_props, path);
+            properties(&comp.result, all, request_props, response_props, path);
         }
         Expr::Literal(_) | Expr::Unspecified => {}
     }
@@ -1010,6 +1076,15 @@ mod tests {
     }
 
     #[test]
+    fn expressions_captures_request_fields() {
+        let value = Expression::new(
+            "auth.identity.anonymous && auth.identity != null && requestBodyJSON('foo.bar') > 3",
+        )
+        .expect("This is valid CEL!");
+        assert_eq!(value.request_body_values, vec!["foo.bar".to_string()]);
+    }
+
+    #[test]
     fn expressions_to_json_resolve() {
         // Test boolean value
         let mock_host = MockWasmHost::new().with_property(
@@ -1164,7 +1239,7 @@ mod tests {
     }
 
     #[test]
-    fn multiple_expressions_share_body_values_from_context() {
+    fn multiple_expressions_share_response_body_values_from_context() {
         let mock_host = MockWasmHost::new();
         let mut ctx = ReqRespCtx::new(Arc::new(mock_host));
         ctx.set_response_body_value("tokens", 100);
@@ -1179,6 +1254,54 @@ mod tests {
             "responseBodyJSON('tokens') > 0 && responseBodyJSON('model') == 'gpt-4'",
         )
         .unwrap();
+        assert_eq!(
+            AttributeState::Available(Value::Bool(true)),
+            expr2.eval(&ctx).unwrap()
+        );
+    }
+
+    #[test]
+    fn request_body_json() {
+        let expr = Expression::new("requestBodyJSON('bar') == 42").unwrap();
+        let mock_host = MockWasmHost::new();
+        let mut ctx = ReqRespCtx::new(Arc::new(mock_host));
+        ctx.set_request_body_value("bar", 42);
+        assert_eq!(
+            AttributeState::Available(Value::Bool(true)),
+            expr.eval(&ctx).unwrap()
+        );
+    }
+
+    #[test]
+    fn request_body_json_returns_pending_when_not_set() {
+        let expr = Expression::new("requestBodyJSON('bar') == 42").unwrap();
+        let mock_host = MockWasmHost::new();
+        let ctx = ReqRespCtx::new(Arc::new(mock_host));
+        assert_eq!(AttributeState::Pending, expr.eval(&ctx).unwrap());
+
+        let expr =
+            Expression::new("requestBodyJSON('foo') + requestBodyJSON('bar') == 100").unwrap();
+        let mock_host = MockWasmHost::new();
+        let mut ctx = ReqRespCtx::new(Arc::new(mock_host));
+        ctx.set_request_body_value("foo", 58);
+        assert_eq!(AttributeState::Pending, expr.eval(&ctx).unwrap());
+    }
+
+    #[test]
+    fn multiple_expressions_share_request_body_values_from_context() {
+        let mock_host = MockWasmHost::new();
+        let mut ctx = ReqRespCtx::new(Arc::new(mock_host));
+        ctx.set_request_body_value("tokens", 100);
+        ctx.set_request_body_value("model", "gpt-4");
+
+        let expr1 = Expression::new("requestBodyJSON('tokens') > 50").unwrap();
+        assert_eq!(
+            AttributeState::Available(Value::Bool(true)),
+            expr1.eval(&ctx).unwrap()
+        );
+        let expr2 =
+            Expression::new("requestBodyJSON('tokens') > 0 && requestBodyJSON('model') == 'gpt-4'")
+                .unwrap();
         assert_eq!(
             AttributeState::Available(Value::Bool(true)),
             expr2.eval(&ctx).unwrap()

--- a/src/data/cel.rs
+++ b/src/data/cel.rs
@@ -102,7 +102,7 @@ pub(crate) mod errors {
 #[derive(Clone, Debug)]
 pub struct Expression {
     attributes: Vec<Attribute>,
-    body_values: Vec<String>,
+    response_body_values: Vec<String>,
     expression: CelExpression,
     extended: bool,
     needs_grpc: bool,
@@ -182,7 +182,7 @@ impl Expression {
 
         Ok(Self {
             attributes,
-            body_values: response_props,
+            response_body_values: response_props,
             expression,
             extended,
             needs_grpc,
@@ -242,7 +242,7 @@ impl Expression {
         }
 
         let mut response_json_map = HashMap::new();
-        for field_key in &self.body_values {
+        for field_key in &self.response_body_values {
             match req_ctx.get_body_value(field_key) {
                 Some(value) => {
                     response_json_map.insert(field_key.clone(), value.clone());
@@ -269,8 +269,8 @@ impl Expression {
         data::AttributeMap::new(self.attributes.clone()).into(req_ctx)
     }
 
-    pub fn body_values(&self) -> &[String] {
-        &self.body_values
+    pub fn response_body_values(&self) -> &[String] {
+        &self.response_body_values
     }
 
     fn resolve_grpc(&self, req_ctx: &ReqRespCtx) -> Option<Value> {
@@ -471,8 +471,8 @@ impl Predicate {
         }
     }
 
-    pub fn body_values(&self) -> &[String] {
-        self.expression.body_values()
+    pub fn response_body_values(&self) -> &[String] {
+        self.expression.response_body_values()
     }
 }
 
@@ -1006,7 +1006,7 @@ mod tests {
             "auth.identity.anonymous && auth.identity != null && responseBodyJSON('foo.bar') > 3",
         )
         .expect("This is valid CEL!");
-        assert_eq!(value.body_values, vec!["foo.bar".to_string()]);
+        assert_eq!(value.response_body_values, vec!["foo.bar".to_string()]);
     }
 
     #[test]
@@ -1141,7 +1141,7 @@ mod tests {
         let expr = Expression::new("responseBodyJSON('bar') == 42").unwrap();
         let mock_host = MockWasmHost::new();
         let mut ctx = ReqRespCtx::new(Arc::new(mock_host));
-        ctx.set_body_value("bar", 42);
+        ctx.set_response_body_value("bar", 42);
         assert_eq!(
             AttributeState::Available(Value::Bool(true)),
             expr.eval(&ctx).unwrap()
@@ -1159,7 +1159,7 @@ mod tests {
             Expression::new("responseBodyJSON('foo') + responseBodyJSON('bar') == 100").unwrap();
         let mock_host = MockWasmHost::new();
         let mut ctx = ReqRespCtx::new(Arc::new(mock_host));
-        ctx.set_body_value("foo", 58);
+        ctx.set_response_body_value("foo", 58);
         assert_eq!(AttributeState::Pending, expr.eval(&ctx).unwrap());
     }
 
@@ -1167,8 +1167,8 @@ mod tests {
     fn multiple_expressions_share_body_values_from_context() {
         let mock_host = MockWasmHost::new();
         let mut ctx = ReqRespCtx::new(Arc::new(mock_host));
-        ctx.set_body_value("tokens", 100);
-        ctx.set_body_value("model", "gpt-4");
+        ctx.set_response_body_value("tokens", 100);
+        ctx.set_response_body_value("model", "gpt-4");
 
         let expr1 = Expression::new("responseBodyJSON('tokens') > 50").unwrap();
         assert_eq!(

--- a/src/filter/kuadrant_filter.rs
+++ b/src/filter/kuadrant_filter.rs
@@ -128,9 +128,12 @@ impl HttpContext for KuadrantFilter {
         }
     }
 
-    fn on_http_request_body(&mut self, _buffer_size: usize, _end_of_stream: bool) -> Action {
+    fn on_http_request_body(&mut self, buffer_size: usize, end_of_stream: bool) -> Action {
         debug!("#{} on_http_request_body", self.context_id);
-        if let Some(pipeline) = self.pipeline.take() {
+        if let Some(mut pipeline) = self.pipeline.take() {
+            pipeline
+                .ctx
+                .set_current_request_body_buffer_size(buffer_size, end_of_stream);
             match pipeline.eval() {
                 PipelineState::InProgress(p) => {
                     self.pipeline = Some(*p);

--- a/src/kuadrant/context.rs
+++ b/src/kuadrant/context.rs
@@ -20,6 +20,8 @@ pub struct ReqRespCtx {
     backend: Arc<dyn AttributeResolver>,
     cache: Arc<AttributeCache>,
     request_data: Option<Vec<RequestData>>,
+    request_body_size: usize,
+    request_end_of_stream: bool,
     response_body_size: usize,
     response_end_of_stream: bool,
     // todo(refactor): we should handle token here
@@ -42,6 +44,8 @@ impl ReqRespCtx {
             backend,
             cache: Arc::new(AttributeCache::new()),
             request_data: None,
+            request_body_size: 0,
+            request_end_of_stream: false,
             response_body_size: 0,
             response_end_of_stream: false,
             grpc_response_data: None,
@@ -102,6 +106,11 @@ impl ReqRespCtx {
 
     pub fn set_hostname(&mut self, hostname: String) {
         self.tracing.hostname = Some(hostname);
+    }
+
+    pub fn set_current_request_body_buffer_size(&mut self, body_size: usize, end_of_stream: bool) {
+        self.request_body_size = body_size;
+        self.request_end_of_stream = end_of_stream;
     }
 
     pub fn set_current_response_body_buffer_size(&mut self, body_size: usize, end_of_stream: bool) {
@@ -412,6 +421,7 @@ impl ReqRespCtx {
         }
     }
 
+    #[allow(dead_code)]
     pub fn set_request_body_value<K: Into<String>, V: Into<Value>>(&mut self, key: K, value: V) {
         self.request_body_values.insert(key.into(), value.into());
     }

--- a/src/kuadrant/context.rs
+++ b/src/kuadrant/context.rs
@@ -26,7 +26,7 @@ pub struct ReqRespCtx {
     grpc_response_data: Option<(u32, usize)>,
     tracing: TracingContext,
     tracker: Tracker,
-    body_values: HashMap<String, Value>,
+    response_body_values: HashMap<String, Value>,
 }
 
 impl Default for ReqRespCtx {
@@ -46,7 +46,7 @@ impl ReqRespCtx {
             grpc_response_data: None,
             tracing: TracingContext::default(),
             tracker: Tracker::default(),
-            body_values: HashMap::new(),
+            response_body_values: HashMap::new(),
         }
     }
 
@@ -410,12 +410,12 @@ impl ReqRespCtx {
         }
     }
 
-    pub fn set_body_value<K: Into<String>, V: Into<Value>>(&mut self, key: K, value: V) {
-        self.body_values.insert(key.into(), value.into());
+    pub fn set_response_body_value<K: Into<String>, V: Into<Value>>(&mut self, key: K, value: V) {
+        self.response_body_values.insert(key.into(), value.into());
     }
 
-    pub fn get_body_value(&self, key: &str) -> Option<&Value> {
-        self.body_values.get(key)
+    pub fn get_response_body_value(&self, key: &str) -> Option<&Value> {
+        self.response_body_values.get(key)
     }
 }
 

--- a/src/kuadrant/context.rs
+++ b/src/kuadrant/context.rs
@@ -26,6 +26,7 @@ pub struct ReqRespCtx {
     grpc_response_data: Option<(u32, usize)>,
     tracing: TracingContext,
     tracker: Tracker,
+    request_body_values: HashMap<String, Value>,
     response_body_values: HashMap<String, Value>,
 }
 
@@ -46,6 +47,7 @@ impl ReqRespCtx {
             grpc_response_data: None,
             tracing: TracingContext::default(),
             tracker: Tracker::default(),
+            request_body_values: HashMap::new(),
             response_body_values: HashMap::new(),
         }
     }
@@ -408,6 +410,14 @@ impl ReqRespCtx {
             None => None,
             Some(id) => Some((id.as_str(), self.request_id())),
         }
+    }
+
+    pub fn set_request_body_value<K: Into<String>, V: Into<Value>>(&mut self, key: K, value: V) {
+        self.request_body_values.insert(key.into(), value.into());
+    }
+
+    pub fn get_request_body_value(&self, key: &str) -> Option<&Value> {
+        self.request_body_values.get(key)
     }
 
     pub fn set_response_body_value<K: Into<String>, V: Into<Value>>(&mut self, key: K, value: V) {

--- a/src/kuadrant/pipeline/blueprint.rs
+++ b/src/kuadrant/pipeline/blueprint.rs
@@ -62,18 +62,18 @@ impl Action {
         let mut fields = Vec::new();
 
         for predicate in &self.predicates {
-            fields.extend(predicate.body_values().iter().cloned());
+            fields.extend(predicate.response_body_values().iter().cloned());
         }
         for data in &self.conditional_data {
             for predicate in &data.predicates {
-                fields.extend(predicate.body_values().iter().cloned());
+                fields.extend(predicate.response_body_values().iter().cloned());
             }
             for item in &data.data {
-                fields.extend(item.value.body_values().iter().cloned());
+                fields.extend(item.value.response_body_values().iter().cloned());
             }
         }
         for (_, expr) in request_data {
-            fields.extend(expr.body_values().iter().cloned());
+            fields.extend(expr.response_body_values().iter().cloned());
         }
 
         fields.dedup();
@@ -258,7 +258,7 @@ impl Blueprint {
                     ));
                     let task = Box::new(FailureModeTask::new(task, abort_on_failure));
 
-                    tasks.push(Box::new(TokenUsageTask::with_expected_fields(
+                    tasks.push(Box::new(TokenUsageTask::with_expected_response_fields(
                         action.collect_body_values(request_data),
                     )));
 

--- a/src/kuadrant/pipeline/tasks/token_usage.rs
+++ b/src/kuadrant/pipeline/tasks/token_usage.rs
@@ -10,19 +10,19 @@ mod event_parser;
 
 pub struct TokenUsageTask {
     strategy: Option<Box<dyn ExtractionStrategy>>,
-    expected_fields: Vec<String>,
+    expected_response_fields: Vec<String>,
 }
 
 impl TokenUsageTask {
     #[cfg(test)]
     pub fn new() -> Self {
-        Self::with_expected_fields(Vec::new())
+        Self::with_expected_response_fields(Vec::new())
     }
 
-    pub fn with_expected_fields(expected_fields: Vec<String>) -> Self {
+    pub fn with_expected_response_fields(expected_response_fields: Vec<String>) -> Self {
         Self {
             strategy: None,
-            expected_fields,
+            expected_response_fields,
         }
     }
 }
@@ -31,7 +31,7 @@ impl From<Box<Self>> for TokenUsageTask {
     fn from(value: Box<Self>) -> Self {
         Self {
             strategy: value.strategy,
-            expected_fields: value.expected_fields,
+            expected_response_fields: value.expected_response_fields,
         }
     }
 }
@@ -81,20 +81,20 @@ impl Task for TokenUsageTask {
         }
 
         if ctx.is_end_of_stream() {
-            for field in &task.expected_fields {
+            for field in &task.expected_response_fields {
                 if let Some(json_value) = strategy.extract_property(field) {
                     match json_value {
-                        Value::Bool(b) => ctx.set_body_value(field, b),
+                        Value::Bool(b) => ctx.set_response_body_value(field, b),
                         Value::Number(n) => {
                             if let Some(u) = n.as_u64() {
-                                ctx.set_body_value(field, u);
+                                ctx.set_response_body_value(field, u);
                             } else if let Some(i) = n.as_i64() {
-                                ctx.set_body_value(field, i);
+                                ctx.set_response_body_value(field, i);
                             } else if let Some(f) = n.as_f64() {
-                                ctx.set_body_value(field, f);
+                                ctx.set_response_body_value(field, f);
                             }
                         }
-                        Value::String(s) => ctx.set_body_value(field, s),
+                        Value::String(s) => ctx.set_response_body_value(field, s),
                         Value::Null | Value::Array(_) | Value::Object(_) => {
                             warn!("Unsupported json value type: {:?}", json_value);
                         }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
* CEL expressions now support `requestBodyJSON()` function to access and filter based on request body JSON fields, alongside the existing `responseBodyJSON()` functionality.

## Improvements
* Request and response body values are now tracked separately, enhancing expression evaluation clarity.
* Request body buffer state is now properly recorded during request processing to support pending state handling when referenced fields are unavailable.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Kuadrant/wasm-shim/pull/338?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->