### PR TITLE
Teardown no longer holds local tasks

### DIFF
--- a/crates/kuadrant-filter/src/kuadrant/pipeline/executor.rs
+++ b/crates/kuadrant-filter/src/kuadrant/pipeline/executor.rs
@@ -14,6 +14,11 @@ pub enum PipelineState {
     Completed { should_resume: bool },
 }
 
+enum ProcessOutcome {
+    Continue,
+    Terminated,
+}
+
 pub struct Pipeline {
     pub ctx: ReqRespCtx,
     task_queue: Vec<Box<dyn Task>>,
@@ -100,10 +105,8 @@ impl Pipeline {
         }
     }
 
-    pub fn eval(mut self) -> PipelineState {
-        let tasks_to_process: Vec<_> = self.task_queue.drain(..).collect();
-
-        for task in tasks_to_process {
+    fn process_tasks(&mut self, tasks: Vec<Box<dyn Task>>) -> ProcessOutcome {
+        for task in tasks {
             if task
                 .dependencies()
                 .iter()
@@ -134,10 +137,21 @@ impl Pipeline {
                     terminal_task.apply(&mut self.ctx);
                     self.task_queue.clear();
                     self.terminated = true;
-                    self.execute_teardown();
-                    return self.into();
+                    return ProcessOutcome::Terminated;
                 }
             }
+        }
+        ProcessOutcome::Continue
+    }
+
+    pub fn eval(mut self) -> PipelineState {
+        let tasks = self.task_queue.drain(..).collect();
+        match self.process_tasks(tasks) {
+            ProcessOutcome::Terminated => {
+                self.execute_teardown();
+                return self.into();
+            }
+            ProcessOutcome::Continue => {}
         }
 
         if self.task_queue.is_empty()


### PR DESCRIPTION
When we migrated `onReply` actions to become fully fledged tasks the reference to their spans are held in the local var `tasks_to_process`. This prevents these spans from being dropped and closed _prior_ to calling the `execute_teardown` which sends the traces causing the overarching `kuadrant_filter` span to be held open.

I've moved the processing to it's own function which is unchanged, but ensures the local ref to the current eval loop is no longer being held (in a different scope) when we process the teardown tasks