### PR TITLE
Add linker arg for rust 1.96

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,2 @@
+[target.wasm32-wasip1]
+rustflags = ["-C", "link-arg=--allow-undefined"]


### PR DESCRIPTION
I think the correct fix is to update in proxy-wasm-rust-sdk and add specific link attributes https://blog.rust-lang.org/2026/04/04/changes-to-webassembly-targets-and-handling-undefined-symbols/