### PR TITLE
More precisely trigger tests on release branches

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -3,7 +3,7 @@ name: Tests
 
 on:
   push:
-    branches: ["main", "release-*"]
+    branches: ["main", "release-[0-9]+.[0-9]+"]
   pull_request:
     branches: ["*"]
   merge_group:


### PR DESCRIPTION
Follows on from #348.

I spotted in our latest release PR that we run the tests twice https://github.com/Kuadrant/wasm-shim/pull/381

One comes from the `pull_request` trigger and a second from the `push` to `release-0.14.1`. I'm restricting this to run the tests on pushes to the main branch or a specific release branch rather than the wildcard prior

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the test workflow trigger so it now runs on `main` and on more specific release branches matching a version-style pattern.
  * This reduces unnecessary test runs on unrelated branches while keeping release validation in place.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->