### PR TITLE
Pin github actions with ratchet

### DIFF
--- a/.github/actions/setup-rust-wasm/action.yaml
+++ b/.github/actions/setup-rust-wasm/action.yaml
@@ -14,13 +14,13 @@ runs:
   using: "composite"
   steps:
     - name: Set up Rust toolchain
-      uses: dtolnay/rust-toolchain@stable
+      uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # ratchet:dtolnay/rust-toolchain@stable
       with:
         targets: wasm32-wasip1
         components: ${{ inputs.rust-components }}
 
     - name: Set up Rust cache
-      uses: Swatinem/rust-cache@v2
+      uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # ratchet:Swatinem/rust-cache@v2
 
     - name: Set up protoc
       shell: bash

--- a/.github/workflows/automated-release.yaml
+++ b/.github/workflows/automated-release.yaml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code at git ref
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # ratchet:actions/checkout@v6
         with:
           ref: ${{ github.event.inputs.gitRef }}
           token: ${{ secrets.KUADRANT_DEV_PAT }}
@@ -34,7 +34,7 @@ jobs:
 
       - name: Create Pull Request
         id: cpr
-        uses: peter-evans/create-pull-request@v8
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # ratchet:peter-evans/create-pull-request@v8
         with:
           token: ${{ secrets.KUADRANT_DEV_PAT }}
           commit-message: Prepare release ${{ github.event.inputs.wasmShimVersion }}

--- a/.github/workflows/build-image.yaml
+++ b/.github/workflows/build-image.yaml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # ratchet:actions/checkout@v6
       - name: Add latest tag for the main branch
         if: ${{ github.ref_name == env.MAIN_BRANCH_NAME }}
         id: add-latest-tag
@@ -35,7 +35,7 @@ jobs:
           echo "IMG_TAGS=${{ github.sha }} ${{ env.IMG_TAGS }}" >> $GITHUB_ENV
       - name: Build Image
         id: build-image
-        uses: redhat-actions/buildah-build@v2
+        uses: redhat-actions/buildah-build@9dc2ade9b5db229966b5025ae266311e12f349c4 # ratchet:redhat-actions/buildah-build@v2
         with:
           image: wasm-shim
           tags: ${{ env.IMG_TAGS }}
@@ -46,7 +46,7 @@ jobs:
       - name: Push Image
         if: ${{ !env.ACT && github.event_name != 'pull_request' }}
         id: push-to-quay
-        uses: redhat-actions/push-to-registry@v2
+        uses: redhat-actions/push-to-registry@5860fc963bf8f2b3221773a023141612f010c469 # ratchet:redhat-actions/push-to-registry@v2
         with:
           image: ${{ steps.build-image.outputs.image }}
           tags: ${{ steps.build-image.outputs.tags }}

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -15,7 +15,7 @@ jobs:
     name: Basic integration test
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # ratchet:actions/checkout@v6
       - name: Set up Rust and WASM environment
         uses: ./.github/actions/setup-rust-wasm
         with:
@@ -31,7 +31,7 @@ jobs:
     name: Remote address integration test
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # ratchet:actions/checkout@v6
       - name: Set up Rust and WASM environment
         uses: ./.github/actions/setup-rust-wasm
         with:

--- a/.github/workflows/issues-workflow.yaml
+++ b/.github/workflows/issues-workflow.yaml
@@ -19,7 +19,7 @@ jobs:
     if: (github.event.pull_request.head.repo.full_name == github.repository || github.event.issue.number != '') && (github.event_name == 'issues' || github.event.pull_request.user.login != 'dependabot[bot]')
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/add-to-project@v1.0.2
+      - uses: actions/add-to-project@244f685bbc3b7adfa8466e08b698b5577571133e # ratchet:actions/add-to-project@v1.0.2
         with:
           project-url: https://github.com/orgs/Kuadrant/projects/18
           github-token: ${{ secrets.ADD_ISSUES_TOKEN }}

--- a/.github/workflows/license-scan.yaml
+++ b/.github/workflows/license-scan.yaml
@@ -14,14 +14,14 @@ jobs:
     name: Find license compliance and security issues
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: fossas/fossa-action@v2.0.0
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # ratchet:actions/checkout@v6
+      - uses: fossas/fossa-action@29693cc50323968e039056be419b32989fc5880c # ratchet:fossas/fossa-action@v2.0.0
         name: License Scan
         with:
           api-key: ${{secrets.FOSSA_API_TOKEN}}
           branch: ${{ github.head_ref || github.ref_name }}
           project: git+github.com/Kuadrant/wasm-shim
-      - uses: fossas/fossa-action@v1.8.0
+      - uses: fossas/fossa-action@c414b9ad82eaad041e47a7cf62a4f02411f427a0 # ratchet:fossas/fossa-action@v1.8.0
         name: License test for issues
         with:
           api-key: ${{secrets.FOSSA_API_TOKEN}}

