### PR TITLE
ci: trigger test workflow on release branch pushes

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -3,7 +3,7 @@ name: Tests
 
 on:
   push:
-    branches: ["main"]
+    branches: ["main", "release-*"]
   pull_request:
     branches: ["*"]
   merge_group:


### PR DESCRIPTION
## Summary

Adds `release-*` to the push branch trigger in `tests.yaml` so CI runs when commits land on release branches. The pull_request trigger already uses a wildcard.

Part of the RFC 0018 migration (Kuadrant/kuadrant-operator#1981).

🤖 Generated with [Claude Code](https://claude.com/claude-code)