### PR TITLE
TokenUsageTask returns early if info is present

### DIFF
--- a/crates/kuadrant-filter/src/kuadrant/pipeline/tasks/token_usage.rs
+++ b/crates/kuadrant-filter/src/kuadrant/pipeline/tasks/token_usage.rs
@@ -44,6 +44,16 @@ impl Task for TokenUsageTask {
     fn apply(self: Box<Self>, ctx: &mut ReqRespCtx) -> TaskOutcome {
         let mut task: TokenUsageTask = self.into();
 
+        // Exit if fields already in context response body.
+        if task
+            .expected_response_fields
+            .iter()
+            .all(|field| ctx.response_body.get_value(field).is_some())
+        {
+            return TaskOutcome::Done;
+        }
+
+        // No stored field info found, proceed with response body extraction
         let mut strategy = match task.strategy.take() {
             Some(s) => s,
             None => {
@@ -219,7 +229,9 @@ mod tests {
         let mut ctx = ReqRespCtx::new(Arc::new(mock_backend));
         ctx.response_body.set_buffer_size(0, false);
 
-        let task = Box::new(TokenUsageTask::new());
+        let task = Box::new(TokenUsageTask::with_expected_response_fields(vec![
+            "/usage/total_tokens".to_string(),
+        ]));
 
         let outcome = task.apply(&mut ctx);
         assert!(matches!(outcome, TaskOutcome::Requeued(_)));


### PR DESCRIPTION
This PR introduces an early check for fields present in order to avoid doing the hard work. It's also useful when external proceses can inject these type of fields and the wasm-shim can be alleviated from doing the body parsing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Response processing now completes immediately when all expected response fields are already available.
  - Prevents unnecessary extraction and waiting for additional response data in these cases.

- **Performance**
  - Reduces processing overhead and improves response handling efficiency when required fields have already been captured.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->