--- a/.github/workflows/ratchet-check.yaml
+++ b/.github/workflows/ratchet-check.yaml
@@ -1,0 +1,29 @@
+name: Ratchet Check
+
+on:
+  pull_request:
+    paths:
+      - '.github/workflows/**'
+      - '.github/actions/**'
+
+  merge_group:
+    types: [checks_requested]
+
+permissions:
+  contents: read
+
+jobs:
+  ratchet:
+    runs-on: ubuntu-latest
+    name: Check pinned actions
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # ratchet:actions/checkout@v4
+        with:
+          persist-credentials: false
+      - uses: sethvargo/ratchet@8b4ca256dbed184350608a3023620f267f0a5253 # ratchet:sethvargo/ratchet@v0.11.4
+        with:
+          files: |
+            .github/workflows/*.yaml
+            .github/workflows/*.yml
+            .github/actions/**/*.yaml
+            .github/actions/**/*.yml

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -4,7 +4,7 @@ name: Release
 on:
   pull_request:
     types:
-    - closed
+      - closed
     branches:
       - 'release-[0-9]+.[0-9]+'
   workflow_dispatch: {}
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # ratchet:actions/checkout@v6
         with:
           token: ${{ secrets.KUADRANT_DEV_PAT }}
 
@@ -63,7 +63,7 @@ jobs:
           git push origin ${{ env.TAG }}
 
       - name: Create GitHub release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # ratchet:softprops/action-gh-release@v2
         with:
           name: ${{ env.TAG }}
           tag_name: ${{ env.TAG }}

--- a/.github/workflows/rust.yaml
+++ b/.github/workflows/rust.yaml
@@ -17,7 +17,7 @@ jobs:
     name: Check
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # ratchet:actions/checkout@v6
       - name: Set up Rust and WASM environment
         uses: ./.github/actions/setup-rust-wasm
         with:
@@ -27,7 +27,7 @@ jobs:
     name: Rustfmt
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # ratchet:actions/checkout@v6
       - name: Set up Rust and WASM environment
         uses: ./.github/actions/setup-rust-wasm
         with:
@@ -39,7 +39,7 @@ jobs:
     name: Clippy
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # ratchet:actions/checkout@v6
       - name: Set up Rust and WASM environment
         uses: ./.github/actions/setup-rust-wasm
         with:

--- a/.github/workflows/sector-release.yaml
+++ b/.github/workflows/sector-release.yaml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code at git ref
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # ratchet:actions/checkout@v6
         with:
           ref: ${{ github.event.inputs.gitRef }}
           token: ${{ secrets.KUADRANT_DEV_PAT }}
@@ -35,7 +35,7 @@ jobs:
       - name: Commit and push changes
         id: commit-and-push-changes
         shell: bash
-        run: | 
+        run: |
           git config --global user.email "${{ github.actor_id }}+${{ github.actor }}@users.noreply.github.com"
           git config --global user.name "${{ github.actor}}"
 

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -15,7 +15,7 @@ jobs:
     name: Test Suite
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # ratchet:actions/checkout@v6
       - name: Set up Rust and WASM environment
         uses: ./.github/actions/setup-rust-wasm
         with:

--- a/make/verify.mk
+++ b/make/verify.mk
@@ -1,0 +1,18 @@
+
+##@ Verify
+
+RATCHET = $(PROJECT_PATH)/bin/ratchet
+RATCHET_VERSION = v0.11.4
+$(RATCHET):
+	$(call go-install-tool,$(RATCHET),github.com/sethvargo/ratchet@$(RATCHET_VERSION))
+
+.PHONY: ratchet
+ratchet: $(RATCHET) ## Download ratchet locally if necessary.
+
+.PHONY: ratchet-pin
+ratchet-pin: ratchet ## Pin GitHub Actions to commit SHAs.
+	$(RATCHET) pin $$(find .github/workflows .github/actions -name '*.yaml' -o -name '*.yml')
+
+.PHONY: verify-ratchet
+verify-ratchet: ratchet ## Verify GitHub Actions are pinned to commit SHAs.
+	$(RATCHET) lint $$(find .github/workflows .github/actions -name '*.yaml' -o -name '*.yml')


### PR DESCRIPTION
## Summary
  - Pin all GitHub Action references to commit SHAs using [ratchet](https://github.com/sethvargo/ratchet)
  - Add a `ratchet-check` CI workflow that lints pull requests for unpinned action references
  - Add `ratchet`, `ratchet-pin`, and `verify-ratchet` make targets in `make/verify.mk`

  Part of the work on https://github.com/Kuadrant/kuadrant-operator/issues/2055

  ## Motivation
  Tags are mutable — action maintainers can force-push them, silently changing the code our CI runs. Pinning to commit SHAs makes each reference immutable, mitigating supply-chain attacks.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security & Reliability**
  * GitHub Actions are now pinned to immutable commit references, improving build and release reproducibility.
  * Added automated checks to verify that workflow actions remain securely pinned.

* **Bug Fixes**
  * Corrected release workflow event configuration to ensure pull-request closure events are handled properly.

* **Developer Tools**
  * Added commands for pinning and validating workflow action references.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->