### PR TITLE
refactor(thread-safety): all Rc are now Arc to run in tokio

### DIFF
--- a/crates/kuadrant-filter/src/filter/descriptor_manager.rs
+++ b/crates/kuadrant-filter/src/filter/descriptor_manager.rs
@@ -5,11 +5,10 @@ use crate::proto::kuadrant::v1::{
 use prost::Message;
 use prost_reflect::DescriptorPool;
 use prost_types::FileDescriptorSet;
-use std::cell::RefCell;
 use std::collections::hash_map::DefaultHasher;
 use std::collections::HashMap;
 use std::hash::{Hash, Hasher};
-use std::rc::Rc;
+use std::sync::{Arc, Mutex};
 use std::time::Duration;
 use tracing::{debug, error};
 
@@ -62,10 +61,10 @@ enum DescriptorState {
 }
 
 pub struct DescriptorManager {
-    pools: RefCell<HashMap<u64, Rc<DescriptorPool>>>,
-    embedded: RefCell<HashMap<String, u64>>,
-    descriptors: RefCell<HashMap<DescriptorKey, DescriptorState>>,
-    descriptor_service: RefCell<Option<String>>,
+    pools: Mutex<HashMap<u64, Arc<DescriptorPool>>>,
+    embedded: Mutex<HashMap<String, u64>>,
+    descriptors: Mutex<HashMap<DescriptorKey, DescriptorState>>,
+    descriptor_service: Mutex<Option<String>>,
 }
 
 impl Default for DescriptorManager {
@@ -110,7 +109,10 @@ impl Default for DescriptorManager {
 
 impl DescriptorManager {
     pub fn set_descriptor_service(&self, service: &str) {
-        let mut current = self.descriptor_service.borrow_mut();
+        let mut current = self
+            .descriptor_service
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
         if current.as_ref().is_none_or(|s| s != service) {
             *current = Some(service.to_string());
         }
@@ -119,20 +121,23 @@ impl DescriptorManager {
     pub fn add_expected(&self, key: DescriptorKey) {
         let initial_state = self
             .embedded
-            .borrow()
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
             .get(&key.service)
             .map(|&hash| DescriptorState::Embedded(hash))
             .unwrap_or(DescriptorState::Missing);
 
         self.descriptors
-            .borrow_mut()
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
             .entry(key)
             .or_insert(initial_state);
     }
 
     pub fn has_expected(&self) -> bool {
         self.descriptors
-            .borrow()
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
             .values()
             .any(|state| !matches!(state, DescriptorState::Embedded(_)))
     }
@@ -145,16 +150,20 @@ impl DescriptorManager {
         &self,
         cluster: &str,
         service: &str,
-    ) -> Result<Rc<DescriptorPool>, DescriptorError> {
+    ) -> Result<Arc<DescriptorPool>, DescriptorError> {
         let key = DescriptorKey::new(cluster.to_string(), service.to_string());
 
         self.descriptors
-            .borrow()
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
             .get(&key)
             .and_then(|state| match state {
-                DescriptorState::Embedded(hash) | DescriptorState::Resolved(hash) => {
-                    self.pools.borrow().get(hash).map(Rc::clone)
-                }
+                DescriptorState::Embedded(hash) | DescriptorState::Resolved(hash) => self
+                    .pools
+                    .lock()
+                    .unwrap_or_else(|e| e.into_inner())
+                    .get(hash)
+                    .map(Arc::clone),
                 _ => None,
             })
             .ok_or_else(|| DescriptorError::NotAvailable {
@@ -167,26 +176,37 @@ impl DescriptorManager {
         let content_hash = hash_bytes(fds_bytes);
 
         self.pools
-            .borrow_mut()
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
             .entry(content_hash)
-            .or_insert_with(|| Rc::new(pool.clone()));
+            .or_insert_with(|| Arc::new(pool.clone()));
 
-        self.embedded.borrow_mut().insert(service, content_hash);
+        self.embedded
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .insert(service, content_hash);
     }
 
     pub fn insert_pool(&self, key: DescriptorKey, pool: DescriptorPool) {
         let mut hasher = DefaultHasher::new();
         key.hash(&mut hasher);
         let hash = hasher.finish();
-        self.pools.borrow_mut().insert(hash, Rc::new(pool));
+        self.pools
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .insert(hash, Arc::new(pool));
         self.descriptors
-            .borrow_mut()
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
             .insert(key, DescriptorState::Resolved(hash));
     }
 
     fn insert_pool_from_bytes(&self, key: DescriptorKey, fds_bytes: &[u8], pool: DescriptorPool) {
         if matches!(
-            self.descriptors.borrow().get(&key),
+            self.descriptors
+                .lock()
+                .unwrap_or_else(|e| e.into_inner())
+                .get(&key),
             Some(DescriptorState::Embedded(_))
         ) {
             return;
@@ -195,18 +215,21 @@ impl DescriptorManager {
         let content_hash = hash_bytes(fds_bytes);
 
         self.pools
-            .borrow_mut()
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
             .entry(content_hash)
-            .or_insert_with(|| Rc::new(pool));
+            .or_insert_with(|| Arc::new(pool));
 
         self.descriptors
-            .borrow_mut()
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
             .insert(key, DescriptorState::Resolved(content_hash));
     }
 
     fn get_missing(&self) -> Vec<DescriptorKey> {
         self.descriptors
-            .borrow()
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
             .iter()
             .filter_map(|(key, state)| {
                 if matches!(state, DescriptorState::Missing) {
@@ -227,7 +250,8 @@ impl DescriptorManager {
 
         let descriptor_service = self
             .descriptor_service
-            .borrow()
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
             .as_ref()
             .ok_or("descriptor service not configured")?
             .clone();
@@ -270,7 +294,7 @@ impl DescriptorManager {
             token
         );
 
-        let mut descriptors = self.descriptors.borrow_mut();
+        let mut descriptors = self.descriptors.lock().unwrap_or_else(|e| e.into_inner());
         for key in missing {
             descriptors.insert(key, DescriptorState::Pending(token));
         }
@@ -280,7 +304,8 @@ impl DescriptorManager {
 
     pub fn reset_pending(&self, token_id: u32) {
         self.descriptors
-            .borrow_mut()
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
             .iter_mut()
             .for_each(|(_, state)| {
                 if matches!(state, DescriptorState::Pending(t) if *t == token_id) {
@@ -292,7 +317,8 @@ impl DescriptorManager {
     pub fn handle_response(&self, token_id: u32, response_bytes: Vec<u8>) -> Result<(), String> {
         let has_pending = self
             .descriptors
-            .borrow()
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
             .values()
             .any(|state| matches!(state, DescriptorState::Pending(t) if *t == token_id));
 
@@ -478,7 +504,11 @@ mod tests {
     #[test]
     fn test_deduplication_same_descriptor_bytes() {
         let manager = DescriptorManager::default();
-        let initial_pool_count = manager.pools.borrow().len();
+        let initial_pool_count = manager
+            .pools
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .len();
 
         let file_descriptor = FileDescriptorProto {
             name: Some("test.proto".to_string()),
@@ -519,9 +549,16 @@ mod tests {
         let result1 = manager.get_pool("cluster-a", "test.TestService").unwrap();
         let result2 = manager.get_pool("cluster-b", "test.TestService").unwrap();
 
-        assert!(Rc::ptr_eq(&result1, &result2));
+        assert!(Arc::ptr_eq(&result1, &result2));
 
-        assert_eq!(manager.pools.borrow().len(), initial_pool_count + 1);
+        assert_eq!(
+            manager
+                .pools
+                .lock()
+                .unwrap_or_else(|e| e.into_inner())
+                .len(),
+            initial_pool_count + 1
+        );
     }
 
     #[test]
@@ -591,7 +628,11 @@ mod tests {
         manager.add_expected(key.clone());
 
         assert!(matches!(
-            manager.descriptors.borrow().get(&key),
+            manager
+                .descriptors
+                .lock()
+                .unwrap_or_else(|e| e.into_inner())
+                .get(&key),
             Some(DescriptorState::Embedded(_))
         ),);
 
@@ -639,7 +680,7 @@ mod tests {
         let result_a = manager.get_pool("cluster-a", "test.TestService").unwrap();
         let result_b = manager.get_pool("cluster-b", "test.TestService").unwrap();
 
-        assert!(Rc::ptr_eq(&result_a, &result_b));
+        assert!(Arc::ptr_eq(&result_a, &result_b));
         assert_eq!(
             result_a.services().next().unwrap().parent_file().name(),
             "embedded.proto"
@@ -649,7 +690,11 @@ mod tests {
     #[test]
     fn test_embedded_entries_share_pool_across_clusters() {
         let manager = DescriptorManager::default();
-        let initial_pool_count = manager.pools.borrow().len();
+        let initial_pool_count = manager
+            .pools
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .len();
 
         let file_descriptor = FileDescriptorProto {
             name: Some("test.proto".to_string()),
@@ -683,8 +728,15 @@ mod tests {
         let result_a = manager.get_pool("cluster-a", "test.TestService").unwrap();
         let result_b = manager.get_pool("cluster-b", "test.TestService").unwrap();
 
-        assert!(Rc::ptr_eq(&result_a, &result_b));
-        assert_eq!(manager.pools.borrow().len(), initial_pool_count + 1);
+        assert!(Arc::ptr_eq(&result_a, &result_b));
+        assert_eq!(
+            manager
+                .pools
+                .lock()
+                .unwrap_or_else(|e| e.into_inner())
+                .len(),
+            initial_pool_count + 1
+        );
     }
 
     #[test]
@@ -698,7 +750,11 @@ mod tests {
         manager.add_expected(key.clone());
 
         assert!(matches!(
-            manager.descriptors.borrow().get(&key),
+            manager
+                .descriptors
+                .lock()
+                .unwrap_or_else(|e| e.into_inner())
+                .get(&key),
             Some(DescriptorState::Embedded(_))
         ));
         assert!(!manager.has_expected());
@@ -710,7 +766,7 @@ mod tests {
                 "envoy.service.ratelimit.v3.RateLimitService",
             )
             .expect("Should have embedded rate limit pool");
-        assert!(Rc::strong_count(&pool) >= 1);
+        assert!(Arc::strong_count(&pool) >= 1);
     }
 
     #[test]
@@ -721,7 +777,11 @@ mod tests {
         manager.add_expected(key.clone());
 
         assert!(matches!(
-            manager.descriptors.borrow().get(&key),
+            manager
+                .descriptors
+                .lock()
+                .unwrap_or_else(|e| e.into_inner())
+                .get(&key),
             Some(DescriptorState::Missing)
         ));
         assert!(manager.has_expected());

--- a/crates/kuadrant-filter/src/kuadrant/context.rs
+++ b/crates/kuadrant-filter/src/kuadrant/context.rs
@@ -1,9 +1,8 @@
 use cel::{Context, Env, Value};
-use std::cell::{OnceCell, RefCell};
+use std::cell::OnceCell;
 use std::collections::hash_map::Entry;
 use std::collections::{BTreeMap, HashMap, HashSet};
-use std::rc::Rc;
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 use tracing::{debug, error, warn};
 
 use crate::data::attribute::{wasm_prop, AttributeError, AttributeState, AttributeValue, Path};
@@ -548,22 +547,26 @@ fn is_ancestor(scope_id: &str, task_id: &str) -> bool {
 
 pub struct PathReservation {
     path: String,
-    registry: Rc<RefCell<HashMap<String, usize>>>,
+    registry: Arc<Mutex<HashMap<String, usize>>>,
 }
 
 impl PathReservation {
-    fn new(path: String, registry: &Rc<RefCell<HashMap<String, usize>>>) -> Self {
-        *registry.borrow_mut().entry(path.clone()).or_insert(0) += 1;
+    fn new(path: String, registry: &Arc<Mutex<HashMap<String, usize>>>) -> Self {
+        *registry
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .entry(path.clone())
+            .or_insert(0) += 1;
         Self {
             path,
-            registry: Rc::clone(registry),
+            registry: Arc::clone(registry),
         }
     }
 }
 
 impl Drop for PathReservation {
     fn drop(&mut self) {
-        let mut map = self.registry.borrow_mut();
+        let mut map = self.registry.lock().unwrap_or_else(|e| e.into_inner());
         match map.entry(self.path.clone()) {
             Entry::Occupied(mut entry) => {
                 *entry.get_mut() -= 1;
@@ -584,7 +587,7 @@ impl Drop for PathReservation {
 #[derive(Default)]
 pub struct ValueStore {
     values: BTreeMap<String, Value>,
-    reserved: Rc<RefCell<HashMap<String, usize>>>,
+    reserved: Arc<Mutex<HashMap<String, usize>>>,
 }
 
 impl ValueStore {
@@ -593,7 +596,12 @@ impl ValueStore {
     }
 
     pub fn is_pending(&self, path: &str) -> bool {
-        !self.values.contains_key(path) && self.reserved.borrow().contains_key(path)
+        !self.values.contains_key(path)
+            && self
+                .reserved
+                .lock()
+                .unwrap_or_else(|e| e.into_inner())
+                .contains_key(path)
     }
 
     pub fn has_prefix(&self, prefix: &str) -> bool {
@@ -601,7 +609,12 @@ impl ValueStore {
             .range::<String, _>(prefix.to_string()..)
             .next()
             .is_some_and(|(k, _)| k.starts_with(prefix))
-            || self.reserved.borrow().keys().any(|p| p.starts_with(prefix))
+            || self
+                .reserved
+                .lock()
+                .unwrap_or_else(|e| e.into_inner())
+                .keys()
+                .any(|p| p.starts_with(prefix))
     }
 
     pub fn store(&mut self, path: String, value: Value) {

--- a/crates/kuadrant-filter/src/kuadrant/pipeline/blueprint.rs
+++ b/crates/kuadrant-filter/src/kuadrant/pipeline/blueprint.rs
@@ -13,7 +13,7 @@ use crate::services::ServiceInstance;
 use cel::ParseErrors;
 use std::collections::HashMap;
 use std::fmt::Display;
-use std::rc::Rc;
+use std::sync::Arc;
 
 pub type RequestData = ((String, String), Expression);
 
@@ -84,7 +84,7 @@ impl Action {
                         Some(Box::new(DynamicTask::new_with_attributes(
                             ctx,
                             self.id.clone(),
-                            Rc::clone(dynamic_service),
+                            Arc::clone(dynamic_service),
                             var.clone(),
                             message_builder.clone(),
                             children,
@@ -350,7 +350,7 @@ impl Blueprint {
                         }
                         if let Some(service) = tracing_service {
                             teardown_tasks
-                                .push(Box::new(ExportTracesTask::new(ctx, service.clone())));
+                                .push(Box::new(ExportTracesTask::new(ctx, Arc::clone(service))));
                         }
                     }
                     ServiceInstance::Dynamic(_)
@@ -541,13 +541,13 @@ mod tests {
     use crate::filter::DescriptorManager;
     use crate::services::{DynamicService, ServiceInstance};
     use std::collections::HashMap;
-    use std::rc::Rc;
+    use std::sync::Arc;
 
     fn build_test_service(name: &str) -> (String, ServiceInstance) {
-        let descriptor_manager = Rc::new(DescriptorManager::default());
+        let descriptor_manager = Arc::new(DescriptorManager::default());
         (
             name.to_string(),
-            ServiceInstance::Auth(Rc::new(DynamicService::new(
+            ServiceInstance::Auth(Arc::new(DynamicService::new(
                 "test-cluster".to_string(),
                 "envoy.service.auth.v3.Authorization".to_string(),
                 "Check".to_string(),
@@ -559,10 +559,10 @@ mod tests {
     }
 
     fn build_dynamic_service(name: &str) -> (String, ServiceInstance) {
-        let descriptor_manager = Rc::new(DescriptorManager::default());
+        let descriptor_manager = Arc::new(DescriptorManager::default());
         (
             name.to_string(),
-            ServiceInstance::Dynamic(Rc::new(DynamicService::new(
+            ServiceInstance::Dynamic(Arc::new(DynamicService::new(
                 "test-cluster".to_string(),
                 "test.Service".to_string(),
                 "TestMethod".to_string(),
@@ -858,7 +858,7 @@ mod tests {
         use crate::services::TracingService;
         let services = HashMap::from([(
             "tracing-svc".to_string(),
-            ServiceInstance::Tracing(Some(Rc::new(TracingService::new(
+            ServiceInstance::Tracing(Some(Arc::new(TracingService::new(
                 "test-cluster".to_string(),
                 std::time::Duration::from_secs(10),
             )))),

--- a/crates/kuadrant-filter/src/kuadrant/pipeline/factory.rs
+++ b/crates/kuadrant-filter/src/kuadrant/pipeline/factory.rs
@@ -13,16 +13,15 @@ use crate::services::ServiceInstance;
 use radix_trie::Trie;
 use std::collections::HashMap;
 use std::fmt::Display;
-use std::rc::Rc;
 use std::sync::Arc;
 use tracing::debug;
 
 type RequestData = ((String, String), Expression);
 
 pub struct PipelineFactory {
-    index: Trie<String, Vec<Rc<Blueprint>>>,
+    index: Trie<String, Vec<Arc<Blueprint>>>,
     request_data: Arc<Vec<RequestData>>,
-    fallback_blueprint: Option<Rc<Blueprint>>,
+    fallback_blueprint: Option<Arc<Blueprint>>,
 }
 
 #[derive(Debug)]
@@ -53,7 +52,7 @@ impl Default for PipelineFactory {
 impl PipelineFactory {
     pub fn try_from(
         mut config: PluginConfiguration,
-        descriptor_manager: &Rc<DescriptorManager>,
+        descriptor_manager: &Arc<DescriptorManager>,
     ) -> Result<Self, CompileError> {
         let services: HashMap<String, ServiceInstance> = config
             .services
@@ -117,13 +116,13 @@ impl PipelineFactory {
                 blueprint.actions.push(dev_mode.clone());
             }
 
-            let blueprint = Rc::new(blueprint);
+            let blueprint = Arc::new(blueprint);
             for hostname in &config_action_set.route_rule_conditions.hostnames {
                 let key = reverse_subdomain(hostname);
                 index.map_with_default(
                     key,
-                    |blueprints| blueprints.push(Rc::clone(&blueprint)),
-                    vec![Rc::clone(&blueprint)],
+                    |blueprints| blueprints.push(Arc::clone(&blueprint)),
+                    vec![Arc::clone(&blueprint)],
                 );
             }
         }
@@ -172,7 +171,7 @@ impl PipelineFactory {
         ))
     }
 
-    fn select_blueprint(&self, ctx: &mut ReqRespCtx) -> Result<Option<Rc<Blueprint>>, BuildError> {
+    fn select_blueprint(&self, ctx: &mut ReqRespCtx) -> Result<Option<Arc<Blueprint>>, BuildError> {
         let hostname = self.get_hostname(ctx)?;
         ctx.set_hostname(hostname.clone());
 
@@ -190,7 +189,7 @@ impl PipelineFactory {
                     "Selected blueprint {} for hostname: {}",
                     blueprint.name, hostname
                 );
-                return Ok(Some(Rc::clone(blueprint)));
+                return Ok(Some(Arc::clone(blueprint)));
             }
         }
 
@@ -339,7 +338,7 @@ mod tests {
     fn factory_creates_from_valid_config() {
         let config = build_test_config(vec!["example.com".to_string()], vec![], "test-service");
 
-        let result = PipelineFactory::try_from(config, &Rc::new(DescriptorManager::default()));
+        let result = PipelineFactory::try_from(config, &Arc::new(DescriptorManager::default()));
         assert!(result.is_ok());
     }
 
@@ -370,7 +369,7 @@ mod tests {
             }],
         );
 
-        let result = PipelineFactory::try_from(config, &Rc::new(DescriptorManager::default()));
+        let result = PipelineFactory::try_from(config, &Arc::new(DescriptorManager::default()));
         assert!(result.is_err());
     }
 
@@ -378,7 +377,7 @@ mod tests {
     fn build_returns_none_when_hostname_does_not_match() {
         let config = build_test_config(vec!["example.com".to_string()], vec![], "test-service");
         let factory =
-            PipelineFactory::try_from(config, &Rc::new(DescriptorManager::default())).unwrap();
+            PipelineFactory::try_from(config, &Arc::new(DescriptorManager::default())).unwrap();
 
         let mock_host = MockWasmHost::new()
             .with_property("request.host".into(), "other.com".as_bytes().to_vec());
@@ -393,7 +392,7 @@ mod tests {
     fn build_returns_pipeline_when_hostname_matches_exact() {
         let config = build_test_config(vec!["example.com".to_string()], vec![], "test-service");
         let factory =
-            PipelineFactory::try_from(config, &Rc::new(DescriptorManager::default())).unwrap();
+            PipelineFactory::try_from(config, &Arc::new(DescriptorManager::default())).unwrap();
 
         let mock_host = MockWasmHost::new()
             .with_property("request.host".into(), "example.com".as_bytes().to_vec());
@@ -408,7 +407,7 @@ mod tests {
     fn build_returns_pipeline_when_hostname_matches_wildcard() {
         let config = build_test_config(vec!["*.example.com".to_string()], vec![], "test-service");
         let factory =
-            PipelineFactory::try_from(config, &Rc::new(DescriptorManager::default())).unwrap();
+            PipelineFactory::try_from(config, &Arc::new(DescriptorManager::default())).unwrap();
 
         let mock_host = MockWasmHost::new()
             .with_property("request.host".into(), "api.example.com".as_bytes().to_vec());
@@ -423,7 +422,7 @@ mod tests {
     fn build_returns_none_when_wildcard_does_not_match_base_domain() {
         let config = build_test_config(vec!["*.example.com".to_string()], vec![], "test-service");
         let factory =
-            PipelineFactory::try_from(config, &Rc::new(DescriptorManager::default())).unwrap();
+            PipelineFactory::try_from(config, &Arc::new(DescriptorManager::default())).unwrap();
 
         let mock_host = MockWasmHost::new()
             .with_property("request.host".into(), "example.com".as_bytes().to_vec());
@@ -442,7 +441,7 @@ mod tests {
             "test-service",
         );
         let factory =
-            PipelineFactory::try_from(config, &Rc::new(DescriptorManager::default())).unwrap();
+            PipelineFactory::try_from(config, &Arc::new(DescriptorManager::default())).unwrap();
 
         let mock_host = MockWasmHost::new()
             .with_property("request.host".into(), "example.com".as_bytes().to_vec())
@@ -462,7 +461,7 @@ mod tests {
             "test-service",
         );
         let factory =
-            PipelineFactory::try_from(config, &Rc::new(DescriptorManager::default())).unwrap();
+            PipelineFactory::try_from(config, &Arc::new(DescriptorManager::default())).unwrap();
 
         let mock_host = MockWasmHost::new()
             .with_property("request.host".into(), "example.com".as_bytes().to_vec())
@@ -482,7 +481,7 @@ mod tests {
             "test-service",
         );
         let factory =
-            PipelineFactory::try_from(config, &Rc::new(DescriptorManager::default())).unwrap();
+            PipelineFactory::try_from(config, &Arc::new(DescriptorManager::default())).unwrap();
 
         let mock_host = MockWasmHost::new()
             .with_property("request.host".into(), "example.com".as_bytes().to_vec());
@@ -503,7 +502,7 @@ mod tests {
             "test-service",
         );
         let factory =
-            PipelineFactory::try_from(config, &Rc::new(DescriptorManager::default())).unwrap();
+            PipelineFactory::try_from(config, &Arc::new(DescriptorManager::default())).unwrap();
 
         let mock_host = MockWasmHost::new()
             .with_property("request.host".into(), "example.com".as_bytes().to_vec());
@@ -522,7 +521,7 @@ mod tests {
             "test-service",
         );
         let factory =
-            PipelineFactory::try_from(config, &Rc::new(DescriptorManager::default())).unwrap();
+            PipelineFactory::try_from(config, &Arc::new(DescriptorManager::default())).unwrap();
 
         let mock_host = MockWasmHost::new()
             .with_property("request.host".into(), "example.com".as_bytes().to_vec())
@@ -544,7 +543,7 @@ mod tests {
             "test-service",
         );
         let factory =
-            PipelineFactory::try_from(config, &Rc::new(DescriptorManager::default())).unwrap();
+            PipelineFactory::try_from(config, &Arc::new(DescriptorManager::default())).unwrap();
 
         let mock_host = MockWasmHost::new()
             .with_property("request.host".into(), "example.com".as_bytes().to_vec())
@@ -568,7 +567,7 @@ mod tests {
             "test-service",
         );
         let factory =
-            PipelineFactory::try_from(config, &Rc::new(DescriptorManager::default())).unwrap();
+            PipelineFactory::try_from(config, &Arc::new(DescriptorManager::default())).unwrap();
 
         let mock_host = MockWasmHost::new()
             .with_property("request.host".into(), "example.com".as_bytes().to_vec())
@@ -608,7 +607,7 @@ mod tests {
         };
 
         let factory =
-            PipelineFactory::try_from(config, &Rc::new(DescriptorManager::default())).unwrap();
+            PipelineFactory::try_from(config, &Arc::new(DescriptorManager::default())).unwrap();
         assert_eq!(factory.request_data.len(), 1);
     }
 
@@ -620,7 +619,7 @@ mod tests {
             "test-service",
         );
         let factory =
-            PipelineFactory::try_from(config, &Rc::new(DescriptorManager::default())).unwrap();
+            PipelineFactory::try_from(config, &Arc::new(DescriptorManager::default())).unwrap();
 
         // Test exact match
         let mock_host1 = MockWasmHost::new()

--- a/crates/kuadrant-filter/src/kuadrant/pipeline/tasks/dynamic.rs
+++ b/crates/kuadrant-filter/src/kuadrant/pipeline/tasks/dynamic.rs
@@ -1,4 +1,4 @@
-use std::rc::Rc;
+use std::sync::Arc;
 
 use tracing::{debug, error};
 
@@ -12,7 +12,7 @@ use crate::services::{DescriptorConverter, DynamicService};
 
 pub struct DynamicTask {
     task_id: String,
-    service: Rc<DynamicService>,
+    service: Arc<DynamicService>,
     var: String,
     message_builder: Expression,
     on_reply: Vec<Box<dyn Task>>,
@@ -26,7 +26,7 @@ impl DynamicTask {
     pub fn new_with_attributes(
         ctx: &mut ReqRespCtx,
         task_id: String,
-        service: Rc<DynamicService>,
+        service: Arc<DynamicService>,
         var: String,
         message_builder: Expression,
         on_reply: Vec<Box<dyn Task>>,

--- a/crates/kuadrant-filter/src/kuadrant/pipeline/tasks/export_traces.rs
+++ b/crates/kuadrant-filter/src/kuadrant/pipeline/tasks/export_traces.rs
@@ -1,15 +1,15 @@
 use crate::kuadrant::pipeline::tasks::{TeardownAction, TeardownOutcome};
 use crate::kuadrant::ReqRespCtx;
 use crate::services::TracingService;
-use std::rc::Rc;
+use std::sync::Arc;
 use tracing::{debug, warn};
 
 pub struct ExportTracesTask {
-    service: Rc<TracingService>,
+    service: Arc<TracingService>,
 }
 
 impl ExportTracesTask {
-    pub fn new(ctx: &mut ReqRespCtx, service: Rc<TracingService>) -> Self {
+    pub fn new(ctx: &mut ReqRespCtx, service: Arc<TracingService>) -> Self {
         ctx.enter_request_span();
         Self { service }
     }

--- a/crates/kuadrant-filter/src/kuadrant/pipeline/tasks/store/json_body_parser.rs
+++ b/crates/kuadrant-filter/src/kuadrant/pipeline/tasks/store/json_body_parser.rs
@@ -1,7 +1,6 @@
-use std::cell::RefCell;
 use std::collections::HashMap;
 use std::collections::HashSet;
-use std::rc::Rc;
+use std::sync::{Arc, Mutex};
 
 use cel::Value;
 use tracing::error;
@@ -13,8 +12,8 @@ use crate::kuadrant::context::BodyContext;
 pub(crate) struct JsonBodyParser {
     fields: Vec<String>,
     parser: Option<acutejson::Parser>,
-    buffers: Rc<RefCell<HashMap<String, Vec<u8>>>>,
-    matched: Rc<RefCell<HashSet<String>>>,
+    buffers: Arc<Mutex<HashMap<String, Vec<u8>>>>,
+    matched: Arc<Mutex<HashSet<String>>>,
     extracted: HashMap<String, Value>,
     bytes_consumed: usize,
     complete: bool,
@@ -22,22 +21,26 @@ pub(crate) struct JsonBodyParser {
 
 impl JsonBodyParser {
     pub fn new(fields: Vec<String>) -> Result<Self, AttributeError> {
-        let buffers: Rc<RefCell<HashMap<String, Vec<u8>>>> = Rc::new(RefCell::new(HashMap::new()));
-        let matched: Rc<RefCell<HashSet<String>>> = Rc::new(RefCell::new(HashSet::new()));
-        let results: Rc<RefCell<HashMap<String, Vec<u8>>>> = Rc::clone(&buffers);
+        let buffers: Arc<Mutex<HashMap<String, Vec<u8>>>> = Arc::new(Mutex::new(HashMap::new()));
+        let matched: Arc<Mutex<HashSet<String>>> = Arc::new(Mutex::new(HashSet::new()));
+        let results: Arc<Mutex<HashMap<String, Vec<u8>>>> = Arc::clone(&buffers);
 
         let mut builder = acutejson::Builder::new();
         for field in &fields {
             let field_name = field.clone();
-            let field_buffers = Rc::clone(&results);
-            let field_matched = Rc::clone(&matched);
+            let field_buffers = Arc::clone(&results);
+            let field_matched = Arc::clone(&matched);
             field_buffers
-                .borrow_mut()
+                .lock()
+                .unwrap_or_else(|e| e.into_inner())
                 .insert(field_name.clone(), Vec::new());
 
             builder = match builder.register(field, move |bytes, _is_complete| {
-                field_matched.borrow_mut().insert(field_name.clone());
-                let mut bufs = field_buffers.borrow_mut();
+                field_matched
+                    .lock()
+                    .unwrap_or_else(|e| e.into_inner())
+                    .insert(field_name.clone());
+                let mut bufs = field_buffers.lock().unwrap_or_else(|e| e.into_inner());
                 if let Some(buf) = bufs.get_mut(&field_name) {
                     buf.extend_from_slice(bytes);
                 } else {
@@ -66,8 +69,8 @@ impl JsonBodyParser {
     }
 
     fn finalize_extracted(&mut self) -> Result<(), AttributeError> {
-        let buffers = self.buffers.borrow();
-        let matched = self.matched.borrow();
+        let buffers = self.buffers.lock().unwrap_or_else(|e| e.into_inner());
+        let matched = self.matched.lock().unwrap_or_else(|e| e.into_inner());
         for (field, raw_bytes) in buffers.iter() {
             if matched.contains(field) {
                 let raw_value = std::str::from_utf8(raw_bytes).map_err(|e| {

--- a/crates/kuadrant-filter/src/services/dynamic.rs
+++ b/crates/kuadrant-filter/src/services/dynamic.rs
@@ -1,4 +1,4 @@
-use std::rc::Rc;
+use std::sync::Arc;
 use std::time::Duration;
 
 use cel::Value;
@@ -21,7 +21,7 @@ pub struct DynamicService {
     method: String,
     timeout: Duration,
     failure_mode: FailureMode,
-    descriptor_manager: Rc<DescriptorManager>,
+    descriptor_manager: Arc<DescriptorManager>,
 }
 
 impl DynamicService {
@@ -31,7 +31,7 @@ impl DynamicService {
         grpc_method: String,
         timeout: Duration,
         failure_mode: FailureMode,
-        descriptor_manager: Rc<DescriptorManager>,
+        descriptor_manager: Arc<DescriptorManager>,
     ) -> Self {
         descriptor_manager.add_expected(DescriptorKey::new(endpoint.clone(), grpc_service.clone()));
 
@@ -180,7 +180,7 @@ mod tests {
         FileDescriptorSet, MethodDescriptorProto, ServiceDescriptorProto,
     };
 
-    fn create_test_descriptor_manager() -> Rc<DescriptorManager> {
+    fn create_test_descriptor_manager() -> Arc<DescriptorManager> {
         let file_descriptor = FileDescriptorProto {
             name: Some("test.proto".to_string()),
             package: Some("test".to_string()),
@@ -226,7 +226,7 @@ mod tests {
         let pool = DescriptorPool::from_file_descriptor_set(fds)
             .expect("Failed to create descriptor pool");
 
-        let manager = Rc::new(DescriptorManager::default());
+        let manager = Arc::new(DescriptorManager::default());
         let key = DescriptorKey::new("test-cluster".to_string(), "test.TestService".to_string());
         manager.insert_pool(key, pool);
 

--- a/crates/kuadrant-filter/src/services/mod.rs
+++ b/crates/kuadrant-filter/src/services/mod.rs
@@ -1,7 +1,7 @@
 use crate::configuration::{FailureMode, Service as ServiceConfig, ServiceType};
 use crate::filter::DescriptorManager;
 use crate::kuadrant::ReqRespCtx;
-use std::{rc::Rc, time::Duration};
+use std::{sync::Arc, time::Duration};
 
 mod dynamic;
 mod tracing;
@@ -14,12 +14,12 @@ pub use tracing::TracingService;
 
 #[derive(Clone)]
 pub enum ServiceInstance {
-    Auth(Rc<DynamicService>),
-    RateLimit(Rc<DynamicService>),
-    RateLimitCheck(Rc<DynamicService>),
-    RateLimitReport(Rc<DynamicService>),
-    Tracing(Option<Rc<TracingService>>),
-    Dynamic(Rc<DynamicService>),
+    Auth(Arc<DynamicService>),
+    RateLimit(Arc<DynamicService>),
+    RateLimitCheck(Arc<DynamicService>),
+    RateLimitReport(Arc<DynamicService>),
+    Tracing(Option<Arc<TracingService>>),
+    Dynamic(Arc<DynamicService>),
 }
 
 impl ServiceInstance {
@@ -36,46 +36,48 @@ impl ServiceInstance {
 
     pub fn from_config(
         service: ServiceConfig,
-        descriptor_manager: &Rc<DescriptorManager>,
+        descriptor_manager: &Arc<DescriptorManager>,
     ) -> Result<Self, ServiceError> {
         match service.service_type {
-            ServiceType::Auth => Ok(ServiceInstance::Auth(Rc::new(DynamicService::new(
+            ServiceType::Auth => Ok(ServiceInstance::Auth(Arc::new(DynamicService::new(
                 service.endpoint,
                 "envoy.service.auth.v3.Authorization".to_string(),
                 "Check".to_string(),
                 service.timeout.0,
                 service.failure_mode,
-                Rc::clone(descriptor_manager),
+                Arc::clone(descriptor_manager),
             )))),
-            ServiceType::RateLimit => Ok(ServiceInstance::RateLimit(Rc::new(DynamicService::new(
-                service.endpoint,
-                "envoy.service.ratelimit.v3.RateLimitService".to_string(),
-                "ShouldRateLimit".to_string(),
-                service.timeout.0,
-                service.failure_mode,
-                Rc::clone(descriptor_manager),
-            )))),
-            ServiceType::RateLimitCheck => Ok(ServiceInstance::RateLimitCheck(Rc::new(
+            ServiceType::RateLimit => {
+                Ok(ServiceInstance::RateLimit(Arc::new(DynamicService::new(
+                    service.endpoint,
+                    "envoy.service.ratelimit.v3.RateLimitService".to_string(),
+                    "ShouldRateLimit".to_string(),
+                    service.timeout.0,
+                    service.failure_mode,
+                    Arc::clone(descriptor_manager),
+                ))))
+            }
+            ServiceType::RateLimitCheck => Ok(ServiceInstance::RateLimitCheck(Arc::new(
                 DynamicService::new(
                     service.endpoint,
                     "kuadrant.service.ratelimit.v1.RateLimitService".to_string(),
                     "CheckRateLimit".to_string(),
                     service.timeout.0,
                     service.failure_mode,
-                    Rc::clone(descriptor_manager),
+                    Arc::clone(descriptor_manager),
                 ),
             ))),
-            ServiceType::RateLimitReport => Ok(ServiceInstance::RateLimitReport(Rc::new(
+            ServiceType::RateLimitReport => Ok(ServiceInstance::RateLimitReport(Arc::new(
                 DynamicService::new(
                     service.endpoint,
                     "kuadrant.service.ratelimit.v1.RateLimitService".to_string(),
                     "Report".to_string(),
                     service.timeout.0,
                     service.failure_mode,
-                    Rc::clone(descriptor_manager),
+                    Arc::clone(descriptor_manager),
                 ),
             ))),
-            ServiceType::Tracing => Ok(ServiceInstance::Tracing(Some(Rc::new(
+            ServiceType::Tracing => Ok(ServiceInstance::Tracing(Some(Arc::new(
                 TracingService::new(service.endpoint, service.timeout.0),
             )))),
             ServiceType::Dynamic => {
@@ -86,13 +88,13 @@ impl ServiceInstance {
                     ServiceError::Dispatch("Missing grpc_method for Dynamic service".to_string())
                 })?;
 
-                Ok(ServiceInstance::Dynamic(Rc::new(DynamicService::new(
+                Ok(ServiceInstance::Dynamic(Arc::new(DynamicService::new(
                     service.endpoint,
                     grpc_service.clone(),
                     grpc_method.clone(),
                     service.timeout.0,
                     service.failure_mode,
-                    Rc::clone(descriptor_manager),
+                    Arc::clone(descriptor_manager),
                 ))))
             }
         }

--- a/crates/wasm-shim/src/filter/kuadrant_filter.rs
+++ b/crates/wasm-shim/src/filter/kuadrant_filter.rs
@@ -4,20 +4,19 @@ use proxy_wasm::hostcalls;
 use proxy_wasm::traits::{Context, HttpContext};
 use proxy_wasm::types::Action;
 use std::ops::Not;
-use std::rc::Rc;
 use std::sync::Arc;
 use tracing::{debug, error, trace, warn};
 
 pub struct KuadrantFilter {
     context_id: u32,
-    factory: Rc<PipelineFactory>,
+    factory: Arc<PipelineFactory>,
     pipeline: Option<Pipeline>,
     in_response_phase: bool,
     force_resume: bool,
 }
 
 impl KuadrantFilter {
-    pub fn new(context_id: u32, factory: Rc<PipelineFactory>) -> Self {
+    pub fn new(context_id: u32, factory: Arc<PipelineFactory>) -> Self {
         Self {
             context_id,
             factory,

--- a/crates/wasm-shim/src/filter/root_context.rs
+++ b/crates/wasm-shim/src/filter/root_context.rs
@@ -7,7 +7,7 @@ use kuadrant_filter::kuadrant::PipelineFactory;
 use kuadrant_filter::metrics::METRICS;
 use proxy_wasm::traits::{Context, HttpContext, RootContext};
 use proxy_wasm::types::ContextType;
-use std::rc::Rc;
+use std::sync::Arc;
 use std::time::Duration;
 use tracing::{debug, error, info};
 
@@ -15,8 +15,8 @@ const WASM_SHIM_HEADER: &str = "Kuadrant wasm module";
 
 pub struct FilterRoot {
     pub context_id: u32,
-    pub pipeline_factory: Rc<PipelineFactory>,
-    pub descriptor_manager: Rc<DescriptorManager>,
+    pub pipeline_factory: Arc<PipelineFactory>,
+    pub descriptor_manager: Arc<DescriptorManager>,
     tick_enabled: bool,
 }
 
@@ -24,8 +24,8 @@ impl FilterRoot {
     pub fn new(context_id: u32) -> Self {
         Self {
             context_id,
-            pipeline_factory: Rc::new(PipelineFactory::default()),
-            descriptor_manager: Rc::new(DescriptorManager::default()),
+            pipeline_factory: Arc::new(PipelineFactory::default()),
+            descriptor_manager: Arc::new(DescriptorManager::default()),
             tick_enabled: false,
         }
     }
@@ -57,7 +57,7 @@ impl FilterRoot {
             }
         };
 
-        self.pipeline_factory = Rc::new(factory);
+        self.pipeline_factory = Arc::new(factory);
         self.descriptor_manager
             .set_descriptor_service(&descriptor_service);
 
@@ -123,7 +123,7 @@ impl RootContext for FilterRoot {
         debug!("#{} create_http_context", context_id);
         Some(Box::new(KuadrantFilter::new(
             context_id,
-            Rc::clone(&self.pipeline_factory),
+            Arc::clone(&self.pipeline_factory),
         )))
     }
 
@@ -223,7 +223,7 @@ mod tests {
         .to_string();
 
         let config = serde_json::from_slice::<PluginConfiguration>(config_str.as_bytes()).unwrap();
-        let descriptor_manager = Rc::new(DescriptorManager::default());
+        let descriptor_manager = Arc::new(DescriptorManager::default());
         let result = PipelineFactory::try_from(config, &descriptor_manager);
         assert!(result.is_err());
     }
@@ -263,7 +263,7 @@ mod tests {
         let pool = DescriptorPool::from_file_descriptor_set(fds)
             .expect("Failed to create descriptor pool");
 
-        let descriptor_manager = Rc::new(DescriptorManager::default());
+        let descriptor_manager = Arc::new(DescriptorManager::default());
         descriptor_manager.insert_pool(
             DescriptorKey::new("test-cluster".to_string(), "test.TestService".to_string()),
             pool,
@@ -291,7 +291,7 @@ mod tests {
 
     #[test]
     fn test_factory_succeeds_without_descriptors() {
-        let descriptor_manager = Rc::new(DescriptorManager::default());
+        let descriptor_manager = Arc::new(DescriptorManager::default());
 
         let config_str = serde_json::json!({
             "services": {


### PR DESCRIPTION
Stack atop of #399 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Improved concurrent handling of shared descriptor, pipeline, service, reservation and parsing state.
  * Strengthened thread safety across filter processing and service execution.
  * Maintained existing descriptor fetching, JSON extraction, tracing and dynamic service behaviour.
* **Compatibility**
  * Updated public interfaces to support the improved shared-state handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->