### PR TITLE
Update example versions

### DIFF
--- a/examples/ratelimit/docker-compose.yaml
+++ b/examples/ratelimit/docker-compose.yaml
@@ -29,7 +29,7 @@ services:
       - ./envoy.yaml:/etc/envoy.yaml
       - ../../target/wasm32-wasip1/debug/wasm_shim.wasm:/opt/kuadrant/wasm/wasm_shim.wasm
   limitador:
-    image: ${LIMITADOR_IMAGE:-quay.io/kuadrant/limitador:v2.2.0}
+    image: ${LIMITADOR_IMAGE:-quay.io/kuadrant/limitador:latest}
     container_name: limitador
     command:
       - --rls-ip

--- a/examples/ratelimit_check_report/docker-compose.yaml
+++ b/examples/ratelimit_check_report/docker-compose.yaml
@@ -30,7 +30,7 @@ services:
       - ./envoy.yaml:/etc/envoy.yaml
       - ../../target/wasm32-wasip1/debug/wasm_shim.wasm:/opt/kuadrant/wasm/wasm_shim.wasm
   limitador:
-    image: ${LIMITADOR_IMAGE:-quay.io/kuadrant/limitador:v2.2.0}
+    image: ${LIMITADOR_IMAGE:-quay.io/kuadrant/limitador:latest}
     container_name: limitador
     command:
       - --rls-ip


### PR DESCRIPTION
Examples image version has drifted and no longer working

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Docker Compose examples for rate-limiting services to support flexible Limitador image versioning. Service configurations now accept custom image references via environment variable configuration, with the latest tag as default fallback. This replaces the previously pinned version approach, enabling easier updates and version management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->