### PR TITLE
Backport patch-safe fixes for v0.14.2

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -3,7 +3,7 @@ name: Tests
 
 on:
   push:
-    branches: ["main", "release-*"]
+    branches: ["main", "release-[0-9]+.[0-9]+"]
   pull_request:
     branches: ["*"]
   merge_group:


### PR DESCRIPTION
## Summary

Cherry-picked 1 patch-safe fix from main for a v0.14.2 release.

- `c4b0c24` — CI: tighten release branch trigger pattern to `release-[0-9]+.[0-9]+`

**Excluded:**
- `5af2c73` (proxy-wasm SDK update) — already on the release branch
- `9857fa6` (remove implicit sequential dependency from typed actions) — behavioral change, not patch-safe

## Test plan
- [x] `cargo check` passes
- [ ] CI passes on this PR