### PR TITLE
Fix nested map and field presence

### DIFF
--- a/src/services/dynamic/converters.rs
+++ b/src/services/dynamic/converters.rs
@@ -76,16 +76,14 @@ impl DescriptorConverter {
                 continue;
             }
 
-            if desc.is_map_entry() {
-                continue;
-            }
-
             for field in desc.fields() {
                 if let ProtoKind::Message(nested_desc) = field.kind() {
-                    if !nested_desc.is_map_entry() {
-                        to_register.push(nested_desc);
-                    }
+                    to_register.push(nested_desc);
                 }
+            }
+
+            if desc.is_map_entry() {
+                continue;
             }
 
             let struct_def = Self::to_struct_def(&desc)?;
@@ -220,7 +218,7 @@ impl MessageConverter {
         let mut cel_struct = CelStruct::new(descriptor.full_name().to_string());
 
         for field in descriptor.fields() {
-            if field.containing_oneof().is_some() && !message.has_field(&field) {
+            if !message.has_field(&field) && field.supports_presence() {
                 continue;
             }
             let field_value = message.get_field(&field);
@@ -256,7 +254,7 @@ impl MessageConverter {
                 let mut cel_struct = CelStruct::new(descriptor.full_name().to_string());
 
                 for field in descriptor.fields() {
-                    if field.containing_oneof().is_some() && !m.has_field(&field) {
+                    if !m.has_field(&field) && field.supports_presence() {
                         continue;
                     }
                     let field_value = m.get_field(&field);


### PR DESCRIPTION
- Ensure we add descriptors from maps as well as structs
- Don't only skip oneof, but also skip fields that support presence (avoids empty data structures for `has()` expressions)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of nested message descriptors within map structures; nested messages are now correctly discoverable.
  * Enhanced accuracy of field presence detection when converting dynamic messages, ensuring unset fields are properly identified and handled.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Kuadrant/wasm-shim/pull/352?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->