### PR TITLE
Adopt RFC 0018 release branch naming (release-X.Y)

### DIFF
--- a/.github/actions/prepare-release/action.yaml
+++ b/.github/actions/prepare-release/action.yaml
@@ -40,7 +40,7 @@ runs:
       id: create-branch
       shell: bash
       run: |
-        base_branch=release-v$(echo "$WASM_SHIM_VERSION" | sed 's/[+-].*//; s/\.[0-9]*$//')
+        base_branch=release-$(echo "$WASM_SHIM_VERSION" | sed 's/[+-].*//; s/\.[0-9]*$//')
         echo "BASE_BRANCH=$base_branch" >> $GITHUB_ENV
         echo "base-branch=$base_branch" >> $GITHUB_OUTPUT
 

--- a/.github/workflows/automated-release.yaml
+++ b/.github/workflows/automated-release.yaml
@@ -42,7 +42,7 @@ jobs:
           author: ${{ github.actor }} <${{ github.actor_id }}+${{ github.actor }}@users.noreply.github.com>
           signoff: true
           base: ${{ env.BASE_BRANCH }}
-          branch: release-v${{ env.WASM_SHIM_VERSION }}
+          branch: release-${{ env.WASM_SHIM_VERSION }}
           delete-branch: true
           title: '[Release] WASM Shim v${{ env.WASM_SHIM_VERSION }}'
           body: |

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -7,6 +7,7 @@ on:
     - closed
     branches:
       - 'release-v[0-9]+.[0-9]+'
+      - 'release-[0-9]+.[0-9]+'
   workflow_dispatch: {}
 
 permissions:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -6,7 +6,6 @@ on:
     types:
     - closed
     branches:
-      - 'release-v[0-9]+.[0-9]+'
       - 'release-[0-9]+.[0-9]+'
   workflow_dispatch: {}
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -6,14 +6,14 @@ The wasm-shim uses an automated release process with protected release branches.
 
 1. **Run the workflow**: Actions → “Automated Release WASM Shim” → “Run workflow”
    - **wasmShimVersion**: Version to release (e.g., `0.12.1`)
-   - **gitRef**: `main` for new minor, `release-v0.12` for patches
+   - **gitRef**: `main` for new minor, `release-0.12` for patches
 2. **Review and merge the PR** that gets created
 3. **Done** - tag and release happen automatically on merge
 
 ## Standard Release
 
 1. Actions → “Automated Release WASM Shim” → “Run workflow”
-   - **gitRef**: `main` (for new minor like `0.13.0`) or `release-v0.12` (for patch like `0.12.1`)
+   - **gitRef**: `main` (for new minor like `0.13.0`) or `release-0.12` (for patch like `0.12.1`)
    - **wasmShimVersion**: `0.12.1` (or whatever version)
 2. Review and merge the PR
 3. Tag and release created automatically
@@ -23,15 +23,15 @@ The wasm-shim uses an automated release process with protected release branches.
 1. **First, cherry-pick and merge your fixes:**
 
    ```bash
-   git checkout -b backport-my-fix origin/release-v0.12
+   git checkout -b backport-my-fix origin/release-0.12
    git cherry-pick <commit-sha>
    git push -u origin HEAD
-   # Create PR from backport-my-fix to release-v0.12, get it merged
+   # Create PR from backport-my-fix to release-0.12, get it merged
    ```
 
 2. **Then run the release workflow:**
    - Actions → “Automated Release WASM Shim” → “Run workflow”
-   - **gitRef**: `release-v0.12` (picks up the cherry-picks)
+   - **gitRef**: `release-0.12` (picks up the cherry-picks)
    - **wasmShimVersion**: `0.12.1`
 
 3. Review and merge the version bump PR
@@ -40,7 +40,7 @@ The wasm-shim uses an automated release process with protected release branches.
 ## Details
 
 - Version format: semver without `v` prefix (e.g., `0.12.1`, not `v0.12.1`)
-- Release branches: `release-v0.12`, `release-v0.13`, etc.
+- Release branches: `release-0.12`, `release-0.13`, etc.
 - One branch per minor version, shared by all patches
 - Workflow creates the release branch if it doesn't exist
   - For new minor versions, creates from specified `gitRef`


### PR DESCRIPTION
## Summary

Updates workflows, composite action, and release docs to use `release-X.Y` convention (no `v` prefix) per [RFC 0018](https://github.com/Kuadrant/architecture/blob/main/rfcs/0018-release-branch-naming.md).

## Changes

- `release.yaml` — add `release-[0-9]+.[0-9]+` alongside existing `release-v[0-9]+.[0-9]+` (dual patterns)
- `automated-release.yaml` — PR head branch drops `v` prefix
- `.github/actions/prepare-release/action.yaml` — base branch construction drops `v` prefix
- `RELEASE.md` — update all examples to `release-X.Y`

Part of Kuadrant/kuadrant-operator#1981

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated release branch naming convention from `release-vX.Y` to `release-X.Y` format.
  * Updated automated release workflows and documentation to reflect the simplified branch naming pattern.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Kuadrant/wasm-shim/pull/339?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->