### PR TITLE
Remove implicit sequential dependency from typed action

### DIFF
--- a/src/kuadrant/pipeline/blueprint.rs
+++ b/src/kuadrant/pipeline/blueprint.rs
@@ -186,13 +186,13 @@ impl Blueprint {
             .enumerate()
             .map(|(i, action_config)| {
                 let id = i.to_string();
-                let dependencies = if i > 0 {
-                    vec![(i - 1).to_string()]
-                } else {
-                    vec![]
-                };
                 match action_config {
                     configuration::ActionConfig::Legacy(action) => {
+                        let dependencies = if i > 0 {
+                            vec![(i - 1).to_string()]
+                        } else {
+                            vec![]
+                        };
                         let legacy_request_data: Vec<((String, String), String)> = request_data
                             .iter()
                             .map(|(key, expr)| (key.clone(), expr.source().to_string()))
@@ -200,7 +200,7 @@ impl Blueprint {
                         Action::compile(action, services, id, dependencies, &legacy_request_data)
                     }
                     configuration::ActionConfig::Typed(typed) => {
-                        Action::compile_typed(typed, services, id, dependencies)
+                        Action::compile_typed(typed, services, id, vec![])
                     }
                 }
             })
@@ -430,12 +430,7 @@ impl Action {
                     .enumerate()
                     .map(|(idx, typed_action)| {
                         let reply_id = format!("{}.{}", id, idx);
-                        let reply_deps = if idx > 0 {
-                            vec![format!("{}.{}", id, idx - 1)]
-                        } else {
-                            vec![]
-                        };
-                        Action::compile_typed(typed_action, services, reply_id, reply_deps)
+                        Action::compile_typed(typed_action, services, reply_id, vec![])
                     })
                     .collect::<Result<_, _>>()?;
 
@@ -1028,6 +1023,7 @@ mod tests {
             assert!(matches!(service, ServiceInstance::Dynamic(_)));
             assert_eq!(on_reply.len(), 1);
         }
-        assert_eq!(blueprint.actions[1].dependencies, vec!["0"]);
+
+        assert!(blueprint.actions[1].dependencies.is_empty());
     }
 }


### PR DESCRIPTION
DynamicTasks are treated as sequential implicitly rather than trusting the configuration to explicitly define dependence. Their onreply tasks also are tried to execute on response.. but then will enforce sequential ordering if requeued.

Once we migrate from legacy config we can remove the dependencies field entirely and have it explicitly defined.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved action dependency handling in the pipeline compilation process for better execution flow and consistency between different action types.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->