### PR TITLE
Refactor `SendReplyTask`

### DIFF
--- a/src/kuadrant/pipeline/tasks/send_reply.rs
+++ b/src/kuadrant/pipeline/tasks/send_reply.rs
@@ -29,7 +29,6 @@ pub struct SendReplyTask {
 
 impl SendReplyTask {
     pub fn new(status_code: u32, headers: Vec<(String, String)>, body: Option<String>) -> Self {
-        METRICS.denied().increment();
         Self {
             predicate: None,
             mode: SendReplyMode::Concrete {
@@ -159,6 +158,8 @@ impl Task for SendReplyTask {
         if let Some((tracker, value)) = ctx.tracker() {
             headers_ref.push((tracker, value));
         }
+
+        METRICS.denied().increment();
 
         let body_bytes = body.as_ref().map(|s| s.as_bytes());
         match ctx.send_http_reply(status_code, headers_ref, body_bytes) {

--- a/src/kuadrant/pipeline/tasks/send_reply.rs
+++ b/src/kuadrant/pipeline/tasks/send_reply.rs
@@ -1,5 +1,7 @@
+use std::sync::Arc;
+
 use cel::common::types::{CelString, CelUInt};
-use cel::Value;
+use cel::{Env, Value};
 use tracing::error;
 
 use crate::data::attribute::AttributeState;
@@ -8,34 +10,30 @@ use crate::data::Expression;
 use crate::kuadrant::pipeline::tasks::{NoopTerminalTask, Task, TaskOutcome};
 use crate::kuadrant::ReqRespCtx;
 use crate::metrics::METRICS;
-use crate::services::cel_value_to_header_pairs;
-
-enum SendReplyMode {
-    Concrete {
-        status_code: u32,
-        headers: Vec<(String, String)>,
-        body: Option<String>,
-    },
-    Deferred {
-        deny_with: Expression,
-    },
-}
+use crate::services::{cel_value_to_header_pairs, deny_response_struct_def};
 
 pub struct SendReplyTask {
     predicate: Option<Predicate>,
-    mode: SendReplyMode,
+    deny_with: Expression,
     terminal: bool,
 }
 
 impl SendReplyTask {
     pub fn new(status_code: u32, headers: Vec<(String, String)>, body: Option<String>) -> Self {
+        let headers = headers
+            .into_iter()
+            .map(|(h, v)| format!("['''{h}''', '''{v}''']"))
+            .collect::<Vec<String>>()
+            .join(", ");
+        let body_field = body.map(|b| format!("body: '''{b}'''")).unwrap_or_default();
+        let expr = format!(
+            "DenyResponse {{ status: {status_code}u, headers: [{headers}], {body_field} }}"
+        );
+        #[allow(clippy::expect_used)]
+        let deny_with = Expression::new(&expr).expect("Needs to be valid CEL!");
         Self {
             predicate: None,
-            mode: SendReplyMode::Concrete {
-                status_code,
-                headers,
-                body,
-            },
+            deny_with,
             terminal: false,
         }
     }
@@ -43,7 +41,7 @@ impl SendReplyTask {
     pub fn new_deferred(predicate: Predicate, deny_with: Expression, terminal: bool) -> Self {
         Self {
             predicate: Some(predicate),
-            mode: SendReplyMode::Deferred { deny_with },
+            deny_with,
             terminal,
         }
     }
@@ -104,48 +102,46 @@ impl Task for SendReplyTask {
             }
         }
 
-        let (status_code, headers, body) = match &self.mode {
-            SendReplyMode::Concrete {
-                status_code,
-                headers,
-                body,
-            } => (*status_code, headers.clone(), body.clone()),
-            SendReplyMode::Deferred { deny_with } => {
-                let mut cel_ctx = cel::Context::default();
-                match deny_with.eval(ctx, &mut cel_ctx) {
-                    Ok(AttributeState::Pending) => {
-                        error!("Unexpected pending state in deny expression");
+        let (status_code, headers, body) = {
+            let mut env = Env::stdlib();
+            env.add_struct(deny_response_struct_def());
+            let mut cel_ctx = cel::Context::with_env(Arc::new(env));
+            match self.deny_with.eval(ctx, &mut cel_ctx) {
+                Ok(AttributeState::Pending) => {
+                    error!("Unexpected pending state in deny expression");
+                    return TaskOutcome::Failed;
+                }
+                Ok(AttributeState::Available(val @ Value::Struct(_))) => {
+                    let Value::Struct(deny_response) = val else {
+                        error!("Invalid DenyResponse: {val:?}");
                         return TaskOutcome::Failed;
-                    }
-                    Ok(AttributeState::Available(val @ Value::Struct(_))) => {
-                        match SendReplyTask::try_from(val) {
-                            Ok(concrete_task) => {
-                                if let SendReplyMode::Concrete {
-                                    status_code,
-                                    headers,
-                                    body,
-                                } = concrete_task.mode
-                                {
-                                    (status_code, headers, body)
-                                } else {
-                                    error!("Expected concrete task from try_from");
-                                    return TaskOutcome::Failed;
-                                }
-                            }
-                            Err(e) => {
-                                error!("Invalid DenyResponse: {e}");
-                                return TaskOutcome::Failed;
-                            }
-                        }
-                    }
-                    Ok(AttributeState::Available(other)) => {
-                        error!("denyWith must return DenyResponse, got: {other:?}");
-                        return TaskOutcome::Failed;
-                    }
-                    Err(e) => {
-                        error!("Failed to evaluate denyWith expression: {e}");
-                        return TaskOutcome::Failed;
-                    }
+                    };
+
+                    let status = deny_response
+                        .field_value("status")
+                        .and_then(|v| v.downcast_ref::<CelUInt>())
+                        .map(|v| *v.inner() as u32);
+
+                    let body = deny_response
+                        .field_value("body")
+                        .and_then(|v| v.downcast_ref::<CelString>())
+                        .map(|v| v.inner().to_string())
+                        .filter(|s| !s.is_empty());
+
+                    let headers = deny_response
+                        .field_value("headers")
+                        .and_then(|v| Value::try_from(v).ok())
+                        .map(|v| cel_value_to_header_pairs(&v))
+                        .unwrap_or_default();
+                    (status.unwrap_or(500u32), headers, body)
+                }
+                Ok(AttributeState::Available(other)) => {
+                    error!("denyWith must return DenyResponse, got: {other:?}");
+                    return TaskOutcome::Failed;
+                }
+                Err(e) => {
+                    error!("Failed to evaluate denyWith expression: {e}");
+                    return TaskOutcome::Failed;
                 }
             }
         };
@@ -191,7 +187,13 @@ mod tests {
 
         let task = Box::new(SendReplyTask::new(
             403,
-            vec![("content-type".to_string(), "text/plain".to_string())],
+            vec![
+                ("content-type".to_string(), "text/plain".to_string()),
+                (
+                    "WWW-Authenticate".to_string(),
+                    "APIKEY realm=\"api-key-users\"".to_string(),
+                ),
+            ],
             Some("Access Denied".to_string()),
         ));
 

--- a/src/services/mod.rs
+++ b/src/services/mod.rs
@@ -6,7 +6,9 @@ use std::{rc::Rc, time::Duration};
 mod dynamic;
 mod tracing;
 
-pub use dynamic::converters::{cel_value_to_header_pairs, MessageConverter};
+pub use dynamic::converters::{
+    cel_value_to_header_pairs, deny_response_struct_def, MessageConverter,
+};
 pub use dynamic::DynamicService;
 pub use tracing::TracingService;
 


### PR DESCRIPTION
Not at all as far as where I was hoping to get, but that's the idea. 
When that's done for all other "`Action`", `DynamicTask` won't need the `Action`s anymore, but the `Pipeline` could be constructed with "only `Task`s". And all the `impl TryFrom<Value> for` can be :fire: too.

@adam-cattermole Do not expand on this, but have a look at the `Store` for `requestBodyJSON('/model')` as discussed. I'll keep moving this PR forward (my) tomorrow. Now all input is welcome already tho!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Refactored denial response handling to improve evaluation flexibility.
  * Adjusted denial metrics recording to occur at execution time for enhanced accuracy.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Kuadrant/wasm-shim/pull/359?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->