### PR TITLE
FIX: workflow with token

### DIFF
--- a/.github/workflows/sector-release.yaml
+++ b/.github/workflows/sector-release.yaml
@@ -23,7 +23,7 @@ jobs:
         uses: actions/checkout@v6
         with:
           ref: ${{ github.event.inputs.gitRef }}
-          token: ${{ secrets.KUADRANT_WORKFLOWS_PAT }}
+          token: ${{ secrets.KUADRANT_DEV_PAT }}
 
       - name: Prepare release
         uses: ./.github/actions/prepare-release


### PR DESCRIPTION
The wrong token was used on the sector release workflow.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions workflow to reference a different token secret for release automation.

---

Note: This release contains infrastructure updates with no user-facing changes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Kuadrant/wasm-shim/pull/365?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->